### PR TITLE
Allow ? in Asset source

### DIFF
--- a/system/asset.php
+++ b/system/asset.php
@@ -122,11 +122,11 @@ class Asset_Container {
 	 */
 	public function add($name, $source, $dependencies = array(), $attributes = array())
 	{
-		$source = explode('?', $source);
-		
-		$type = (File::extension($source[0]) == 'css') ? 'style' : 'script';
+		$_source = explode('?', $source);
 
-		return call_user_func(array($this, $type), $name, $source[0], $dependencies, $attributes);
+		$type = (File::extension($_source[0]) == 'css') ? 'style' : 'script';
+
+		return call_user_func(array($this, $type), $name, $source, $dependencies, $attributes);
 	}
 
 	/**


### PR DESCRIPTION
Sometimes develops would put a question mark and a timestamp after the asset source in order to force a recache or if the asset source is a script that needs it. My case was the recache.

Example:

`/assets/css/app.css?1234567890`

Usually when I deploy, I have a deployment script that will update a config file that will change the timestamp or the parameter to force the users to recache my css or my javascript. The Asset::add() method would not get the right extension if this question mark was present (besides JS).
