### PR TITLE
Added $response as parameter for 'laravel.done' event

### DIFF
--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -246,4 +246,4 @@ $response->send();
 |
 */
 
-Event::fire('laravel.done');
+Event::fire('laravel.done', $response);


### PR DESCRIPTION
According to the documentation:

```
Event fired when a database query is executed:

Event::listen('laravel.query', function($sql, $bindings, $time) {});
```

The code, however, runs (in `laravel/laravel.php`)

```
Event::fire('laravel.done');
```

I added the reponse parameter:

```
Event::fire('laravel.done', $response);
```

Now the code matches the docs, and listeners/handlers of the 'laravel.done' event - like my new bundle Rejigger - can have access to the response.

Signed-off-by: Joe Wallace joe.c.wallace@gmail.com
