### PR TITLE
Honor $timestamp variable with Pivot tables

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -25,7 +25,7 @@ class Has_Many_And_Belongs_To extends Relationship {
 	 *
 	 * @var array
 	 */
-	protected $with = array('id', 'created_at', 'updated_at');
+	protected $with = array('id');
 
 	/**
 	 * Create a new many to many relationship instance.
@@ -42,6 +42,10 @@ class Has_Many_And_Belongs_To extends Relationship {
 		$this->other = $other;
 
 		$this->joining = $table ?: $this->joining($model, $associated);
+
+		if (Pivot::$timestamps === true) {
+			$this->with = array_merge($this->with, array('created_at', 'updated_at'));
+		}
 
 		parent::__construct($model, $associated, $foreign);
 	}


### PR DESCRIPTION
It seems that currently the Pivot::$timestamps variable doesn't
actually honor the created_at and updated_at database requirements.
