### PR TITLE
Don't mark the model as 'dirty' if nothing changed actually

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -477,10 +477,12 @@ abstract class Model {
 		}
 		else
 		{
-			if (! $this->exists || $this->attributes[$key] !== $value) {
-				$this->attributes[$key] = $value;
-				$this->dirty[$key] = $value;
+			if (isset($this->attributes[$key]) && $this->attributes[$key] === $value) {
+				return;
 			}
+
+			$this->attributes[$key] = $value;
+			$this->dirty[$key] = $value;
 		}
 	}
 


### PR DESCRIPTION
Before: If an attribute is set to the same value, the model is marked as
'dirty'. This causes the save() method to return false as no rows where changed
in the database.

Now the model will be marked as 'dirty' only when an attribute differs from the
previous one.

Maybe it's cleaner to fix the save() method to not to return false if no rows were
changed but this one works too.
