### PR TITLE
Issue #48 typo fix.

### DIFF
--- a/application/config/error.php
+++ b/application/config/error.php
@@ -46,7 +46,7 @@ return array(
 	| level such as "Parsing Error" or "Fatal Error".
 	|
 	| A simple logging system has been setup for you. By default, all errors
-	| will be logged to the application/log.txt file.
+	| will be logged to the storage/log.txt file.
 	|
 	*/
 


### PR DESCRIPTION
Comment in config/error editied from application/log.txt to storage/log.txt (Issue #48)
