### PR TITLE
DB::query() fails when using formatted sql

### DIFF
--- a/system/db/connection.php
+++ b/system/db/connection.php
@@ -73,6 +73,8 @@ class Connection {
 	 */
 	public function query($sql, $bindings = array())
 	{
+		$sql = trim($sql);
+		
 		$this->queries[] = $sql;
 
 		$query = $this->pdo->prepare($sql);


### PR DESCRIPTION
DB::query() sometimes does not return expected result, because "strpos" check expects "SELECT","UPDATE", "DELETE" should be very first word of
sql.  
so, following formatted(see indentation) heredoc style SQL always fails:

```
$sql = <<<SQL  
    SELECT …  
    FROM … 
SQL;
```
