### PR TITLE
Session should throw an Exception when it's not started

### DIFF
--- a/laravel/session.php
+++ b/laravel/session.php
@@ -111,7 +111,7 @@ class Session {
 	 */
 	public static function __callStatic($method, $parameters)
 	{
-		return call_user_func_array(array(static::$instance, $method), $parameters);
+		return call_user_func_array(array(static::instance(), $method), $parameters);
 	}
 
 }


### PR DESCRIPTION
Should use `static::instance()` not `static::$instance` in `__callStatic` otherwise you don't check the session's been started and get an obscure error instead of a meaningful Exception.
