### PR TITLE
Allow File::cpdir() to return false on failure.

### DIFF
--- a/laravel/file.php
+++ b/laravel/file.php
@@ -183,7 +183,7 @@ class File {
 	 */
 	public static function mvdir($source, $destination, $options = fIterator::SKIP_DOTS)
 	{
-		static::cpdir($source, $destination, true, $options);
+		return static::cpdir($source, $destination, true, $options);
 	}
 
 	/**
@@ -197,7 +197,7 @@ class File {
 	 */
 	public static function cpdir($source, $destination, $delete = false, $options = fIterator::SKIP_DOTS)
 	{
-		if ( ! is_dir($source)) return;
+		if ( ! is_dir($source)) return false;
 
 		// First we need to create the destination directory if it doesn't
 		// already exists. This directory hosts all of the assets we copy
@@ -221,7 +221,7 @@ class File {
 			{
 				$path = $item->getRealPath();
 
-				static::cpdir($path, $location, $delete, $options);
+				if (! static::cpdir($path, $location, $delete, $options)) return false;
 
 				if ($delete) @rmdir($item->getRealPath());
 			}
@@ -231,13 +231,15 @@ class File {
 			// files with the same name.
 			else
 			{
-				copy($item->getRealPath(), $location);
+				if(! copy($item->getRealPath(), $location)) return false;
 
 				if ($delete) @unlink($item->getRealPath());
 			}
 		}
 
 		if ($delete) rmdir($source);
+		
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Would this be useful at all?

We could use it to track down issues with bundles failing to install due to filesystem permissions, etc.

Dayle.
