### PR TITLE
Adding support for values in nested lists generated in the HTML class.

### DIFF
--- a/laravel/html.php
+++ b/laravel/html.php
@@ -315,7 +315,14 @@ class HTML {
 			// lists may exist within nested lists, etc.
 			if (is_array($value))
 			{
-				$html .= static::listing($type, $value);
+				if (is_int($key))
+				{
+					$html .= static::listing($type, $value);
+				}
+				else
+				{
+					$html .= '<li>'.$key.static::listing($type, $value).'</li>';
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Hi fellas,
## Current Situation

Currently, the usage of `HTML::ul` and `HTML::ol` methods is like so:

``` php
<?php
$list = array(
    'first',
    'second',
    'third',
    'fourth',
);

echo HTML::ol($list);
```

I like that. It's nice and simple. It produces:

``` html
<ol>
    <li>first</li>
    <li>second</li>
    <li>third</li>
</ol>
```

---

Nesting lists is done like so:

``` php
<?php
$list = array(
    'first',
    'second',
    'third',
    array(
        'lorem',
        'ipsum',
    ),
);

echo HTML::ol($list);
```

Which produces:

``` html
<ol>
    <li>first</li>
    <li>second</li>
    <li>third</li>
    <ol>
        <li>lorem</li>
        <li>ipsum</li>
    </ol>
</ol>
```
## Proposal

This pull request enables the `HTML::listing` (the method that produces `HTML::ul` and `HTML::ol`) to display values for corresponding nested lists **in addition** to the already supported usage above. It doesn't touch the Laravel API and doesn't break backwards compatibility.

You might recognise this sort of stuff from typical navigation / dropdown menus:

``` php
<?php
$list = array(
    'first',
    'second',
    'third',
    'fourth' => array(
        'lorem',
        'ipsum',
    ),
);

echo HTML::ol($list);
```

The only difference between this and the examples before is that we now have a key for the `fourth` item. This produces the following hypertext markup:

``` html
<ol>
    <li>first</li>
    <li>second</li>
    <li>third</li>
    <li>
        fourth
        <ol>
            <li>lorem</li>
            <li>ipsum</li>
        </ol>
    </li>
</ol>
```

> Note: the list is only produced in this format if there is a key provided for the nested list array.

Thoughts on this?

Signed-off-by: Ben Corlett bencorlett@me.com
