### PR TITLE
Method for HTML special characters

### DIFF
--- a/laravel/html.php
+++ b/laravel/html.php
@@ -46,6 +46,19 @@ class HTML {
 	}
 
 	/**
+	 * Convert HTML special characters.
+	 *
+	 * The encoding specified in the application configuration file will be used.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	public static function specialchars($value)
+	{
+		return htmlspecialchars($value, ENT_QUOTES, Config::get('application.encoding'), false);
+	}
+
+	/**
 	 * Generate a link to a JavaScript file.
 	 *
 	 * <code>


### PR DESCRIPTION
I've noticed that while working on other languages, the HTML::entities() method converts some language specific characters like á, and ó into html entities. Let's say i want to send email. That would not be ideal, since the person receiving the email would see something cryptic instead of a nice word.

Perhaps is a HTML::specialchars() method also of use?

What do you think?
