### PR TITLE
Added ability to leave config URL blank

### DIFF
--- a/application/config/application.php
+++ b/application/config/application.php
@@ -9,9 +9,11 @@ return array(
 	|
 	| The URL used to access your application. No trailing slash.
 	|
+	| Leave empty for Laravel to automatically set the URL for the application
+	|
 	*/
 
-	'url' => 'http://localhost',
+	'url' => '',
 
 	/*
 	|--------------------------------------------------------------------------

--- a/laravel/uri.php
+++ b/laravel/uri.php
@@ -34,7 +34,7 @@ class URI {
 		// Remove the root application URL from the request URI. If the application
 		// is nested within a sub-directory of the web document root, this will get
 		// rid of all of the the sub-directories from the request URI.
-		$uri = static::remove($uri, parse_url(Config::$items['application']['url'], PHP_URL_PATH));
+		$uri = static::remove($uri, parse_url(URL::base_url(FALSE), PHP_URL_PATH));
 
 		if (($index = '/'.Config::$items['application']['index']) !== '/')
 		{

--- a/laravel/url.php
+++ b/laravel/url.php
@@ -23,7 +23,7 @@ class URL {
 	{
 		if (filter_var($url, FILTER_VALIDATE_URL) !== false) return $url;
 
-		$root = Config::$items['application']['url'].'/'.Config::$items['application']['index'];
+		$root = static::base_url();
 
 		// Since SSL is often not used while developing the application, we allow the
 		// developer to disable SSL on all framework generated links to make it more
@@ -189,6 +189,38 @@ class URL {
 		}
 
 		throw new \BadMethodCallException("Method [$method] is not defined on the URL class.");
+	}
+
+	/**
+	 * Setup the base URL for the application
+	 * 
+	 * @return string
+	 */
+	public static function base_url($full_url = TRUE)
+	{
+		$base_url = Config::$items['application']['url'];
+
+		if ($base_url == '')
+		{
+			if (isset($_SERVER['HTTP_HOST']))
+			{
+				$base_url = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off' ? 'https' : 'http';
+				$base_url .= '://'.$_SERVER['HTTP_HOST'];
+				$base_url .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);
+				$base_url = rtrim($base_url, '/');
+			}
+			else
+			{
+				$base_url = 'http://localhost/';
+			}
+		}
+
+		if ($full_url)
+		{
+			$base_url .= '/'.Config::$items['application']['index'];
+		}
+
+		return $base_url;
 	}
 
 }


### PR DESCRIPTION
Created a `base_url()` method that guesses what the application's URL is if none is set in _config/application.php_.

Always enjoyed this feature from CodeIgniter, so I thought I would port it over to Laravel to allow for a zero configuration setup!
