### PR TITLE
Added a method to merge Laravel\Messages

### DIFF
--- a/laravel/messages.php
+++ b/laravel/messages.php
@@ -162,5 +162,22 @@ class Messages {
 
 		return $messages;
 	}
+	
+	/**
+	* Merge another messages object into current one
+	* The current object's messages have precedence, i.e, 
+	* if same key exists in both messages, the current object's key will be used
+	*/
+	public function merge(Messages $container)
+	{
+		if(! ($container instanceof Messages) )
+		{
+			return $this;
+		}
+
+		$this->messages += $container->messages;
+
+		return $this;
+	}
 
 }


### PR DESCRIPTION
Helps in certain scenarios where you need to populate more than one tables from a single form and are using validation at model level .. eg:
$errors = new Laravel\Messages;
if($val1->fails())
  $errors->merge($val1->errors);
if($val2->fails() and $val3->fails())
  $errors->merge($val2->errors)->merge($va3->errors)
