### PR TITLE
Makes Request::secure() take into account ssl configuration flag.

### DIFF
--- a/laravel/request.php
+++ b/laravel/request.php
@@ -104,7 +104,7 @@ class Request {
 	 */
 	public static function secure()
 	{
-		return isset($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) !== 'off';
+		return isset($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) !== 'off' and Config::$items['application']['ssl'];
 	}
 
 	/**


### PR DESCRIPTION
Hi. I ran into an issue with my server in which I had an https site configured but which was independent of the site I was using Laravel with. Laravel kept trying to redirect to that other https site and failed. I thought that an easy fix would be to switch the SSL configuration option to false but that didn't seem to work. I looked in Request::secure() and saw that the code looked at the server HTTPS configuration but did not recognize that it might be for another site not related to the Laravel site I was configuring. Hence, I added a check for the the Laravel SSL configuration flag within Request::secure().
