### PR TITLE
moose are uncountable

### DIFF
--- a/application/config/strings.php
+++ b/application/config/strings.php
@@ -95,6 +95,7 @@ return array(
 		'series',
 		'sheep',
 		'species',
+		'moose',
 	),
 
 	/*


### PR DESCRIPTION
Added "moose" to the list of uncountable words. See discussion at http://forrst.com/posts/Testing_Plural_or_Singular-U6F
