### PR TITLE
Change argument to $publisher->publish() from $bundle to $bundle['name'].

### DIFF
--- a/laravel/cli/tasks/bundle/bundler.php
+++ b/laravel/cli/tasks/bundle/bundler.php
@@ -51,7 +51,7 @@ class Bundler extends Task {
 
 			IoC::resolve($provider)->install($bundle);
 
-			$publisher->publish($bundle);
+			$publisher->publish($bundle['name']);
 		}
 	}
 
@@ -72,7 +72,7 @@ class Bundler extends Task {
 
 		foreach ($bundles as $bundle)
 		{
-			$publisher->publish($bundle);
+			$publisher->publish($bundle['name']);
 		}
 	}
 


### PR DESCRIPTION
Don't know if this is right but it eliminates the warnings referenced at: http://forums.laravel.com/viewtopic.php?pid=3834#p3834
