### PR TITLE
Parsing the query string straight from the REQUEST_URI

### DIFF
--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -135,7 +135,8 @@ $input = array();
 switch (Request::method())
 {
 	case 'GET':
-		$input = $_GET;
+		$query_string = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+		parse_str($query_string, $input);
 		break;
 
 	case 'POST':


### PR DESCRIPTION
Hey Taylor,

I was having problems with getting $_GET (Input::get('something')) variables.

GET would only work on domain.com/?a=1&b=2
However, if my URL looked like this:
domain.com/admin/accounts/index?page=2, $_GET would be an empty array.

I am guessing this is because of the way Nginx sends the parameters to PHP?
(http://pastie.org/3275915) this is my nginx configuration if it helps.

This pull fixes the problem but I have no idea how this behaves on Apache setups.

Anyways, see what you can do with it ;)
