### PR TITLE
Add support for non-string parameters in controller routes

### DIFF
--- a/laravel/routing/controller.php
+++ b/laravel/routing/controller.php
@@ -179,6 +179,8 @@ abstract class Controller {
 		// controllers with much less code than would be usual.
 		foreach ($parameters as $key => $value)
 		{
+			if ( ! is_string($value)) continue;
+
 			$search = '(:'.($key + 1).')';
 
 			$destination = str_replace($search, $value, $destination, $count);


### PR DESCRIPTION
I perform HMVC calls in my application like so:

```
$route = new Route('GET', 
    'customers/'.$customer->id.'/comments', 
    array('uses' => 'controller@method'), 
    array($customer_object));
```

But currently using an object causes issues when laravel tries to do a str_replace() on them. This patch excludes non-string parameters from being subjected to back-reference replacements.

Btw, it would be super nice to have helper method to facilitate calls like the above. :)

Signed-off-by: Kelly Banman kelly.banman@gmail.com
