### PR TITLE
Paginator: Added an easy way to get *only* URL's to previous and next page, without formatting.

### DIFF
--- a/laravel/paginator.php
+++ b/laravel/paginator.php
@@ -125,7 +125,7 @@ class Paginator {
 	 * @param  int 		$page_number
 	 * @return string
 	 */
-	private function url($page_number)
+	public function url($page_number)
 	{
 		if ((int) $page_number > $this->last)
 		{


### PR DESCRIPTION
I am working on a blog bundle for Laravel that uses the Paginator. I noticed that the automatic generation of "Next" and "Previous" links is pre formatted and there seems to be no way to add or delete a class (or maybe I am missing out on something ?). This commit allows to retrieve _only_ the URL, without any HTML, to the next or previous pagination page. This way, you can than do something like this:

```
<div id="pagination" class="btn-group">
        <a class="btn" href="<?= $blog_posts->url_to_previous ?>">&laquo; Previous</a>
        <a class="btn" href="<?= $blog_posts->url(1) ?>">1</a>
        <a class="btn">...</a>
        <a class="btn" href="<?= $blog_posts->url($blog_posts->last) ?>"><?= $blog_posts->last ?></a>
        <a class="btn" href="<?= $blog_posts->url_to_next ?>">Next &raquo;</a>
</div>
```

This code would do something like that with the Twitter CSS Bootstrap:
[Pagination demo image](http://s13.postimage.org/paj4cctn9/Screenshot_from_2012_05_17_00_07_28.png)
