### PR TITLE
Quick fix to stop publishing on non-registered bundles

### DIFF
--- a/laravel/cli/tasks/bundle/publisher.php
+++ b/laravel/cli/tasks/bundle/publisher.php
@@ -14,6 +14,9 @@ class Publisher {
 	 */
 	public function publish($bundle)
 	{
+		if (! Bundle::exists($bundle))
+			throw new \Exception('A bundle must be registered in bundles.php to be published.');
+
 		$path = Bundle::path($bundle);
 
 		$this->move($path.'public', path('public').'bundles'.DS.$bundle);
@@ -30,7 +33,7 @@ class Publisher {
 	 */
 	protected function move($source, $destination)
 	{
-		File::cpdir($source, $destination);	
+		File::cpdir($source, $destination);
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Dayle Rees thepunkfan@gmail.com

Added a Bundle::exists() to bundle:publish as a quick fix for the issue : #369
