### PR TITLE
Bug when not getting the id column from the database

### DIFF
--- a/system/db/eloquent/hydrator.php
+++ b/system/db/eloquent/hydrator.php
@@ -50,7 +50,14 @@ class Hydrator {
 
 			$model->exists = true;
 
-			$models[$model->id] = $model;
+			if ($model->id)
+			{
+				$models[$model->id] = $model;
+			}
+			else
+			{
+				$models[] = $model;
+			}
 		}
 
 		return $models;


### PR DESCRIPTION
If you try to get only some columns from the database, but not the id one, you only get the last row with an index of ''.
