### PR TITLE
[develop] Fix URI class

### DIFF
--- a/laravel/request.php
+++ b/laravel/request.php
@@ -34,7 +34,7 @@ class Request {
 	 */
 	public static function uri()
 	{
-		return URI::get();
+		return URI::current();
 	}
 
 	/**

--- a/laravel/uri.php
+++ b/laravel/uri.php
@@ -86,6 +86,7 @@ class URI {
 		{
 			return substr($uri, strlen($value));
 		}
+		return $uri;
 	}
 
 	/**


### PR DESCRIPTION
`URI::remove` didn't return anything if it couldn't remove anything, causing lots of empty URIs to be returned from `URI::current`.
