### PR TITLE
Make key optional for Messages->has() as well

### DIFF
--- a/laravel/messages.php
+++ b/laravel/messages.php
@@ -52,10 +52,18 @@ class Messages {
 	/**
 	 * Determine if messages exist for a given key.
 	 *
+	 * <code>
+	 *		// Is there a message for the e-mail attribute
+	 *		return $messages->has('email');
+	 *
+	 *		// Is there a message for the any attribute
+	 *		echo $messages->has();
+	 * </code>
+	 *
 	 * @param  string  $key
 	 * @return bool
 	 */
-	public function has($key)
+	public function has($key = null)
 	{
 		return $this->first($key) !== '';
 	}


### PR DESCRIPTION
Seems logical to me, if the key is optional for `first()` (i.e. get the first of all messages).  This way:

```
$messages->has()
```

will tell you if there are any messages at all.  Less code than using `count()` or something.

Signed-off-by: Colin Viebrock colin@viebrock.ca
