### PR TITLE
Stack filters

### DIFF
--- a/laravel/routing/filter.php
+++ b/laravel/routing/filter.php
@@ -39,7 +39,18 @@ class Filter {
 	{
 		if (isset(static::$aliases[$name])) $name = static::$aliases[$name];
 
-		static::$filters[$name] = $callback;
+		if (isset(static::$filters[$name]))
+		{
+			$old = static::$filters[$name];
+			static::$filters[$name] = function() use ($old, $callback) {
+				call_user_func_array($callback, func_get_args());
+				call_user_func_array($old, func_get_args());
+			};
+		} 
+		else 
+		{
+			static::$filters[$name] = $callback;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Makes it possible to stack filter. This is useful if for example a bundle wants to add something to the "after" filter and not override the applications "after" filter.
