### PR TITLE
Remove case-sensitivity from outgoing request headers

### DIFF
--- a/laravel/response.php
+++ b/laravel/response.php
@@ -181,14 +181,14 @@ class Response {
 		if (is_null($name)) $name = basename($path);
 
 		$headers = array_merge(array(
-			'Content-Description'       => 'File Transfer',
-			'Content-Type'              => File::mime(File::extension($path)),
-			'Content-Disposition'       => 'attachment; filename="'.$name.'"',
-			'Content-Transfer-Encoding' => 'binary',
-			'Expires'                   => 0,
-			'Cache-Control'             => 'must-revalidate, post-check=0, pre-check=0',
-			'Pragma'                    => 'public',
-			'Content-Length'            => File::size($path),
+			'content-description'       => 'File Transfer',
+			'content-type'              => File::mime(File::extension($path)),
+			'content-disposition'       => 'attachment; filename="'.$name.'"',
+			'content-transfer-Encoding' => 'binary',
+			'expires'                   => 0,
+			'cache-control'             => 'must-revalidate, post-check=0, pre-check=0',
+			'pragma'                    => 'public',
+			'content-length'            => File::size($path),
 		), $headers);
 
 		return new static(File::get($path), 200, $headers);
@@ -279,7 +279,7 @@ class Response {
 		// If the content type was not set by the developer, we will set the
 		// header to a default value that indicates to the browser that the
 		// response is HTML and that it uses the default encoding.
-		if ( ! isset($this->headers['Content-Type']))
+		if ( ! isset($this->headers['content-type']))
 		{
 			$encoding = Config::get('application.encoding');
 
@@ -314,7 +314,7 @@ class Response {
 	 */
 	public function header($name, $value)
 	{
-		$this->headers[$name] = $value;
+		$this->headers[strtolower($name)] = $value;
 		return $this;
 	}
 


### PR DESCRIPTION
Headers are not case sensitive (http://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive) but Laravel treats them as such.

This causes confusion when setting a header such as "Content-Type", but accidentally/unknowingly setting it as "Content-type". The header is forgotten in the overwrite.

This pull request fixes this issue, although it still leaves a minor hole for errors. It might be an idea to either use an Array interface for the headers or set them to private and use __get, __set for retrieving them in a case-insensitive manner.
