### PR TITLE
Syncing Up Magic Methods

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -650,6 +650,8 @@ abstract class Model {
 		{
 			if (array_key_exists($key, $this->$source)) return true;
 		}
+		
+		if (method_exists($this, $key)) return true;
 	}
 
 	/**


### PR DESCRIPTION
This pull addresses an issue while using Twig with an Eloquent model. Twig checks if a property isset before calling it in the template. Unfortunately Eloquent's magic methods were running methods inside __get but not checking for the presence of those methods inside __isset. This will allow the following to work inside Twig:

```
{{ post.author.name }}
```

If this should not go to `develop` let me know. I'm happy to resubmit.
