### PR TITLE
Edited: Additional wildcard URI  (:alpha) and added salt method for login

### DIFF
--- a/application/config/auth.php
+++ b/application/config/auth.php
@@ -44,7 +44,7 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
-	| Perform Hash and Salt
+	| Perform Password Salt
 	|--------------------------------------------------------------------------
 	|
 	| When true this let the Auth::login() method to use the following
@@ -55,13 +55,13 @@ return array(
 	|
 	*/
 
-	'perform_hash_salt' => true,
+	'perform_salt' => true,
 
 
 
 	/*
 	|--------------------------------------------------------------------------
-	| Hash Salt Password
+	| Salt Password
 	|--------------------------------------------------------------------------
 	|
 	| If the previous field is set to true this method is called by 
@@ -69,19 +69,18 @@ return array(
 	| checking credentials received from a login 
 	| form .
 	|
-	| It shall salt and hash a password to match the one save in the Db for
-	| the current user.
+	| It shall salt the password which hashed should match the one saved in the
+	| Db for the current user.
 	|
 	| You are free to change this method for your application however you wish.
 	|
-	| Note: This method must return an string that has "id" and "password"
-	|       properties. The type of object returned does not matter.
+	| Note: This method must return an string that will be hashed 
 	|
 	*/
 
-	'hash_salt' => function($password, $salt)
+	'salt' => function($password, $salt)
 	{
-		return Hash::make($password.$salt);
+		return $password.$salt;
 	},
 
 

--- a/system/auth.php
+++ b/system/auth.php
@@ -61,9 +61,9 @@ class Auth {
 	{
 		if ( ! is_null($user = call_user_func(Config::get('auth.by_username'), $username)))
 		{
-			if(isset(Config::get('auth.perform_hash_salt') and Config::get('auth.perform_hash_salt') )
+			if(isset(Config::get('auth.perform_salt') and Config::get('auth.perform_salt') )
 			{
-				$password = call_user_func(Config::get('auth.hash_salt'), $password, $user->salt))	
+				$password = call_user_func(Config::get('auth.salt'), $password, $user->salt))	
 			}
 						
 			if (Hash::check($password, $user->password))

--- a/system/router.php
+++ b/system/router.php
@@ -118,11 +118,11 @@ class Router {
 		// For optional parameters, first translate the wildcards to their
 		// regex equivalent, sans the ")?" ending. We will add the endings
 		// back on after we know how many replacements we made.
-		$key = str_replace(array('/(:num?)', '/(:any?)', '/(:alpha?)', '/(:hash?)'), array('(?:/([0-9]+)', '(?:/([a-zA-Z0-9\-_]+)', '(?:/([a-zA-Z]+)', '(?:/([a-z0-9]{8,})'), $key, $replacements);
+		$key = str_replace(array('/(:num?)', '/(:any?)', '/(:alpha?)', array('(?:/([0-9]+)', '(?:/([a-zA-Z0-9\-_]+)', '(?:/([a-zA-Z]+)'), $key, $replacements);
 
 		$key .= ($replacements > 0) ? str_repeat(')?', $replacements) : '';
 
-		return str_replace(array(':num', ':any', ':alpha', ':hash'), array('[0-9]+', '[a-zA-Z0-9\-_]+', '[a-zA-Z]+', '[a-z0-9]{8,}'), $key);
+		return str_replace(array(':num', ':any', ':alpha'), array('[0-9]+', '[a-zA-Z0-9\-_]+', '[a-zA-Z]+'), $key);
 	}
 
 	/**


### PR DESCRIPTION
-   Improved Auth:login() to provide salting function 
  This is especially suited when the salt field is stored in the user
  table, this allows to avoid a query to the database just to retrieve the
  salt field that is already retrieved in the call of the
  "auth.by_username" method
-   Added "alpha" Wildcard URI Segment (:alpha) for only letters 
