### PR TITLE
Fixed problem with Eloquent2 pivot tables

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -290,19 +290,17 @@ class Has_Many_And_Belongs_To extends Relationship {
 			// the pivot table that may need to be accessed by the developer.
 			$pivot = new Pivot($this->joining);
 
-			$attributes = array_filter($result->attributes, function($attribute)
-			{
-				return starts_with($attribute, 'pivot_');
-			});
-
 			// If the attribute key starts with "pivot_", we know this is a column on
 			// the pivot table, so we will move it to the Pivot model and purge it
 			// from the model since it actually belongs to the pivot.
-			foreach ($attributes as $key => $value)
+			foreach ($result->attributes as $key => $value)
 			{
-				$pivot->{substr($key, 6)} = $value;
+				if (starts_with($key, 'pivot_'))
+				{
+					$pivot->{substr($key, 6)} = $value;
 
-				$result->purge($key);
+					$result->purge($key);
+				}
 			}
 
 			// Once we have completed hydrating the pivot model instance, we'll set


### PR DESCRIPTION
Signed-off-by: Daniel Bondergaard danielboendergard@gmail.com

When hydrating the pivot tables Eloquent is checking the attributes from the result for column names starting with 'pivot_'. Before it was checking the values, but the column names is in the array keys.

This problem occurs when you try to eager load a has_many_and_belongs_to relationship.
