### PR TITLE
Show an error when an artisan task's method cannot be found.

### DIFF
--- a/laravel/cli/command.php
+++ b/laravel/cli/command.php
@@ -42,7 +42,14 @@ class Command {
 			throw new \Exception("Sorry, I can't find that task.");
 		}
 
-		$task->$method(array_slice($arguments, 1));
+		if(method_exists($task, $method))
+		{
+			$task->$method(array_slice($arguments, 1));
+		}
+		else
+		{
+			throw new \Exception("Sorry, I can't find that method!");
+		}
 	}
 
 	/**


### PR DESCRIPTION
Originally this would happen :

```
dre: /home/dre/www/laravel/new [git:develop+] 
->php artisan key:sdfsdff
PHP Fatal error:  Call to undefined method Laravel\CLI\Tasks\Key::sdfsdff() in /home/dre/www/laravel/new/laravel/cli/command.php on line 45
```

and now :

```
dre: /home/dre/www/laravel/new [git:develop+] 
-> php artisan key:sdfsdff
Sorry, I can't find that method!
```

Thanks :)
