### PR TITLE
Lang::__construct(): turn non-array $replacements into an array

### DIFF
--- a/laravel/lang.php
+++ b/laravel/lang.php
@@ -51,7 +51,7 @@ class Lang {
 	{
 		$this->key = $key;
 		$this->language = $language;
-		$this->replacements = $replacements;
+		$this->replacements = (array) $replacements;
 	}
 
 	/**


### PR DESCRIPTION
In my language files I often use strings with 1-2 replacements which I don't assign names: `Written on :0`, `Error :0 - try again`, etc. Currently I have to write `__('key', array('22/03/2012'))`; with this fix it's possible to avoid `array()` and also possible to pass objects which will be automatically turned into the replacement array.

Signed-off-by: Pavel proger.xp@gmail.com
