### PR TITLE
Fix for validate_unique to allow column name and ID

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -407,7 +407,7 @@ class Validator {
 	 * Validate the uniqueness of an attribute value on a given database table.
 	 *
 	 * If a database column is not specified, the attribute name will be used.
-	 * When performing an update a second parameter containing the ID of the record
+	 * When performing an update a third parameter containing the ID of the record
 	 * can be given to avoid checking itself.
 	 *
 	 * @param  string  $attribute


### PR DESCRIPTION
If developers are updating and using unique to check for a unique column they can specify the column name as well as the current records ID. Saves having two methods.

```
unique:tablename,columname,id
```

Of course if none are provided then the column name is still set to the attribute name.
