### PR TITLE
Make File::delete() return result of unlink()

### DIFF
--- a/laravel/file.php
+++ b/laravel/file.php
@@ -61,11 +61,11 @@ class File {
 	 * Delete a file.
 	 *
 	 * @param  string  $path
-	 * @return void
+	 * @return bool
 	 */
 	public static function delete($path)
 	{
-		if (static::exists($path)) @unlink($path);
+		if (static::exists($path)) return @unlink($path);
 	}
 
 	/**


### PR DESCRIPTION
I don't see why it shouldn't do this while eliminating extra is_file() check after the method call.

Signed-off-by: Pavel proger.xp@gmail.com
