### PR TITLE
Preload the System\Error class

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -48,6 +48,11 @@ System\Benchmark::$marks['laravel'] = LARAVEL_START;
 error_reporting((System\Config::get('error.detail')) ? E_ALL | E_STRICT : 0);
 
 // --------------------------------------------------------------
+// Ensure Error class loads before any errors fire.
+// --------------------------------------------------------------
+class_exists('System\Error');
+
+// --------------------------------------------------------------
 // Register the error handlers.
 // --------------------------------------------------------------
 set_exception_handler(function($e)


### PR DESCRIPTION
When I autoload in some external library code which hits a compile-time warning (happened to be a parent-child typehint mismatch but that's not relevant here) the error handler fires but autoload is at best finicky and at worst nonfunctional during error/exception handling. Without the preload my compile-time warning turns into an out-of-memory runaway and segfault.

Preloading the class forces it to exist ahead of time and ensures proper, immediate handling. A similar pattern occurs in Zend Framework which loads in possible exceptions 'just in case'.
