### PR TITLE
Fix View's use of Events so you can actually implement your own things

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -42,7 +42,7 @@ class Blade {
 			// return false so the View can be rendered as normal.
 			if ( ! str_contains($view->path, BLADE_EXT))
 			{
-				return false;
+				return;
 			}
 
 			$compiled = path('storage').'views/'.md5($view->path);

--- a/laravel/event.php
+++ b/laravel/event.php
@@ -151,7 +151,7 @@ class Event {
 			}
 		}
 
-		return $responses;
+		return $halt ? null : $responses;
 	}
 
 }

--- a/laravel/view.php
+++ b/laravel/view.php
@@ -125,7 +125,7 @@ class View implements ArrayAccess {
 		// We delegate the determination of view paths to the view loader event
 		// so that the developer is free to override and manage the loading
 		// of views in any way they see fit for their application.
-		$path = Event::first(static::loader, array($bundle, $view));
+		$path = Event::until(static::loader, array($bundle, $view));
 
 		if ( ! is_null($path))
 		{
@@ -322,9 +322,9 @@ class View implements ArrayAccess {
 		// allows easy attachment of other view parsers.
 		if (Event::listeners(static::engine))
 		{
-			$result = Event::first(static::engine, array($this));
+			$result = Event::until(static::engine, array($this));
 
-			if ($result !== false) return $result;
+			if ( ! is_null($result)) return $result;
 		}
 
 		return $this->get();


### PR DESCRIPTION
I've just tried to make use of the View events and ran into a few problems; here's how/why I fixed it:
1. Using `Event::first` returns the response of the first event, often `null`.  So instead use `Event::until` to get the first non-null response.
2. If none of the events return a value then `Event::until` returns `$responses` (an empty array) - `null` makes more sense.
3. Get Blade to return `null` instead of `false` if it can't handle the file, since Event watches for `null`, and `null` is what you get with no return too.  And updated View to check for `null` too.

**Note:** Tested on master and rebased for develop; **untested** on develop.
