### PR TITLE
Fix raw table expressions

### DIFF
--- a/laravel/database/grammar.php
+++ b/laravel/database/grammar.php
@@ -35,6 +35,11 @@ abstract class Grammar {
 	 */
 	public function wrap_table($table)
 	{
+		if ($table instanceof Expression)
+		{
+			return $this->wrap($table);
+		}
+
 		$prefix = '';
 
 		// Tables may be prefixed with a string. This allows developers to


### PR DESCRIPTION
Fixes the issue I mentioned on IRC yesterday where a complex table expression doesn't work in Query Builder. Even wrapping the expression in `DB::raw()` didn't matter because adding the table prefix (even if blank) cast the `Expression` back into a string, with undesirable results.

This patch makes sure that raw expressions are not prefixed. I suppose this will need to be noted in the documentation.
