### PR TITLE
Fixed PHP_NOTICE and a following exception in Str::words() on empty $value

### DIFF
--- a/laravel/str.php
+++ b/laravel/str.php
@@ -148,6 +148,9 @@ class Str {
 	 */
 	public static function words($value, $words = 100, $end = '...')
 	{
+    $value = (string) $value;
+    if ($value === '') return '';
+	
 		preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/', $value, $matches);
 
 		if (static::length($value) == static::length($matches[0]))


### PR DESCRIPTION
This has been bugging me for some time now and I see no reason why this can't be fixed. 

``` PHP
Str::words('');
```

PHP_NOTICE: **Undefined offset: 0**. Then Laravel catches and fails with an error.

Signed-off-by: Pavel proger.xp@gmail.com
