### PR TITLE
Created Validator::make()

### DIFF
--- a/system/validator.php
+++ b/system/validator.php
@@ -53,6 +53,19 @@ class Validator {
 	}
 
 	/**
+	 * Factory for creating new validator instances.
+	 *
+	 * @param  array      $attributes
+	 * @param  array      $rules
+	 * @param  array      $messages
+	 * @return Validator
+	 */
+	public static function make($attributes, $rules, $messages = array())
+	{
+		return new static($attributes, $rules, $messages);
+	}
+
+	/**
 	 * Validate the target array using the specified validation rules.
 	 *
 	 * @return bool


### PR DESCRIPTION
I noticed there wasn't a make method in the new Validator class. I wasn't sure if this was on purpose but I created it anyways. I prefer to create an instance for a make() method rather then set a new class. Just feels more natural to me.
