### PR TITLE
Possible Bug Fix: Input::get() does not return $_GET values when left null

### DIFF
--- a/laravel/input.php
+++ b/laravel/input.php
@@ -56,7 +56,12 @@ class Input {
 	public static function get($key = null, $default = null)
 	{
 		$value = array_get(Request::foundation()->request->all(), $key);
-
+		
+		if (is_null($key))
+		{
+			$value = array_merge(static::query(), $value);
+		}
+		
 		if (is_null($value))
 		{
 			return array_get(static::query(), $key, $default);


### PR DESCRIPTION
Not sure if this is intended functionality or not, but Input::get() does not return $_GET values when a key is left null.  This is a fix to merge $_GET with $_POST if no key is passed since get() is supposed to be used for both $_POST and $_GET.  $value was an empty array in this scenario so the foundation()->request logic never fires.
