### PR TITLE
Allow to add database specific fieldtype within Schema using Closure.

### DIFF
--- a/laravel/database/schema/grammars/grammar.php
+++ b/laravel/database/schema/grammars/grammar.php
@@ -1,5 +1,6 @@
 <?php namespace Laravel\Database\Schema\Grammars;
 
+use \Closure;
 use Laravel\Fluent;
 use Laravel\Database\Schema\Table;
 

--- a/laravel/database/schema/table.php
+++ b/laravel/database/schema/table.php
@@ -1,5 +1,6 @@
 <?php namespace Laravel\Database\Schema;
 
+use \Closure;
 use Laravel\Fluent;
 
 class Table {


### PR DESCRIPTION
This allow developer that need database specific configuration to do so, without the need to do Schema, ALTER TABLE using Raw Query and so on.

For example:

```
Schema::create('users', function($table)
{
    $table->increments('id');
    $table->string('username', 50);
    $table->generic('gender', function ($column) {
        return "ENUM('m','f')";
    });
});
```

Initial discussion at #668
