### PR TITLE
Prevented Fatal Error if an exception occurs inside the Autoloader

### DIFF
--- a/laravel/core.php
+++ b/laravel/core.php
@@ -33,6 +33,7 @@ require path('sys').'event'.EXT;
 require path('sys').'bundle'.EXT;
 require path('sys').'config'.EXT;
 require path('sys').'helpers'.EXT;
+require path('sys').'error'.EXT;
 require path('sys').'autoloader'.EXT;
 
 /*


### PR DESCRIPTION
Currently Laravel uses regular autoloading mechanism to load the Error class. However, if an exception occurs while __autoload() is being executed PHP won't invoke it (or other SPL handlers) again and will fail with the following error:

```
Class 'Laravel\Error' not found
```

**How to reproduce**
Create a directory, register it using `Autoloader::directory()` and create a PSR-compliant file there:

``` PHP
class K {
  abstract static function f();
}
```

Now as soon as `K` is called PHP attempts to autoload it and stumbles upon the fatal error (`Static function K::f() should not be abstract`). Laravel's `set_error_handler()` is called but it also references an undefined class `Error` which PHP won't attempt to load anymore and will fail with a misleading message.

Signed-off-by: Pavel proger.xp@gmail.com
