### PR TITLE
Add trim() to Connection::query()

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -175,6 +175,8 @@ class Connection {
 	 */
 	public function query($sql, $bindings = array())
 	{
+		$sql = trim($sql);
+
 		list($statement, $result) = $this->execute($sql, $bindings);
 
 		// The result we return depends on the type of query executed against the


### PR DESCRIPTION
For those of us who format their SQL in various ways, such as the following basic example, we need to have `trim()` applied to `$sql` in `Connection::query()`. Without this the `stripos` calls fail to find the select, insert, etc.

```
DB::query('
    SELECT *
      FROM table
');
```
