### PR TITLE
Duplicate paginate::page through query::paginate

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -537,8 +537,6 @@ class Query {
 		// them back on the query after we have the count.
 		list($orderings, $this->orderings) = array($this->orderings, null);
 
-		$page = Paginator::page($total = $this->count(), $per_page);
-
 		$this->orderings = $orderings;
 
 		return Paginator::make($this->for_page($page, $per_page)->get($columns), $total, $per_page);


### PR DESCRIPTION
Removed paginate::page which validates the page number, as this method if already called in the paginator::make method that is called next. No need to call it twice.
