### PR TITLE
Modified Command::run() to pass actual params instead of array.

### DIFF
--- a/laravel/cli/command.php
+++ b/laravel/cli/command.php
@@ -46,7 +46,7 @@ class Command {
 
 		if(is_callable(array($task, $method)))
 		{
-			$task->$method(array_slice($arguments, 1));
+			call_user_func_array(array($task, $method), array_slice($arguments, 1));
 		}
 		else
 		{


### PR DESCRIPTION
This lets you use tasks w/ actual paramater names, instead of using an array of params.

```
public function run($args)
{
     My::method($args[0], $args[1]);
}
```

Becomes

```
public function run($this, $that)
{
     My::method($this, $that);
}
```

I think I did this right, you guys should give it a look.
