### PR TITLE
Config not found, added use System\Config

### DIFF
--- a/system/session/apc.php
+++ b/system/session/apc.php
@@ -1,6 +1,7 @@
 <?php namespace System\Session;
 
 use System\Cache;
+use System\Config;
 
 class APC implements Driver {
 


### PR DESCRIPTION
Bug found.

The Config class was not reachable. Needed to add `use System\Config;`
