### PR TITLE
Includes use render to prevent WSOD

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -264,7 +264,7 @@ class Blade {
 	{
 		$pattern = static::matcher('include');
 
-		return preg_replace($pattern, '$1<?php echo view$2->with(get_defined_vars()); ?>', $value);
+		return preg_replace($pattern, '$1<?php echo view$2->with(get_defined_vars())->render(); ?>', $value);
 	}
 
 	/**


### PR DESCRIPTION
When using @include the compiled PHP isn't using the render() method, it's better to use render() to avoid any possible WSOD.

Signed-off-by: Jason Lewis jason.lewis1991@gmail.com
