### PR TITLE
Allow third party database drivers

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -1,4 +1,4 @@
-<?php namespace Laravel\Database; use PDO, PDOStatement, Laravel\Config, Laravel\Event;
+<?php namespace Laravel\Database; use PDO, PDOStatement, Laravel\Config, Laravel\Event, Laravel\Database as DB;
 
 class Connection {
 
@@ -71,17 +71,14 @@ class Connection {
 	{
 		if (isset($this->grammar)) return $this->grammar;
 
-		switch (isset($this->config['grammar']) ? $this->config['grammar'] : $this->driver())
+		$grammar = isset($this->config['grammar']) ? $this->config['grammar'] : $this->driver();
+		
+		if (isset(DB::$drivers[$grammar]['query']))
 		{
-			case 'mysql':
-				return $this->grammar = new Query\Grammars\MySQL($this);
-
-			case 'sqlsrv':
-				return $this->grammar = new Query\Grammars\SQLServer($this);
-
-			default:
-				return $this->grammar = new Query\Grammars\Grammar($this);
+			return $this->grammar = new DB::$drivers[$grammar]['query']($this);
 		}
+		
+		return $this->grammar = new Query\Grammars\Grammar($this);
 	}
 
 	/**
@@ -287,7 +284,7 @@ class Connection {
 	 */
 	public function driver()
 	{
-		return $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+		return $this->config['driver'];
 	}
 
 	/**

--- a/laravel/database/schema.php
+++ b/laravel/database/schema.php
@@ -145,19 +145,9 @@ class Schema {
 	{
 		$driver = $connection->driver();
 
-		switch ($driver)
+		if (isset(DB::$drivers[$driver]['schema']))
 		{
-			case 'mysql':
-				return new Schema\Grammars\MySQL($connection);
-
-			case 'pgsql':
-				return new Schema\Grammars\Postgres($connection);
-
-			case 'sqlsrv':
-				return new Schema\Grammars\SQLServer($connection);
-
-			case 'sqlite':
-				return new Schema\Grammars\SQLite($connection);
+			return new DB::$drivers[$driver]['schema']($connection);
 		}
 
 		throw new \Exception("Schema operations not supported for [$driver].");


### PR DESCRIPTION
Removes the hardcoded list of database drivers and replaces it with a driver
registration model. This will allow third parties to create database drivers without
requiring modifications to the laravel folder directly, thus easing installation, version upgrades, etc.

I'm using this in multiple ways, but primarily to create multiple drivers that use the same PDO driver but different query and schema grammars, such as an ODBC connection to Filemaker Pro and an ODBC connection to SQLServer (on a mac).

(initial pull request closed, resubmitted properly from it's own branch)
