### PR TITLE
Throw ErrorException so developer can catch it

### DIFF
--- a/laravel/error.php
+++ b/laravel/error.php
@@ -62,11 +62,12 @@ class Error {
 		if (in_array($code, Config::get('error.ignore')))
 		{
 			return static::log($exception);
-
-			return true;
 		}
 
-		static::exception($exception);
+		// Throw the ErrorException so that the developer may catch it
+		// themselves.  If it is not caught then the exception handler will
+		// take over.
+		throw $exception;
 	}
 
 	/**


### PR DESCRIPTION
Can you remember why we pass the ErrorException to the exception handler instead of throwing it?  There might be a good reason, but someone in IRC wanted to catch the ErrorException earlier and this fixed it for them.
