### PR TITLE
Query::left_join to accept closures

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -182,7 +182,7 @@ class Query {
 	 * @param  string  $column2
 	 * @return Query
 	 */
-	public function left_join($table, $column1, $operator, $column2)
+	public function left_join($table, $column1, $operator = null, $column2 = null)
 	{
 		return $this->join($table, $column1, $operator, $column2, 'LEFT');
 	}


### PR DESCRIPTION
Added default values to the arguments of left_join. Now it will accept closures that define join conditions.
