### PR TITLE
where_nested breaks on empty closures

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -414,7 +414,10 @@ class Query {
 		// Once the callback has been run on the query, we will store the nested
 		// query instance on the where clause array so that it's passed to the
 		// query's query grammar instance when building.
-		$this->wheres[] = compact('type', 'query', 'connector');
+		if ($query->wheres !== null)
+		{
+			$this->wheres[] = compact('type', 'query', 'connector');
+		}
 
 		$this->bindings = array_merge($this->bindings, $query->bindings);
 


### PR DESCRIPTION
I ran into an issue today where I needed to set conditions on my model's relationship ONLY if the search form I was using had a checkbox ticked.

The example code:

```
$results = MCache::with(array('spellings' => function($query) {
    if (Input::get('flagged'))
    {
        $query->where('flagged', '=', '1')
    }
}))->paginate(50);
```

This code above would break as if the condition isn't met that creates an empty `AND ()` statement in the query which breaks the query.

My fix will check to make sure `$query->wheres !== null` before adding to `$this->wheres`. This allows my above example to work as expected and I think should be default behavior in the query builder.
