### PR TITLE
Bug with module composers.

### DIFF
--- a/system/view.php
+++ b/system/view.php
@@ -124,9 +124,9 @@ class View {
 		static::load_composers($this->module);
 		$view = ($this->module != 'application' ? $this->module . '::' : '') . $this->view;
 
-		if (isset(static::$composers[$this->module][$this->view]))
+		if (isset(static::$composers[$this->module][$view]))
 		{
-			foreach ((array) static::$composers[$this->module][$this->view] as $key => $value)
+			foreach ((array) static::$composers[$this->module][$view] as $key => $value)
 			{
 				if (is_callable($value)) return call_user_func($value, $this);
 			}


### PR DESCRIPTION
I say bug but it could be me doing it wrong. Let me do some explaining.

This isn't mentioned in the docs but it does say that module composers act just like the application composers, but I figured that because it's a module the composer should also have the module name prefixed to the view file. So if my view was **template** and it was located at **module/admin/views/template.php** then the composer should reference it like `'admin::template'` instead of just as `'template'`

That's all fine, I gave it a name and dynamically called it like `return View::of_template()` and it worked. So I set about added assets for my template but found none were showing up in the template.php file once rendered. So I bound a variable in the composer (and yes I did return the $view variable at the end) but kept getting undefined variable errors. I did a bit of debugging and found that the `static::$composers` property in the system/view.php file contained an array similar to this:

```
Array ( [admin] => Array ( [admin::template] => Array ( [name] => template [0] => Closure Object ( [parameter] => Array ( [$view] => ) ) ) ) ) 1
```

I also echo'd out the `$this->view` and `$this->module` properties and found that they contained the values **template** and **admin** respectively. So the if() statement in the compose() method was not succeeding because `static::$composers['admin']['template']` does not exist.

So in my 2 (unfortunately I forgot something) commits and 1 new line I simply check if we are not running under the application module, and if not prefix the module to the view so it can be called correctly.

Again, this could be me doing something wrong. Sorry for the long-winded post.

Regards,
Jason.
