### PR TITLE
Add URI class to class aliases array.

### DIFF
--- a/application/config/application.php
+++ b/application/config/application.php
@@ -134,6 +134,7 @@ return array(
 		'Lang'       => 'Laravel\\Lang',
 		'Memcached'  => 'Laravel\\Memcached',
 		'Paginator'  => 'Laravel\\Paginator',
+		'URI'        => 'Laravel\\URI',
 		'URL'        => 'Laravel\\URL',
 		'Redirect'   => 'Laravel\\Redirect',
 		'Redis'      => 'Laravel\\Redis',


### PR DESCRIPTION
The URI class is one of the most commonly used classes in Laravel, so it would make sense to have it in the class aliases array along with most of the other classes. At the moment, you need to use Laravel\URI to access the URI class from within a Laravel application so adding an alias would make things much more convenient.
