### PR TITLE
Add possibility to add brackets to where clause by fluent interface.

### DIFF
--- a/system/db/query.php
+++ b/system/db/query.php
@@ -185,7 +185,7 @@ class Query {
 	public function reset_where()
 	{
 		$this->where = 'WHERE 1 = 1';
-		$this->brackets = 1;
+		$this->brackets = 0;
 		$this->bindings = array();
 	}
 


### PR DESCRIPTION
This change allows to use fluent interface for building more complex queries:

``` php
    $rows = DB::table('log')->where('time', '>', '2011-08-01')
        ->bracket()
          ->where('src_user', 'like', $search)
          ->or_where('dst_user', 'like', $search)
          ->or_where('src_ip', 'like', $search)
          ->or_where('dst_ip', 'like', $search)
        ->close_bracket()
        ->get()
```
