### PR TITLE
Memcached driver should use Memcached, not Memcache

### DIFF
--- a/laravel/cache/drivers/memcached.php
+++ b/laravel/cache/drivers/memcached.php
@@ -1,13 +1,13 @@
-<?php namespace Laravel\Cache\Drivers; use Memcache;
+<?php namespace Laravel\Cache\Drivers;
 
 class Memcached extends Driver {
 
 	/**
-	 * The Memcache instance.
+	 * The Memcached instance.
 	 *
-	 * @var Memcache
+	 * @var Memcached
 	 */
-	protected $memcache;
+	protected $memcached;
 
 	/**
 	 * The cache key from the cache configuration file.
@@ -19,13 +19,14 @@ class Memcached extends Driver {
 	/**
 	 * Create a new Memcached cache driver instance.
 	 *
-	 * @param  Memcache  $memcache
+	 * @param  \Memcached  $memcached
+	 * @param  string     $key
 	 * @return void
 	 */
-	public function __construct(Memcache $memcache, $key)
+	public function __construct(\Memcached $memcached, $key)
 	{
 		$this->key = $key;
-		$this->memcache = $memcache;
+		$this->memcached = $memcached;
 	}
 
 	/**
@@ -47,7 +48,7 @@ class Memcached extends Driver {
 	 */
 	protected function retrieve($key)
 	{
-		if (($cache = $this->memcache->get($this->key.$key)) !== false)
+		if (($cache = $this->memcached->get($this->key.$key)) !== false)
 		{
 			return $cache;
 		}
@@ -68,7 +69,7 @@ class Memcached extends Driver {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		$this->memcache->set($this->key.$key, $value, 0, $minutes * 60);
+		$this->memcached->set($this->key.$key, $value, $minutes * 60);
 	}
 
 	/**
@@ -91,7 +92,7 @@ class Memcached extends Driver {
 	 */
 	public function forget($key)
 	{
-		$this->memcache->delete($this->key.$key);
+		$this->memcached->delete($this->key.$key);
 	}
 
 }

--- a/laravel/memcached.php
+++ b/laravel/memcached.php
@@ -40,19 +40,19 @@ class Memcached {
 	 */
 	protected static function connect($servers)
 	{
-		$memcache = new \Memcache;
+		$memcached = new \Memcached;
 
 		foreach ($servers as $server)
 		{
-			$memcache->addServer($server['host'], $server['port'], true, $server['weight']);
+			$memcached->addServer($server['host'], $server['port'], $server['weight']);
 		}
 
-		if ($memcache->getVersion() === false)
+		if ($memcached->getVersion() === false)
 		{
 			throw new \Exception('Could not establish memcached connection.');
 		}
 
-		return $memcache;
+		return $memcached;
 	}
 
 	/**


### PR DESCRIPTION
Maybe I'm just being stupid, because this is the first time I've used Memcached... But the driver should be using the `Memcached` class, not `Memcache` - right?
