### PR TITLE
Ignore empty validation rules

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -174,6 +174,10 @@ class Validator {
 	protected function check($attribute, $rule)
 	{
 		list($rule, $parameters) = $this->parse($rule);
+		
+		//return if the rule is empty
+		if (!$rule)
+			return;
 
 		$value = array_get($this->attributes, $attribute);
 


### PR DESCRIPTION
I accidentally created a validation rule, like so: 'required|', and got an error (see below) from Laravel because there is no second rule after the pipe character. This patch makes Laravel ignore empty rules, since there is no harm in doing so.

---

Unhandled Exception

Message:

Method [] does not exist.
Location:

/laravel/validator.php on line 1066
Stack Trace:
#0 /laravel/validator.php(186): Laravel\Validator->__call('validate_', Array)
#1 /laravel/validator.php(186): Laravel\Validator->validate_('password_confir...', 'asd', Array, Object(Laravel\Validator))
#2 /laravel/validator.php(161): Laravel\Validator->check('password_confir...', '')
#3 /laravel/validator.php(147): Laravel\Validator->valid()
#4 /laravel/validator.php(137): Laravel\Validator->invalid()
#5 /application/controllers/user.php(41): Laravel\Validator->fails()
#6 [internal function]: User_Controller->post_create()
#7 /laravel/routing/controller.php(323): call_user_func_array(Array, Array)
#8 /laravel/routing/controller.php(283): Laravel\Routing\Controller->response('create', Array)
#9 /laravel/routing/controller.php(165): Laravel\Routing\Controller->execute('create', Array)
#10 /laravel/routing/route.php(153): Laravel\Routing\Controller::call('user@(:1)', Array)
#11 /laravel/routing/route.php(124): Laravel\Routing\Route->response()
#12 /laravel/laravel.php(125): Laravel\Routing\Route->call()
#13 /public/index.php(34): require('/larave...')
#14 {main}
