### PR TITLE
</form> in form class

### DIFF
--- a/system/form.php
+++ b/system/form.php
@@ -259,7 +259,7 @@ class Form {
     */
    public static function close()
    {
-      return '</form>';
+      return '</form>'.PHP_EOL;
    }
 
 	/**


### PR DESCRIPTION
My IDE or any editor like's to pretend there are errors when I use the form open method but then put an html `</form>`. I figured this would fix that problem. You open the form with PHP, why not close it with PHP. 

I did this on your develop branch. Not sure if thats the best practice when sending pull requests. Never done this before.
