### PR TITLE
PHPDoc edits and removed $uri from Route::parameters().

### DIFF
--- a/laravel/routing/route.php
+++ b/laravel/routing/route.php
@@ -45,6 +45,20 @@ class Route {
 	public $parameters;
 
 	/**
+	 * The route's controller.
+	 *
+	 * @var string
+	 */
+	public $controller;
+
+	/**
+	 * The directory of the route's controller.
+	 *
+	 * @var string
+	 */
+	public $directory;
+
+	/**
 	 * Create a new Route instance.
 	 *
 	 * @param  string   $method
@@ -67,6 +81,25 @@ class Route {
 		// compared to the parameters that were needed. If more parameters
 		// are needed, we'll merge in defaults.
 		$this->parameters($action, $parameters);
+
+		// Here we will detect the route's directory and the controller. If the
+		// directory does not exist then only the controller will be set. This
+		// uses the "uses" attribute of $action such as admin.home@(:1).
+		$uses = array_get($action, 'uses');
+		if ($uses !== null)
+		{
+			$uses = explode('@', $uses);
+			$uses = explode('.', $uses);
+			if (count($uses) > 1)
+			{
+				$this->controller = array_pop($uses);
+				$this->directory = implode('.', $uses);
+			}
+			else
+			{
+				$this->controller = $uses[0];
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Cleaned up the PHPDoc for route.php and also removed the $uri argument from `Route::parameters()` as the variable is unused within the method.
