### PR TITLE
Non ASCII characters get removed in URL::slug

### DIFF
--- a/laravel/url.php
+++ b/laravel/url.php
@@ -212,8 +212,6 @@ class URL {
 	 */
 	public static function slug($title, $separator = '-')
 	{
-		$title = Str::ascii($title);
-
 		// Remove all characters that are not the separator, letters, numbers, or whitespace.
 		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', Str::lower($title));
 


### PR DESCRIPTION
During the back and forth on pull request 215 I noticed the URL::slug runs the title text through the STR::ascii method which removes non-ascii characters often leaving you with a completely empty string as the result. This change removes that and simply creates the slug on the current text. For example:

URL::slug('Я   люблю   еду');
URL::slug('私は料理が大好き');

Another issue thought is that this does not encode the output. If this is to be used in the view code to create a URL it's likely it should be encoded, but I don't know if we want to handle that within this logic.
