### PR TITLE
Automatically wrap numeric routes in parentheses

### DIFF
--- a/laravel/routing/router.php
+++ b/laravel/routing/router.php
@@ -174,6 +174,7 @@ class Router {
 	 */
 	public static function register($method, $route, $action)
 	{
+		if (ctype_digit($route)) $route = "({$route})";
 		if (is_string($route)) $route = explode(', ', $route);
 
 		// If the developer is registering multiple request methods to handle


### PR DESCRIPTION
Allows for routes to be defined as

```
Route::get('123', function()
{
    return 'Hello';
});
```
