### PR TITLE
Fix capitalization regression in Request::server()

### DIFF
--- a/laravel/request.php
+++ b/laravel/request.php
@@ -81,7 +81,7 @@ class Request {
 	 */
 	public static function server($key = null, $default = null)
 	{
-		return array_get(static::foundation()->server->all(), $key, $default);
+		return array_get(static::foundation()->server->all(), strtoupper($key), $default);
 	}
 
 	/**


### PR DESCRIPTION
In versions previous to the inclusion of the symfony HttpFoundation library, keys passed to Request::server() were auto-capitalized. 

This patch restores that functionality. 
(The regression invalidated the documentation also)

Signed-off-by: Kelly Banman kelly.banman@gmail.com
