### PR TITLE
Added bundle fetching notification for bundle:install

### DIFF
--- a/laravel/cli/tasks/bundle/bundler.php
+++ b/laravel/cli/tasks/bundle/bundler.php
@@ -53,9 +53,10 @@ class Bundler extends Task {
 			// hosting party and installing it into the application.
 			$path = path('bundle').$this->path($bundle);
 
+			echo "Fetching [{$bundle['name']}]...";
 			$this->download($bundle, $path);
 
-			echo "Bundle [{$bundle['name']}] installed!".PHP_EOL;
+			echo "done! Bundle installed.".PHP_EOL;
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Dayle Rees thepunkfan@gmail.com

On slow connections (noticed while family member was leeching our ADSL) the bundle:install can look a little like it has crashed.

Added a Fetching.. message to show action.

Looks like this :

Before download has finished :

```
daylerees: /home/daylerees/www/laravel/help [git:fetching-notice+?] 
⚡php artisan bundle:install eloquent
Fetching [eloquent]...
```

and when the download completes :

```
daylerees: /home/daylerees/www/laravel/help [git:fetching-notice+?] 
⚡php artisan bundle:install eloquent
Fetching [eloquent]...done! Bundle installed.
```

A % bar would be sweet down the line, not sure how to replace lines on the CLI yet though.
