### PR TITLE
Added a method to turn URI into associative array

### DIFF
--- a/laravel/uri.php
+++ b/laravel/uri.php
@@ -81,6 +81,38 @@ class URI {
 	}
 
 	/**
+	 * Returns the URI as an associative array.
+	 * 
+	 * Set the offset to return the URI as assoc after the $offset.
+	 *
+	 * <code>
+	 * 		// Get the URI as an associative array
+	 * 		$assoc = URI::to_assoc();
+	 * 
+	 * 		// Get the URI after the 2nd segment as an associative array
+	 * 		$assoc = URI::to_assoc(2);
+	 * </code>
+	 *
+	 * @param int     $offset
+	 * @return array
+	 **/
+	public static function to_assoc($offset = 0)
+	{
+		$uri_segments = explode('/', static::current());
+
+		$uri_segments_length = count($uri_segments);
+
+		$uri_as_assoc = array();
+
+		for ($i = $offset; $i < $uri_segments_length; $i = $i + 2)
+		{
+			$uri_as_assoc[$uri_segments[$i]] = $uri_segments[$i + 1];
+		}
+
+		return $uri_as_assoc;
+	}
+
+	/**
 	 * Remove a given value from the URI.
 	 *
 	 * @param  string  $uri


### PR DESCRIPTION
Returns the URI as an associative array. For example:

```
example.com/category/12/inventory/in-stock/sort-by/price/
```

`to_assoc()` would return:

```
array(
    'category' => 12,
    'inventory' => 'in-stock',
    'sort-by' => 'price'
);
```

This example illustrates how we are currently using this method, to filter/sort products.

You can use `$offset` to start parsing the URI at the specified segment, and if there is an odd number of segments, the last key will be set to null.

```
example.com/category/toys/inventory/in-stock/sort
```

Since there are 5 URI segments, `to_assoc()` would return:

```
array(
    'category' => 'toys',
    'inventory' => 'in-stock',
    'sort' => null
);
```

If you had a URI of `/store/brand/nike/category/shoes` and set an offset of 1 you would get could bypass the `store` segment and get only the part of the URI you need. In this case, `to_assoc(1)` would return:

```
array(
    'brand' => 'nike',
    'category' => 'shoes',
);
```
