### PR TITLE
Trailing slash in form fields for XHTML compatibility

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -200,7 +200,7 @@ class Form {
 
 		$attributes = array_merge($attributes, compact('type', 'name', 'value', 'id'));
 
-		return '<input'.HTML::attributes($attributes).'>'.PHP_EOL;
+		return '<input'.HTML::attributes($attributes).' />'.PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
Forms generated by Laravel's form class did not output a trailing slash for <input> elements. This might not be required with HTML5 (if I remember correctly), but is necessary for things like valid XHTML.
