### PR TITLE
Made SQLITE "order_by" consistent with MySQL and SQLServer (case-sensitivity)

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -76,6 +76,9 @@ class Connection {
 			case 'mysql':
 				return $this->grammar = new Query\Grammars\MySQL($this);
 
+			case 'sqlite':
+				return $this->grammar = new Query\Grammars\SQLite($this);
+
 			case 'sqlsrv':
 				return $this->grammar = new Query\Grammars\SQLServer($this);
 

--- a/laravel/database/query/grammars/sqlite.php
+++ b/laravel/database/query/grammars/sqlite.php
@@ -1,0 +1,24 @@
+<?php namespace Laravel\Database\Query\Grammars;
+
+use Laravel\Database\Query;
+
+class SQLite extends Grammar
+{
+
+	/**
+	 * Compile the ORDER BY clause for a query.
+	 *
+	 * @param  Query   $query
+	 * @return string
+	 */
+	protected function orderings(Query $query)
+	{
+		foreach ($query->orderings as $ordering)
+		{
+			$sql[] = $this->wrap($ordering['column']).' COLLATE NOCASE '.strtoupper($ordering['direction']);
+		}
+
+		return 'ORDER BY '.implode(', ', $sql);
+	}
+
+}


### PR DESCRIPTION
Potential fix for issue #592

added sqlite query grammar class
updated connection class to use sqlite query grammar class
