### PR TITLE
Allow setting merge method

### DIFF
--- a/laravel/input.php
+++ b/laravel/input.php
@@ -231,12 +231,15 @@ class Input {
 	/**
 	 * Merge new input into the current request's input array.
 	 *
-	 * @param  array  $input
+	 * @param  array   $input
+	 * @param  string  $method
 	 * @return void
 	 */
-	public static function merge(array $input)
+	public static function merge(array $input, $method = 'POST')
 	{
-		Request::foundation()->request->replace($input);
+		$param = ($method == 'POST') ? 'request' : 'query';
+
+		Request::foundation()->{$param}->replace($input);
 	}
 
 }


### PR DESCRIPTION
Allows you to set which method of data you wish to reset instead of always defaulting to replacing POST.

Also - unrelated, but is merge the best name for this method since it is actually replacing the Input rather than merging?  $_POST is getting completely replaced, $_GET merges by default since it seems the request class auto finds the query string.
