### PR TITLE
Httpsroutefix

### DIFF
--- a/laravel/url.php
+++ b/laravel/url.php
@@ -127,6 +127,10 @@ class URL {
 		if ($https and Config::get('application.ssl'))
 		{
 			$root = preg_replace('~http://~', 'https://', $root, 1);
+		} 
+		else if (strpos($root, 'https://') !== false)
+		{
+			$root = preg_replace('~https://~', 'http://', $root, 1);
 		}
 
 		return rtrim($root, '/').'/'.ltrim($url, '/');


### PR DESCRIPTION
When working with https all the links become https even if https is set to false in the route. This fix checks if the root contains https:// if so replaces https with http when the route is set to not use https.
