### PR TITLE
Resolver::resolve() bug fix

### DIFF
--- a/laravel/cli/tasks/migrate/resolver.php
+++ b/laravel/cli/tasks/migrate/resolver.php
@@ -116,7 +116,7 @@ class Resolver {
 			// naming collisions with other bundle's migrations.
 			$prefix = Bundle::class_prefix($bundle);
 
-			$class = $prefix.substr($name, 18);
+			$class = $prefix.\Laravel\Str::classify(substr($name, 18));
 
 			$migration = new $class;
 


### PR DESCRIPTION
I changed `Resolver::resolve()` to use the `Str::classify()` method, just like `Migrator::stub()` does.

I found this issue while creating a migration with a dot in the name - e.g. `php artisan migrate:make migrate_to_laravel_3.1`. The resulting class name was `migrate_to_laravel_3_1`, which could not be found by the `Resolver::resolve()` method without the `Str::classify()` call.

Signed-off-by: Joe Wallace joew@atiba.com
