### PR TITLE
Date before and after filters

### DIFF
--- a/application/language/en/validation.php
+++ b/application/language/en/validation.php
@@ -59,6 +59,8 @@ return array(
 	),
 	"unique"         => "The :attribute has already been taken.",
 	"url"            => "The :attribute format is invalid.",
+	"before"		 => "The :attribute field must contain a date before :date.",
+	"after"		 	=> "The :attribute field must contain a date after :date.",
 
 	/*
 	|--------------------------------------------------------------------------

--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -647,6 +647,32 @@ class Validator {
 	}
 
 	/**
+	 * Validate the date is before a given date.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @param  array   $parameters
+	 * @return bool
+	 */
+	protected function validate_before($attribute, $value, $parameters)
+	{
+		return (strtotime($value) < strtotime($parameters[0]));
+	}	
+
+	/**
+	 * Validate the date is after a given date.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @param  array   $parameters
+	 * @return bool
+	 */
+	protected function validate_after($attribute, $value, $parameters)
+	{
+		return (strtotime($value) > strtotime($parameters[0]));
+	}		
+
+	/**
 	 * Get the proper error message for an attribute and rule.
 	 *
 	 * @param  string  $attribute
@@ -876,6 +902,34 @@ class Validator {
 	{
 		return str_replace(':other', $parameters[0], $message);
 	}
+
+	/**
+	 * Replace all place-holders for the before rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replace_before($message, $attribute, $rule, $parameters)
+	{
+		return str_replace(':date', $parameters[0], $message);
+	}
+
+	/**
+	 * Replace all place-holders for the after rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replace_after($message, $attribute, $rule, $parameters)
+	{
+		return str_replace(':date', $parameters[0], $message);
+	}	
 
 	/**
 	 * Get the displayable name for a given attribute.


### PR DESCRIPTION
This patch allows you to specify a before:<datehere> and after:<datehere> validation rule.

A fix for #373

The <datehere> parameter is run through strtotime() so can take many formats, the field value is also compared this way.

For example :

$rules = array('time' => 'before:24-12-2007');

Also included validation error strings.
