### PR TITLE
Fix inconsistent data referencing in View

### DIFF
--- a/laravel/view.php
+++ b/laravel/view.php
@@ -358,7 +358,7 @@ class View implements ArrayAccess {
 	 */
 	public function __get($key)
 	{
-		return $this[$key];
+		return $this->data[$key];
 	}
 
 	/**
@@ -366,7 +366,15 @@ class View implements ArrayAccess {
 	 */
 	public function __set($key, $value)
 	{
-		$this[$key] = $value;
+		$this->data[$key] = $value;
+	}
+
+	/**
+	 * Magic Method for checking dynamically-set data.
+	 */
+	public function __isset($key)
+	{
+		return isset($this->data[$key]);
 	}
 
 	/**


### PR DESCRIPTION
Seems too simple of an error to be accidental, so correct me if I'm wrong, but the View class currently seems to be doing a mix of storing template variables as properties of the View class and as members of the `$data` array.

This commit fixes those references to use only `$data` and re-implements the `isset()` magic method for template variables. Again, this worked fine in 2.1, so if it's removal was intentional let me know...
