### PR TITLE
Bugfix - Detect already installed bundle.

### DIFF
--- a/laravel/cli/tasks/bundle/bundler.php
+++ b/laravel/cli/tasks/bundle/bundler.php
@@ -37,9 +37,9 @@ class Bundler extends Task {
 	{
 		foreach ($this->get($bundles) as $bundle)
 		{
-			if (Bundle::exists($bundle['name']))
+			if (Bundle::exists($bundle['path']))
 			{
-				echo "Bundle {$bundle['name']} is already installed.";
+				echo "Bundle [{$bundle['name']}] is already installed.";
 
 				continue;
 			}


### PR DESCRIPTION
When "name" and "path" aren't the same, it can't see if the bundle are already installed or not.

This patch fixes that.
