### PR TITLE
Fix case mismatch in Bundle loader

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -64,7 +64,7 @@ class Bundle {
 
 		static::$bundles[$bundle] = array_merge($defaults, $config);
 
-		// It is possible for the develoepr to specify auto-loader mappings
+		// It is possible for the developer to specify auto-loader mappings
 		// directly on the bundle registration. This provides a convenient
 		// way to register mappings withuot a bootstrap.
 		if (isset($config['autoloads']))
@@ -127,7 +127,7 @@ class Bundle {
 
 		if ( ! static::routed($bundle) and file_exists($path))
 		{
-			static::$routed[] = $bundle;
+			static::$routed[] = strtolower($bundle);
 
 			require $path;
 		}
@@ -204,7 +204,7 @@ class Bundle {
 	 */
 	public static function exists($bundle)
 	{
-		return $bundle == DEFAULT_BUNDLE or in_array(strtolower($bundle), static::names());
+		return $bundle == DEFAULT_BUNDLE or in_array(strtolower($bundle), array_map(function($v){ return strtolower($v); },static::names()));
 	}
 
 	/**


### PR DESCRIPTION
Bundle class mismatched cases in some comparisons, thus reporting that
any bundle with a non lowercased name would load but not be reported as
existing.

Currently I'm fixing the case mismatch in the exists() function because
I'm not sure where else "names()" is called. It may be better to run
the array_map in the names() function itself.

Also fixed a small comment typo I discovered.
