### PR TITLE
Allow overloading of core tasks.

### DIFF
--- a/laravel/cli/dependencies.php
+++ b/laravel/cli/dependencies.php
@@ -6,36 +6,46 @@
  * of the migration resolver and database classes, which are used
  * to perform various support functions for the migrator.
  */
-IoC::register('task: migrate', function()
+if(! IoC::registered('task: migrate'))
 {
-	$database = new Tasks\Migrate\Database;
+	IoC::register('task: migrate', function()
+	{
+		$database = new Tasks\Migrate\Database;
 
-	$resolver = new Tasks\Migrate\Resolver($database);
+		$resolver = new Tasks\Migrate\Resolver($database);
 
-	return new Tasks\Migrate\Migrator($resolver, $database);
-});
+		return new Tasks\Migrate\Migrator($resolver, $database);
+	});	
+}
+
 
 /**
  * The bundle task is responsible for the installation of bundles
  * and their dependencies. It utilizes the bundles API to get the
  * meta-data for the available bundles.
  */
-IoC::register('task: bundle', function()
+if(! IoC::registered('task: bundle'))
 {
-	$repository = IoC::resolve('bundle.repository');
+	IoC::register('task: bundle', function()
+	{
+		$repository = IoC::resolve('bundle.repository');
 
-	return new Tasks\Bundle\Bundler($repository);
-});
+		return new Tasks\Bundle\Bundler($repository);
+	});
+}
 
 /**
  * The key task is responsible for generating a secure, random
  * key for use by the application when encrypting strings or
  * setting the hash values on cookie signatures.
  */
-IoC::singleton('task: key', function()
+if(! IoC::registered('task: key'))
 {
-	return new Tasks\Key;
-});
+	IoC::singleton('task: key', function()
+	{
+		return new Tasks\Key;
+	});
+}
 
 /**
  * The session task is responsible for performing tasks related
@@ -43,50 +53,65 @@ IoC::singleton('task: key', function()
  * such as generating the session table or clearing expired
  * sessions from storage.
  */
-IoC::singleton('task: session', function()
+if(! IoC::registered('task: session'))
 {
-	return new Tasks\Session\Manager;
-});
+	IoC::singleton('task: session', function()
+	{
+		return new Tasks\Session\Manager;
+	});
+}
 
 /**
  * The route task is responsible for calling routes within the
  * application and dumping the result. This allows for simple
  * testing of APIs and JSON based applications.
  */
-IoC::singleton('task: route', function()
+if(! IoC::registered('task: route'))
 {
-	return new Tasks\Route;
-});
+	IoC::singleton('task: route', function()
+	{
+		return new Tasks\Route;
+	});
+}
 
 /**
  * The "test" task is responsible for running the unit tests for
  * the application, bundles, and the core framework itself.
  * It provides a nice wrapper around PHPUnit.
  */
-IoC::singleton('task: test', function()
+if(! IoC::registered('task: test'))
 {
-	return new Tasks\Test\Runner;
-});
+	IoC::singleton('task: test', function()
+	{
+		return new Tasks\Test\Runner;
+	});
+}
 
 /**
  * The bundle repository is responsible for communicating with
  * the Laravel bundle sources to get information regarding any
  * bundles that are requested for installation.
  */
-IoC::singleton('bundle.repository', function()
+if(! IoC::registered('bundle.repository'))
 {
-	return new Tasks\Bundle\Repository;
-});
+	IoC::singleton('bundle.repository', function()
+	{
+		return new Tasks\Bundle\Repository;
+	});
+}
 
 /**
  * The bundle publisher is responsible for publishing bundle
  * assets to their correct directories within the install,
  * such as the web accessible directory.
  */
-IoC::singleton('bundle.publisher', function()
+if(! IoC::registered('bundle.publisher'))
 {
-	return new Tasks\Bundle\Publisher;
-});
+	IoC::singleton('bundle.publisher', function()
+	{
+		return new Tasks\Bundle\Publisher;
+	});
+}
 
 /**
  * The Github bundle provider installs bundles that live on
@@ -94,7 +119,10 @@ IoC::singleton('bundle.publisher', function()
  * and will update the submodule so that the bundle is
  * installed into the bundle directory.
  */
-IoC::singleton('bundle.provider: github', function()
+if(! IoC::registered('bundle.provider: github'))
 {
-	return new Tasks\Bundle\Providers\Github;
-});
+	IoC::singleton('bundle.provider: github', function()
+	{
+		return new Tasks\Bundle\Providers\Github;
+	});
+}


### PR DESCRIPTION
Fix for #682

CLI dependencies now check to see if they are already registered, tested by overloading the IoC::registers in start.php, result :

```
$ php artisan migrate:make
MADE
```

Seems fine!

Dayle.
