### PR TITLE
Profiler JS causing panels to hide upon opening.

### DIFF
--- a/laravel/profiling/profiler.js
+++ b/laravel/profiling/profiler.js
@@ -98,12 +98,13 @@ var anbu = {
 	close_window : function()
 	{
 		anbu.el.tab_pane.fadeOut(100);
-		anbu.el.window.slideUp(300);
-		anbu.el.close.fadeOut(300);
-		anbu.el.zoom.fadeOut(300);
-		anbu.el.tab_links.removeClass(anbu.active_tab);
-		anbu.active_pane = '';
-		anbu.window_open = false;
+		anbu.el.window.slideUp(300, function(){
+			anbu.el.close.fadeOut(300);
+			anbu.el.zoom.fadeOut(300);
+			anbu.el.tab_links.removeClass(anbu.active_tab);
+			anbu.active_pane = '';
+			anbu.window_open = false;
+		});
 	},
 
 


### PR DESCRIPTION
Two fixes with this:
1. Panel will no longer instantly close when it opens.
2. Panel will no longer re-open when closed.
