### PR TITLE
Added a URI::segment_value() method.

### DIFF
--- a/laravel/uri.php
+++ b/laravel/uri.php
@@ -211,7 +211,45 @@ class URI {
 
 		return array_get(static::$segments, $index - 1, $default);
 	}
-
+	
+	/**
+	 * Get the value of a specific segment key of the request URI.
+	 *
+	 * <code>
+	 *		// Get the value of the segment key "page"
+	 *		$value = URI::segment_value('page');
+	 *
+	 *		// Get the value of the segment key "page", or return a default value
+	 *		$segment = URI::segment('page', '1');
+	 * </code>
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return string
+	 */
+	public static function segment_value($uri_key, $default = null)
+	{
+		static::current();
+		
+		$i = 0;
+		
+		foreach (static::$segments as $value)
+		{
+			if ($uri_key == $value)
+			{
+				// We do +1 because the next segment is the value for the key
+				return static::$segments[$i+1]; 
+			}
+			else
+			{
+				$i++;
+			}
+		}
+		
+		// If we got this far, return our default
+		return $default;
+	}
+	
 	/**
 	 * Set the URI segments for the request.
 	 *


### PR DESCRIPTION
The `segment_value()` method allows you to easily pick out values you need from a URL without having to always know the exact segment the value you want is in.

This is useful for URIs like `/admin/users/view/page/3/sort_by/name/limit/25/show_emails/true`

You can easily find and know if you have a sort order by calling `URI::segment_value('sort_by')`.

The benefit to using URLs like this is you can easily understand what's happening, as opposed to a URL like `/admin/users/view/3/name/25/true`... as well as adding new conditions, etc is simple also.
