### PR TITLE
Load sessions after creating instance

### DIFF
--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -132,7 +132,9 @@ if (Config::$items['session']['driver'] !== '')
 
 	$driver = Session\Drivers\Factory::make(Config::$items['session']['driver']);
 
-	IoC::instance('laravel.session', new Session\Payload($driver, $id));
+	IoC::instance('laravel.session', new Session\Payload($driver));
+	
+	IoC::core('session')->load($id);
 }
 
 /**


### PR DESCRIPTION
Similar to #172, this instead uses the IoC container to load the session.
