### PR TITLE
Sessions no longer working

### DIFF
--- a/laravel/session/payload.php
+++ b/laravel/session/payload.php
@@ -42,9 +42,11 @@ class Payload {
 	 * @param  Driver  $driver
 	 * @return void
 	 */
-	public function __construct(Driver $driver)
+	public function __construct(Driver $driver, $id)
 	{
 		$this->driver = $driver;
+		
+		$this->load($id);
 	}
 
 	/**


### PR DESCRIPTION
Sessions are no longer working after the latest refactoring. The constructor did not accept the id parameter even though Laravel\Laravel passed one in. The session was also not loaded so it kept throwing `Undefined index: id` errors.
