### PR TITLE
Load designated route's response

### DIFF
--- a/laravel/routing/route.php
+++ b/laravel/routing/route.php
@@ -348,5 +348,17 @@ class Route {
 	{
 		Filter::register($name, $callback);
 	}
+	
+	/**
+	 * Calls the specified route and returns its response.
+	 *
+	 * @param  string    $method
+	 * @param  string    $uri
+	 * @return Response
+	 */
+	public static function load($method, $uri)
+	{
+		return Router::route(strtoupper($method), $uri)->call();
+	}
 
 }


### PR DESCRIPTION
Just a quick shortcut method on the Route class that allows you to designate another route and return its Response object. I figure this would get used more often than if you had to do the following each time:

`return Router::route('GET', 'foo')->call();`
