### PR TITLE
CLI env management

### DIFF
--- a/laravel/core.php
+++ b/laravel/core.php
@@ -148,15 +148,19 @@ Request::$foundation = RequestFoundation::createFromGlobals();
 |--------------------------------------------------------------------------
 |
 | Next we're ready to determine the application environment. This may be
-| set either via the command line options, or, if the request is from
-| the web, via the mapping of URIs to environments that lives in
-| the "paths.php" file for the application and is parsed.
+| set either via the command line options or via the mapping of URIs to
+| environments that lives in the "paths.php" file for the application and
+| is parsed. When determining the CLI environment, the "--env" CLI option
+| overrides the mapping in "paths.php".
 |
 */
-
 if (Request::cli())
 {
 	$environment = get_cli_option('env');
+
+	if (! isset($environment)) {
+		$environment = Request::detect_env($environments, gethostname());
+	}
 }
 else
 {


### PR DESCRIPTION
I love the env management in 3.2 so much that I decided to extend it to the CLI.

With this change, you can do something like

```
$environments = array(
    'local' => array('http://localhost*', '*.dev', 'mydevmachine'),
);
```

So that `php artisan migrate` will run against my 'local' env by default on my dev machine.

Of course, the `--env` option overrides this so that `php artisan migrate --env=production` will work as expected.
