### PR TITLE
Bugfix: Avoid double-loading of classes in Autoloader

### DIFF
--- a/laravel/autoloader.php
+++ b/laravel/autoloader.php
@@ -61,6 +61,7 @@ class Autoloader {
 		elseif (isset(static::$mappings[$class]))
 		{
 			require static::$mappings[$class];
+			return;
 		}
 
 		// If the class namespace is mapped to a directory, we will load the


### PR DESCRIPTION
I was trying to use my own Paginator class. Because
Laravel uses explicitely Laravel\Paginator in query.php
I had to declare my Paginator also as Laravel\Paginator.

After creating an Autoloader map in start.php a fatal
error was thrown when using the Paginator because the
Autoloader first included the class from my mapping
and afterwards iterated through the namespaces and
tried to include the Paginator (Laravel's one this
time) class again.

This bugfix makes the load() method return after a
class was loaded from the mappings.

So it's possible to override Laravel's built-in classes.
