### PR TITLE
Allow no key in $messages->first()

### DIFF
--- a/laravel/messages.php
+++ b/laravel/messages.php
@@ -64,6 +64,9 @@ class Messages {
 	 * Get the first message from the container for a given key.
 	 *
 	 * <code>
+	 *		// Echo the first message out of all messages.
+	 *		echo $messages->first();
+	 *
 	 *		// Echo the first message for the e-mail attribute
 	 *		echo $messages->first('email');
 	 *
@@ -75,9 +78,11 @@ class Messages {
 	 * @param  string  $format
 	 * @return string
 	 */
-	public function first($key, $format = ':message')
+	public function first($key = null, $format = ':message')
 	{
-		return (count($messages = $this->get($key, $format)) > 0) ? $messages[0] : '';
+		$messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
+
+		return (count($messages) > 0) ? $messages[0] : '';
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Jason Lewis jason.lewis1991@gmail.com

Often I find I want to get the first message from the array of messages and not for a specific key. Quick fix to allow first message from all messages to be returned. Useful when used with the validator.

```
if($validator->invalid())
{
    throw new Exception($validator->errors->first()); // Throw exception with the first message in the array.
}
```
