### PR TITLE
Use old school callback arrays rather than Closure

### DIFF
--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -24,22 +24,11 @@ require 'core.php';
 |
 */
 
-set_exception_handler(function($e)
-{
-	Error::exception($e);
-});
+set_exception_handler(array('Laravel\Error', 'exception'));
 
+set_error_handler(array('Laravel\Error', 'native'));
 
-set_error_handler(function($code, $error, $file, $line)
-{
-	Error::native($code, $error, $file, $line);
-});
-
-
-register_shutdown_function(function()
-{
-	Error::shutdown();
-});
+register_shutdown_function(array('Laravel\Error', 'shutdown'));
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Makes a shorter trace on the shutdown function too

Signed-off-by: Phill Sparks me@phills.me.uk
