### PR TITLE
Cache::put writes a file even if the $minutes argument is 0.

### DIFF
--- a/laravel/cache/drivers/file.php
+++ b/laravel/cache/drivers/file.php
@@ -68,9 +68,11 @@ class File extends Driver {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		$value = $this->expiration($minutes).serialize($value);
-
-		file_put_contents($this->path.$key, $value, LOCK_EX);
+		if ( !empty($minutes) ) {
+			$value = $this->expiration($minutes).serialize($value);
+	
+			file_put_contents($this->path.$key, $value, LOCK_EX);
+		}
 	}
 
 	/**


### PR DESCRIPTION
It makes sense not to do anything if the $minutes argument is empty (or set to zero).

At the moment, I have 2 environment-based config files. The development config sets cache_time config item to 0 and Laravel still writes a cache file for it.

Obviously, the same change would apply to the other cache drivers, unless you have a reason for not wanting to do it this way.

Actually, it might be better to check: `if ( $minutes > 0 )` instead of `if ( !empty($minutes) )` just in case someone passes a negative value.

Thanks,
Maikel
