### PR TITLE
Timestamps are optional in many-to-many pivot table

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -25,7 +25,7 @@ class Has_Many_And_Belongs_To extends Relationship {
 	 *
 	 * @var array
 	 */
-	protected $with = array('id', 'created_at', 'updated_at');
+	protected $with = array();
 
 	/**
 	 * Create a new many to many relationship instance.
@@ -42,6 +42,11 @@ class Has_Many_And_Belongs_To extends Relationship {
 		$this->other = $other;
 
 		$this->joining = $table ?: $this->joining($model, $associated);
+
+		if (Pivot::$timestamps)
+		{
+			$this->with = array('id', 'created_at', 'updated_at');
+		}
 
 		parent::__construct($model, $associated, $foreign);
 	}


### PR DESCRIPTION
The many-to-many Eloquent relationship now respects the `timestamps` property of `Pivot`.

Signed-off-by: Kelly Banman kelly.banman@gmail.com
