### PR TITLE
Ability to set syntax for self-closing HTML tags

### DIFF
--- a/application/config/strings.php
+++ b/application/config/strings.php
@@ -31,6 +31,20 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
+	| HTML Self-Closing Syntax
+	|--------------------------------------------------------------------------
+	|
+	| Here you can set the global syntax of self-closing tags for functions
+	| that generate HTML, such as those found in the Form and HTML classes.
+	| This ensures that Laravel's generated HTML will validate, no matter what
+	| doctype you use.
+	|
+	*/
+
+	'close_tag' => '>',
+
+	/*
+	|--------------------------------------------------------------------------
 	| ASCII Characters
 	|--------------------------------------------------------------------------
 	|

--- a/laravel/form.php
+++ b/laravel/form.php
@@ -200,7 +200,7 @@ class Form {
 
 		$attributes = array_merge($attributes, compact('type', 'name', 'value', 'id'));
 
-		return '<input'.HTML::attributes($attributes).'>'.PHP_EOL;
+		return '<input'.HTML::attributes($attributes).Config::get('strings.close_tag').PHP_EOL;
 	}
 
 	/**

--- a/laravel/html.php
+++ b/laravel/html.php
@@ -73,7 +73,7 @@ class HTML {
 
 		$url = static::entities(URL::to_asset($url));
 
-		return '<link href="'.$url.'"'.static::attributes($attributes).'>'.PHP_EOL;
+		return '<link href="'.$url.'"'.static::attributes($attributes).Config::get('strings.close_tag').PHP_EOL;
 	}
 
 	/**
@@ -224,7 +224,7 @@ class HTML {
 	{
 		$attributes['alt'] = $alt;
 
-		return '<img src="'.static::entities(URL::to_asset($url)).'"'.static::attributes($attributes).'>';
+		return '<img src="'.static::entities(URL::to_asset($url)).'"'.static::attributes($attributes).Config::get('strings.close_tag');
 	}
 
 	/**


### PR DESCRIPTION
I used to be a full-time front-end developer, and I was always extremely picky about my code. Currently, some of Laravel's HTML helpers would produce invalid HTML if using an XHTML doctype, which would have really bugged me if I were still producing HTML 8 hours a day... and all because of the silly self-closing tag syntax rules of XHTML.

Nevertheless, I have added a config option in the strings file that allows developers to set the self-closing syntax for the HTML helpers that produce self-closing tags. I figure that Laravel is quite good about letting programmers write code the way they want to, that our front-end brethren should have some flexibility too.
