### PR TITLE
Prevent a bundle from starting itself into a loop

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -40,6 +40,8 @@ class Bundle {
 			throw new \Exception("Bundle [$bundle] has not been installed.");
 		}
 
+		static::$started[] = strtolower($bundle);
+
 		// Each bundle may have a "start" script which is responsible for preparing
 		// the bundle for use by the application. The start script may register any
 		// classes the bundle uses with the auto-loader, or perhaps will start any
@@ -53,8 +55,6 @@ class Bundle {
 		// registering the bundle's routes. This is kept separate from the
 		// start script for reverse routing efficiency purposes.
 		static::routes($bundle);
-
-		static::$started[] = strtolower($bundle);
 	}
 
 	/**


### PR DESCRIPTION
It is possible for a bundle to trigger `Bundle::start` on itself within its bundle.php; or for 2 bundles to depend on each other; this prevents the bundles from re-requiring the bundle and route files.

See http://forums.laravel.com/viewtopic.php?id=532
