### PR TITLE
Str::words() doesn't use /u PCRE modifier

### DIFF
--- a/laravel/str.php
+++ b/laravel/str.php
@@ -148,7 +148,7 @@ class Str {
 	 */
 	public static function words($value, $words = 100, $end = '...')
 	{
-		preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/', $value, $matches);
+		preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 
 		if (static::length($value) == static::length($matches[0]))
 		{


### PR DESCRIPTION
Since it deals with natural texts and since Str usually works with /u I think it's just missing from this method.

Signed-off-by: Pavel proger.xp@gmail.com
