### PR TITLE
Fix: Session flush now correctly prepares empty data.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Version 2.0.5
 
 - Fix: Remove orderings before running pagination queries.
+- Fix: Session flush now correctly prepares empty data.
 
 ### Upgrading from 2.0.4
 

--- a/laravel/session/payload.php
+++ b/laravel/session/payload.php
@@ -229,7 +229,10 @@ class Payload {
 	 */
 	public function flush()
 	{
-		$this->session['data'] = array();
+		$this->session['data'] = array(
+			':new:' => array(),
+			':old:' => array(),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Currently flush empties the session rather than preparing it for new and old data.
