### PR TITLE
Specifying array of columns in Eloquent models

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -217,7 +217,7 @@ abstract class Model {
 	 */
 	private function _get($columns = array('*'))
 	{
-		if (is_null($this->selects)) $this->select($columns);
+		if (is_null($this->query->selects)) $this->query->select($columns);
 		
 		return Hydrator::hydrate($this);
 	}


### PR DESCRIPTION
When using Eloquent it isn't possible to provide an array of columns in the all, find, get, first, and paginate methods.

The Fluent Query Builder allows this functionality.

This patch just adds that same functionality, taken straight from FQB.

Allows:

```
return static::where('username', '=', 'jaysonic')->first(array('email', 'password'));
```
