### PR TITLE
Enable table prefixes (Fixes #286)

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -74,13 +74,13 @@ class Connection {
 		switch (isset($this->config['grammar']) ? $this->config['grammar'] : $this->driver())
 		{
 			case 'mysql':
-				return $this->grammar = new Query\Grammars\MySQL;
+				return $this->grammar = new Query\Grammars\MySQL($this);
 
 			case 'sqlsrv':
-				return $this->grammar = new Query\Grammars\SQLServer;
+				return $this->grammar = new Query\Grammars\SQLServer($this);
 
 			default:
-				return $this->grammar = new Query\Grammars\Grammar;
+				return $this->grammar = new Query\Grammars\Grammar($this);
 		}
 	}
 
@@ -258,6 +258,16 @@ class Connection {
 		}
 
 		return trim($sql);
+	}
+
+	/**
+	 * Get the table prefix for the database connection.
+	 *
+	 * @return string
+	 */
+	public function table_prefix()
+	{
+		return isset($this->config['table_prefix']) ? $this->config['table_prefix'] : '';
 	}
 
 	/**

--- a/laravel/database/schema.php
+++ b/laravel/database/schema.php
@@ -33,7 +33,7 @@ class Schema {
 		{
 			$connection = DB::connection($table->connection);
 
-			$grammar = static::grammar($connection->driver());
+			$grammar = static::grammar($connection);
 
 			// Each grammar has a function that corresponds to the command type
 			// and is responsible for building that's commands SQL. This lets
@@ -90,29 +90,29 @@ class Schema {
 	}
 
 	/**
-	 * Create the appropriate schema grammar for the driver.
+	 * Create the appropriate schema grammar for the connection.
 	 *
-	 * @param  string   $driver
+	 * @param  Connection   $connection
 	 * @return Grammar
 	 */
-	public static function grammar($driver)
+	public static function grammar(Connection $connection)
 	{
-		switch ($driver)
+		switch ($connection->driver())
 		{
 			case 'mysql':
-				return new Schema\Grammars\MySQL;
+				return new Schema\Grammars\MySQL($connection);
 
 			case 'pgsql':
-				return new Schema\Grammars\Postgres;
+				return new Schema\Grammars\Postgres($connection);
 
 			case 'sqlsrv':
-				return new Schema\Grammars\SQLServer;
+				return new Schema\Grammars\SQLServer($connection);
 
 			case 'sqlite':
-				return new Schema\Grammars\SQLite;
+				return new Schema\Grammars\SQLite($connection);
 		}
 
-		throw new \Exception("Schema operations not supported for [$driver].");
+		throw new \Exception("Schema operations not supported for [{$connection->driver()}].");
 	}
 
 }

--- a/laravel/database/schema/grammars/grammar.php
+++ b/laravel/database/schema/grammars/grammar.php
@@ -6,6 +6,17 @@ use Laravel\Database\Schema\Table;
 abstract class Grammar extends \Laravel\Database\Grammar {
 
 	/**
+	 * Create a new Grammar instance.
+	 *
+	 * @param  Connection    $connection
+	 * @return void
+	 */
+	public function __construct(\Laravel\Database\Connection $connection)
+	{
+		$this->connection = $connection;
+	}
+
+	/**
 	 * Get the appropriate data type definition for the column.
 	 *
 	 * @param  Fluent  $column
@@ -33,6 +44,25 @@ abstract class Grammar extends \Laravel\Database\Grammar {
 		}
 
 		return parent::wrap($value);
+	}
+
+	/**
+	 * Wrap a table in keyword identifiers after adding the prefix.
+	 *
+	 * @param  Table|string  $value
+	 * @return string
+	 */
+	public function wrap_table($value)
+	{
+		// This method is primarily for convenience so we can just pass a
+		// column or table instance into the wrap method without sending
+		// in the name each time we need to wrap one of these objects.
+		if ($value instanceof Table or $value instanceof Fluent)
+		{
+			$value = $value->name;
+		}
+
+		return parent::wrap($this->connection->table_prefix().$value);
 	}
 
 }

--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -26,7 +26,7 @@ class MySQL extends Grammar {
 		// First we will generate the base table creation statement. Other than
 		// auto-incrementing keys, no indexes will be created during the first
 		// creation of the table. They will be added in separate commands.
-		$sql = 'CREATE TABLE '.$this->wrap($table).' ('.$columns.')';
+		$sql = 'CREATE TABLE '.$this->wrap_table($table).' ('.$columns.')';
 
 		// MySQL supports various "engines" for database tables. If an engine
 		// was specified by the developer, we will set it after adding the
@@ -59,7 +59,7 @@ class MySQL extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -197,7 +197,7 @@ class MySQL extends Grammar {
 
 		$name = $command->name;
 
-		return 'ALTER TABLE '.$this->wrap($table)." ADD {$type} {$name}({$keys})";
+		return 'ALTER TABLE '.$this->wrap_table($table)." ADD {$type} {$name}({$keys})";
 	}
 
 	/**
@@ -209,7 +209,7 @@ class MySQL extends Grammar {
 	 */
 	public function drop(Table $table, Fluent $command)
 	{
-		return 'DROP TABLE '.$this->wrap($table);
+		return 'DROP TABLE '.$this->wrap_table($table);
 	}
 
 	/**
@@ -232,7 +232,7 @@ class MySQL extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -244,7 +244,7 @@ class MySQL extends Grammar {
 	 */
 	public function drop_primary(Table $table, Fluent $command)
 	{
-		return 'ALTER TABLE '.$this->wrap($table).' DROP PRIMARY KEY';
+		return 'ALTER TABLE '.$this->wrap_table($table).' DROP PRIMARY KEY';
 	}
 
 	/**
@@ -292,7 +292,7 @@ class MySQL extends Grammar {
 	 */
 	protected function drop_key(Table $table, Fluent $command)
 	{
-		return 'ALTER TABLE '.$this->wrap($table)." DROP INDEX {$command->name}";
+		return 'ALTER TABLE '.$this->wrap_table($table)." DROP INDEX {$command->name}";
 	}
 
 	/**

--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -19,7 +19,7 @@ class Postgres extends Grammar {
 		// First we will generate the base table creation statement. Other than
 		// auto-incrementing keys, no indexes will be created during the first
 		// creation of the table. They will be added in separate commands.
-		$sql = 'CREATE TABLE '.$this->wrap($table).' ('.$columns.')';
+		$sql = 'CREATE TABLE '.$this->wrap_table($table).' ('.$columns.')';
 
 		return $sql;
 	}
@@ -44,7 +44,7 @@ class Postgres extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Postgres extends Grammar {
 	{
 		$columns = $this->columnize($command->columns);
 
-		return 'ALTER TABLE '.$this->wrap($table)." ADD PRIMARY KEY ({$columns})";
+		return 'ALTER TABLE '.$this->wrap_table($table)." ADD PRIMARY KEY ({$columns})";
 	}
 
 	/**
@@ -163,7 +163,7 @@ class Postgres extends Grammar {
 
 		$columns = $this->columnize($command->columns);
 
-		return "CREATE INDEX {$name} ON ".$this->wrap($table)." USING gin({$columns})";
+		return "CREATE INDEX {$name} ON ".$this->wrap_table($table)." USING gin({$columns})";
 	}
 
 	/**
@@ -192,7 +192,7 @@ class Postgres extends Grammar {
 
 		$create = ($unique) ? 'CREATE UNIQUE' : 'CREATE';
 
-		return $create." INDEX {$command->name} ON ".$this->wrap($table)." ({$columns})";
+		return $create." INDEX {$command->name} ON ".$this->wrap_table($table)." ({$columns})";
 	}
 
 	/**
@@ -204,7 +204,7 @@ class Postgres extends Grammar {
 	 */
 	public function drop(Table $table, Fluent $command)
 	{
-		return 'DROP TABLE '.$this->wrap($table);
+		return 'DROP TABLE '.$this->wrap_table($table);
 	}
 
 	/**
@@ -227,7 +227,7 @@ class Postgres extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -239,7 +239,7 @@ class Postgres extends Grammar {
 	 */
 	public function drop_primary(Table $table, Fluent $command)
 	{
-		return 'ALTER TABLE '.$this->wrap($table).' DROP CONSTRAINT '.$table->name.'_pkey';
+		return 'ALTER TABLE '.$this->wrap_table($table).' DROP CONSTRAINT '.$table->name.'_pkey';
 	}
 
 	/**

--- a/laravel/database/schema/grammars/sqlite.php
+++ b/laravel/database/schema/grammars/sqlite.php
@@ -19,7 +19,7 @@ class SQLite extends Grammar {
 		// First we will generate the base table creation statement. Other than
 		// auto-incrementing keys, no indexes will be created during the first
 		// creation of the table. They will be added in separate commands.
-		$sql = 'CREATE TABLE '.$this->wrap($table).' ('.$columns;
+		$sql = 'CREATE TABLE '.$this->wrap_table($table).' ('.$columns;
 
 		// SQLite does not allow adding a primary key as a command apart from
 		// when the table is initially created, so we'll need to sniff out
@@ -71,7 +71,7 @@ class SQLite extends Grammar {
 		// the schema manager, which will execute each one.
 		foreach ($columns as $column)
 		{
-			$sql[] = 'ALTER TABLE '.$this->wrap($table).' '.$column;
+			$sql[] = 'ALTER TABLE '.$this->wrap_table($table).' '.$column;
 		}
 
 		return (array) $sql;
@@ -173,7 +173,7 @@ class SQLite extends Grammar {
 	{
 		$columns = $this->columnize($command->columns);
 
-		return 'CREATE VIRTUAL TABLE '.$this->wrap($table)." USING fts4({$columns})";
+		return 'CREATE VIRTUAL TABLE '.$this->wrap_table($table)." USING fts4({$columns})";
 	}
 
 	/**
@@ -202,7 +202,7 @@ class SQLite extends Grammar {
 
 		$create = ($unique) ? 'CREATE UNIQUE' : 'CREATE';
 
-		return $create." INDEX {$command->name} ON ".$this->wrap($table)." ({$columns})";
+		return $create." INDEX {$command->name} ON ".$this->wrap_table($table)." ({$columns})";
 	}
 
 	/**
@@ -214,7 +214,7 @@ class SQLite extends Grammar {
 	 */
 	public function drop(Table $table, Fluent $command)
 	{
-		return 'DROP TABLE '.$this->wrap($table);
+		return 'DROP TABLE '.$this->wrap_table($table);
 	}
 
 	/**

--- a/laravel/database/schema/grammars/sqlserver.php
+++ b/laravel/database/schema/grammars/sqlserver.php
@@ -26,7 +26,7 @@ class SQLServer extends Grammar {
 		// First we will generate the base table creation statement. Other than
 		// auto-incrementing keys, no indexes will be created during the first
 		// creation of the table. They will be added in separate commands.
-		$sql = 'CREATE TABLE '.$this->wrap($table).' ('.$columns.')';
+		$sql = 'CREATE TABLE '.$this->wrap_table($table).' ('.$columns.')';
 
 		return $sql;
 	}
@@ -51,7 +51,7 @@ class SQLServer extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -140,7 +140,7 @@ class SQLServer extends Grammar {
 
 		$columns = $this->columnize($columns);
 
-		return 'ALTER TABLE '.$this->wrap($table)." ADD CONSTRAINT {$name} PRIMARY KEY ({$columns})";
+		return 'ALTER TABLE '.$this->wrap_table($table)." ADD CONSTRAINT {$name} PRIMARY KEY ({$columns})";
 	}
 
 	/**
@@ -172,7 +172,7 @@ class SQLServer extends Grammar {
 		// be updated automatically by the server.
 		$sql[] = "CREATE FULLTEXT CATALOG {$command->catalog}";
 
-		$create =  "CREATE FULLTEXT INDEX ON ".$this->wrap($table)." ({$columns}) ";
+		$create =  "CREATE FULLTEXT INDEX ON ".$this->wrap_table($table)." ({$columns}) ";
 
 		// Full-text indexes must specify a unique, non-nullable column as
 		// the index "key" and this should have been created manually by
@@ -209,7 +209,7 @@ class SQLServer extends Grammar {
 
 		$create = ($unique) ? 'CREATE UNIQUE' : 'CREATE';
 
-		return $create." INDEX {$command->name} ON ".$this->wrap($table)." ({$columns})";
+		return $create." INDEX {$command->name} ON ".$this->wrap_table($table)." ({$columns})";
 	}
 
 	/**
@@ -221,7 +221,7 @@ class SQLServer extends Grammar {
 	 */
 	public function drop(Table $table, Fluent $command)
 	{
-		return 'DROP TABLE '.$this->wrap($table);
+		return 'DROP TABLE '.$this->wrap_table($table);
 	}
 
 	/**
@@ -244,7 +244,7 @@ class SQLServer extends Grammar {
 
 		}, $columns));
 
-		return 'ALTER TABLE '.$this->wrap($table).' '.$columns;
+		return 'ALTER TABLE '.$this->wrap_table($table).' '.$columns;
 	}
 
 	/**
@@ -256,7 +256,7 @@ class SQLServer extends Grammar {
 	 */
 	public function drop_primary(Table $table, Fluent $command)
 	{
-		return 'ALTER TABLE '.$this->wrap($table).' DROP CONSTRAINT '.$command->name;
+		return 'ALTER TABLE '.$this->wrap_table($table).' DROP CONSTRAINT '.$command->name;
 	}
 
 	/**
@@ -308,7 +308,7 @@ class SQLServer extends Grammar {
 	 */
 	protected function drop_key(Table $table, Fluent $command)
 	{
-		return "DROP INDEX {$command->name} ON ".$this->wrap($table);
+		return "DROP INDEX {$command->name} ON ".$this->wrap_table($table);
 	}
 
 	/**


### PR DESCRIPTION
Allows specification of a table prefix per connection like so:

``` php
'pgsql' => array(
    'driver'       => 'pgsql',
    'host'         => 'localhost',
    'database'     => 'database',
    'username'     => 'root',
    'password'     => '',
    'charset'      => 'utf8',
    'table_prefix' => 'pre_',
),
```

The prefix is applied at the `Grammar` level (both for Query and Schema), so it applies to all generated SQL. Hand-coded queries can get the prefix by calling `DB::connection()->table_prefix()`.
