### PR TITLE
Adding having() support to the Fluent query builder.

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -71,6 +71,13 @@ class Query {
 	public $groupings;
 
 	/**
+	 * The HAVING clauses.
+	 *
+	 * @var array
+	 */
+	public $havings;
+
+	/**
 	 * The ORDER BY clauses.
 	 *
 	 * @var array
@@ -472,6 +479,22 @@ class Query {
 	public function group_by($column)
 	{
 		$this->groupings[] = $column;
+		return $this;
+	}
+
+	/**
+	 * Add a having to the query.
+	 *
+	 * @param  string  $column
+	 * @param  string  $operator
+	 * @param  mixed   $value
+	 */
+	public function having($column, $operator, $value)
+	{
+		$this->havings[] = compact('column', 'operator', 'value');
+
+		$this->bindings[] = $value;
+
 		return $this;
 	}
 

--- a/laravel/database/query/grammars/grammar.php
+++ b/laravel/database/query/grammars/grammar.php
@@ -19,7 +19,7 @@ class Grammar extends \Laravel\Database\Grammar {
 	 */
 	protected $components = array(
 		'aggregate', 'selects', 'from', 'joins', 'wheres',
-		'groupings', 'orderings', 'limit', 'offset',
+		'groupings', 'havings', 'orderings', 'limit', 'offset',
 	);
 
 	/**
@@ -284,6 +284,24 @@ class Grammar extends \Laravel\Database\Grammar {
 	protected function groupings(Query $query)
 	{
 		return 'GROUP BY '.$this->columnize($query->groupings);
+	}
+
+	/**
+	 * Compile the HAVING clause for a query.
+	 *
+	 * @param  Query  $query
+	 * @return string
+	 */
+	protected function havings(Query $query)
+	{
+		if (is_null($query->havings)) return '';
+
+		foreach ($query->havings as $having)
+		{
+			$sql[] = 'AND '.$this->wrap($having['column']).' '.$having['operator'].' '.$this->parameter($having['value']);
+		}
+
+		return 'HAVING '.preg_replace('/AND /', '', implode(' ', $sql), 1);
 	}
 
 	/**


### PR DESCRIPTION
Currently, the query builder doesn't support the HAVING sql clause. Now it does :)

I have looked over all the drivers that Laravel supports as well, just to make sure this method wasn't intentionally left out for some reason.

```
// Do a GROUP BY and HAVING i
DB::table('foo')->group_by('gender')->having('gender', '=', 'male')->get();
```
