### PR TITLE
Issue when passing lowercase method parameter to Form::open()

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -45,6 +45,8 @@ class Form {
 	 */
 	public static function open($action = null, $method = 'POST', $attributes = array(), $https = false)
 	{
+		$method = strtoupper($method);
+		
 		$attributes['method'] =  static::method($method);
 		
 		$attributes['action'] = static::action($action, $https);


### PR DESCRIPTION
Found this tonight while playing around with Laravel... if you call Form::open() and the second parameter is not in all caps, the hidden spoofer field will not be appended when using "put" or "delete". Simple fix was to strtoupper() $method at the beginning of the function.
