### PR TITLE
Multiple handles for bundles

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -191,35 +191,18 @@ class Bundle {
 
 		foreach (static::$bundles as $key => $value)
 		{
-		
-			if (isset($value['handles']) )
-			{
-				// Do we have multiple handles in an array?
-				if (is_array($value['handles']) )
+			if (isset($value['handles']))
+			{ 
+				// Let's see if one of them matches the uri
+				foreach ((array) $value['handles'] as $handles)
 				{
-					// Let's see if one of them matches the uri
-					foreach($value['handles'] as $handles)
+					if (starts_with($uri, $handles.'/'))
 					{
-					
-						if(starts_with($uri, $handles.'/'))
-						{
-							// replace the array with a string with the matching handles and return the key
-							static::$bundles[$key]['handles'] = $handles;
-							return $key;
-						}
-					}
-				
-				}
-				// Original code for single handles
-				else
-				{
-					if(starts_with($uri, $value['handles'].'/'))
-					{
+						// replace the array with a string with the matching handles and return the key
+						static::$bundles[$key]['handles'] = $handles;
 						return $key;
 					}
-					
 				}
-				
 			}
 		}
 


### PR DESCRIPTION
Hi Taylor,

I made a change to the bundle class, which allows one to set multiple handles for a bundle. It's a simple change, that won't add a lot of extra overhead, but makes the routing of bundles a bit more flexible.

A practical example would be when you have two separate blogs on your website (for example in different languages). They would both use the same blog bundle, but serve up different content based on the URI. With this addition you don't have to include a reference to 'blog' anymore like /blog/myfirstblog and /blog/mysecondblog. Instead you can simply configure multiple handles and use /myfirstblog and /mysecondblog directly. Looks a bit cleaner, I think.

Hope you like it :)
