### PR TITLE
Added type param for Str::random

### DIFF
--- a/system/str.php
+++ b/system/str.php
@@ -71,16 +71,16 @@ class Str {
 		}
 
 		$pool_length = (strlen($pool) - 1);
-        $pool = str_split($pool, 1);
+		$pool = str_split($pool, 1);
 
-        $value = '';
+		$value = '';
 
-        for ($i = 0; $i < $length; $i++)
-        {
-            $value .= $pool[mt_rand(0, $pool_length)];
-        }
+		for ($i = 0; $i < $length; $i++)
+		{
+			$value .= $pool[mt_rand(0, $pool_length)];
+		}
 
-        return $value;
+		return $value;
     }
 
 }


### PR DESCRIPTION
I needed to create a random string based on just alpha characters. So I added a type param on Str::random to allow this. I think everyone would agree this would be a small but beneficial change to the random method. I kept alnum as the default type so it wouldn't not break any existing applications. Thanks!
