### PR TITLE
Eloquent Model::table() bug fix

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -465,7 +465,7 @@ abstract class Model {
 	 */
 	public function table()
 	{
-		return static::$table ?: strtolower(Str::plural(basename(get_class($this))));
+		return static::$table ?: strtolower(Str::plural(class_basename($this)));
 	}
 
 	/**


### PR DESCRIPTION
Eloquent's `Model::table()` method uses PHP's `basename()` function to strip the namespace from the result of `get_class($this)`, which only works on Windows. (`basename()` on *nix systems only uses `'/'` for the DS.)

Happily, Laravel already has a `class_basename()` helper to work around that issue, so I changed `Model::table()` to use it.

Signed-off-by: Joe Wallace joew@atiba.com
