### PR TITLE
Make Section::append public, and do a true append. Other methods are renamed but unchanged.

### DIFF
--- a/laravel/section.php
+++ b/laravel/section.php
@@ -39,7 +39,7 @@ class Section {
 		}
 		else
 		{
-			static::append($section, $content);
+			static::extend($section, $content);
 		}
 	}
 
@@ -79,23 +79,44 @@ class Section {
 	 */
 	public static function stop()
 	{
-		static::append($last = array_pop(static::$last), ob_get_clean());
+		static::extend($last = array_pop(static::$last), ob_get_clean());
 
 		return $last;
 	}
 
 	/**
-	 * Append content to a given section.
+	 * Extend the content in a given section.
+	 * The old content can be injected into the new using "@parent".
 	 *
 	 * @param  string  $section
 	 * @param  string  $content
 	 * @return void
 	 */
-	protected static function append($section, $content)
+	protected static function extend($section, $content)
 	{
 		if (isset(static::$sections[$section]))
 		{
 			static::$sections[$section] = str_replace('@parent', $content, static::$sections[$section]);
+		}
+		else
+		{
+			static::$sections[$section] = $content;
+		}
+	}
+
+	/**
+	 * Append content to a given section.
+	 * This concatenates the old content and the new.
+	 *
+	 * @param  string  $section
+	 * @param  string  $content
+	 * @return void
+	 */
+	public static function append($section, $content)
+	{
+		if (isset(static::$sections[$section]))
+		{
+			static::$sections[$section] .= $content;
 		}
 		else
 		{


### PR DESCRIPTION
The previous functionality using `@parent` in Blade templates is unchanged.  I just changed the protected method from `append` to `extend`, which seems more accurate.  But now, you can do:

```
Section::start('title', 'My App');
Section::append('title', ' - User');
Section::append('title', ' - Account Info');

echo Section::yield('title');
```

Outputs:

```
My App - User - Account Info
```
