### PR TITLE
Old input flashed even when no input present

### DIFF
--- a/laravel/input.php
+++ b/laravel/input.php
@@ -72,7 +72,7 @@ class Input {
 	{
 		if (Config::$items['session']['driver'] !== '')
 		{
-			IoC::core('session')->flash(Input::old_input, static::get());
+			if(count($input = static::get()) > 0) IoC::core('session')->flash(Input::old_input, static::get());
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where old input would be flashed regardless of whether there is any input present. This results in an empty `:new:laravel_old_input` key in the session which prevents you from fetching the aged old input inside views. The problem there is that the new flash data takes precedence over old flash data.

Using `Input::old()` worked fine inside routes but I'm assuming that the after filter is fired before the response is rendered which then causes the issue.
