### PR TITLE
Adding back methods to both Redirect and URL

### DIFF
--- a/laravel/redirect.php
+++ b/laravel/redirect.php
@@ -36,6 +36,17 @@ class Redirect extends Response {
 	}
 
 	/**
+	 * Create a redirect response to the previous URL.
+	 *
+	 * @param  string    $fallback
+	 * @return Redirect
+	 */
+	public static function back($fallback = '/')
+	{
+	    return static::to(URL::back($fallback));
+	}
+
+	/**
 	 * Create a redirect response to a HTTPS URL.
 	 *
 	 * @param  string    $url

--- a/laravel/url.php
+++ b/laravel/url.php
@@ -131,6 +131,18 @@ class URL {
 
 		return rtrim($root, '/').'/'.ltrim($url, '/');
 	}
+	
+	/**
+	 * Generate an application URL to the previous URL.
+	 *
+	 * @param  string  $fallback
+	 * @return string
+	 */
+	public static function back($fallback = '/')
+	{
+	    $url = (isset($_SERVER['HTTP_REFERER'])) ? $_SERVER['HTTP_REFERER'] : $fallback;
+	    return static::to($url);
+	}	
 
 	/**
 	 * Generate an application URL with HTTPS.


### PR DESCRIPTION
A lot of times I find myself doing one of the following:

```
Redirect::to($_SERVER['HTTP_REFERER']);
URL::to($_SERVER['HTTP_REFERER']);
```

So I thought it might be nice to have a `back` method in both the `URL` and `Redirect` class.
