### PR TITLE
Allow Blade extensions to actually extend Blade

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -8,6 +8,7 @@ class Blade {
 	 * @var array
 	 */
 	protected static $compilers = array(
+		'extensions',
 		'layouts',
 		'comments',
 		'echos',
@@ -26,7 +27,6 @@ class Blade {
 		'yield_sections',
 		'section_start',
 		'section_end',
-		'extensions',
 	);
 
 	/**


### PR DESCRIPTION
Currently a developer cannot modify how a part of Blade works using an extension. For example, if I wanted to create an extension that always replaced {{bob}} to <?php echo Some::random()->thing(); ?>, it wouldn't be possible as {{bob}} would always be replaced to <?php echo bob; ?>

For a real example on how this could be helpful look at: http://forums.laravel.com/viewtopic.php?pid=7648#p7648
