### PR TITLE
Allow timestamp method to be extended

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -413,7 +413,7 @@ abstract class Model {
 	 *
 	 * @return void
 	 */
-	private function timestamp()
+	protected function timestamp()
 	{
 		$this->updated_at = date('Y-m-d H:i:s');
 


### PR DESCRIPTION
As a developer, I would like to have the ability to customize the column names and types for my Eloquent tables. By changing the timestamp method to protected, this can easily be customized on a per-model basis, or by extending the overall Eloquent\Model class.
