### PR TITLE
Cannot use provides with simple route

### DIFF
--- a/laravel/routing/router.php
+++ b/laravel/routing/router.php
@@ -115,10 +115,19 @@ class Router {
 		// the request method and a forward slash followed by the URI.
 		$destination = $method.' /'.trim($uri, '/');
 
+		// We need to remove the format from the route since formats are
+		// not specified in the route URI directly, but rather through
+		// the "provides" keyword on the route array.
+		$destination = str_replace('.'.$format, '', $destination);
+
 		// Check for a literal route match first...
 		if (isset($routes[$destination]))
 		{
-			return Request::$route = new Route($destination, $routes[$destination], array());
+			// We need to make sure that the requested format is provided by the route.
+			if (in_array($format, $this->provides($routes[$destination])))
+			{
+				return Request::$route = new Route($destination, $routes[$destination], array());
+			}
 		}
 
 		foreach ($routes as $keys => $callback)
@@ -131,7 +140,7 @@ class Router {
 			// routes would have been caught by the check for literal matches.
 			if (strpos($keys, '(') !== false or strpos($keys, ',') !== false)
 			{
-				if ( ! is_null($route = $this->match($destination, $keys, $callback, $format)))
+				if ( ! is_null($route = $this->match($destination, $keys, $callback)))
 				{
 					return Request::$route = $route;
 				}
@@ -167,16 +176,10 @@ class Router {
 	 * @param  string  $destination
 	 * @param  array   $keys
 	 * @param  mixed   $callback
-	 * @param  string  $format
 	 * @return mixed
 	 */
-	protected function match($destination, $keys, $callback, $format)
+	protected function match($destination, $keys, $callback)
 	{
-		// We need to remove the format from the route since formats are
-		// not specified in the route URI directly, but rather through
-		// the "provides" keyword on the route array.
-		$destination = str_replace('.'.$format, '', $destination);
-
 		foreach (explode(', ', $keys) as $key)
 		{
 			if (preg_match('#^'.$this->wildcards($key).'$#', $destination))
@@ -294,6 +297,6 @@ class Router {
 		}
 
 		return $parameters;
-	}	
+	}
 
 }


### PR DESCRIPTION
``` php
<?php return array(
    'GET /test' => array('provides' => 'html|json', function()
    {
        // Never gets here
    },
);
```

Routes containing "(" or "," are fine but the above route fails for `GET /test.json`.
