### PR TITLE
Bug fix for route::handles

### DIFF
--- a/laravel/routing/route.php
+++ b/laravel/routing/route.php
@@ -118,7 +118,7 @@ class Route {
 	 */
 	public function response()
 	{
-		// If the action is a string, it is simply pointing the route to a 
+		// If the action is a string, it is simply pointing the route to a
 		// controller action, and we can just call the action and return
 		// its response. This is the most basic form of route, and is
 		// the simplest to handle.
@@ -214,7 +214,7 @@ class Route {
 	 */
 	public function handles($uri)
 	{
-		$pattern = ($uri !== '/') ? str_replace('*', '(.*)', $uri) : '^/$';
+		$pattern = ($uri !== '/') ? str_replace('*', '(.*)', $uri).'\z' : '^/$';
 
 		return ! is_null(array_first($this->uris, function($key, $uri) use ($pattern)
 		{

--- a/tests/cases/laravel/route.test.php
+++ b/tests/cases/laravel/route.test.php
@@ -24,6 +24,7 @@ class RouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($route->handles('/'));
 		$this->assertFalse($route->handles('baz'));
 		$this->assertFalse($route->handles('/foo'));
+		$this->assertFalse($route->handles('foo'));
 
 		$route = new Laravel\Routing\Route('GET /', array('handles' => array('GET /', 'GET /home')));
 


### PR DESCRIPTION
This fixes the following bug:

Route: /foo/bar
$this->assertFalse($route->handles('foo'));

That would return true because "foo" was part of the uri. So I added a \z which matches from the end of the string and it appears to be working. I ran all the unit tests and still got GREEN. 
