### PR TITLE
Fixing "Cannot remove ...: Permission denied" in File and bundle:: task

### DIFF
--- a/laravel/cli/tasks/bundle/providers/provider.php
+++ b/laravel/cli/tasks/bundle/providers/provider.php
@@ -54,6 +54,7 @@ abstract class Provider {
 
 		File::rmdir($work.'zip');
 
+		$zip->close();
 		@unlink($target);
 	}
 

--- a/laravel/file.php
+++ b/laravel/file.php
@@ -273,6 +273,7 @@ class File {
 			}
 		}
 
+		unset($items);
 		if ($delete) rmdir($source);
 		
 		return true;
@@ -306,6 +307,7 @@ class File {
 			}
 		}
 
+		unset($items);
 		if ( ! $preserve) @rmdir($directory);
 	}
 


### PR DESCRIPTION
Signed-off-by: Pavel proger.xp@gmail.com

Previously described in #538:

Setup: Windows XP SP3, XAMPP with PHP 5.3.

Problem: `File::rmdir()`, `File::cleandir()`, `Laravel\CLI\Tasks\Bundle\Providers\Provider::zipball()` fail to remove directories even though they have successfully emptied them (`zipball()` fails to remove the temporary zip file).

Cause: FilesystemIterator (`File`) and ZipArchive (`Provider`) are locking the directory/zipfile so that the following rmdir()/unlink() fails. 

I'm not sure thought that the GC will 100% reliably be triggered after the FilesystemIterator is unset so there might be a room for improvements (e.g. using scandir() instead).

Also, unlike other FIle functions cpdir() doesn't use @ silencer on its rmdir(). Is this intended?
