### PR TITLE
Query bindings

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -153,7 +153,7 @@ class Connection {
 		// Since expressions are injected into the query as raw strings, we need
 		// to remove them from the array of bindings. They are not truly bound
 		// to the PDO statement as named parameters.
-		foreach ($bindings as $key => $value)
+		foreach ((array)$bindings as $key => $value)
 		{
 			if ($value instanceof Expression) unset($bindings[$key]);
 		}


### PR DESCRIPTION
 Converts query bindings to an array if they are not already. This is something I like to do as it look cleaner in my opinion.

Compare:

DB::query('SELECT \* FROM table WHERE id = ?', $id);

To:

DB::query('SELECT \* FROM table WHERE id = ?', array($id));

Hope everything goes right, this is my very first pull request! :)
