### PR TITLE
Fix for @forelse only matching $vars.

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -213,12 +213,12 @@ class Blade {
 
 		foreach ($matches[0] as $forelse)
 		{
-			preg_match('/\$[^\s]*/', $forelse, $variable);
+			preg_match('/\s*\(\s*(\S*)\s/', $forelse, $variable);
 
 			// Once we have extracted the variable being looped against, we can add
 			// an if statement to the start of the loop that checks if the count
 			// of the variable being looped against is greater than zero.
-			$if = "<?php if (count({$variable[0]}) > 0): ?>";
+			$if = "<?php if (count({$variable[1]}) > 0): ?>";
 
 			$search = '/(\s*)@forelse(\s*\(.*\))/';
 


### PR DESCRIPTION
Fix for #691

@forelse can now match all kinds of values, tested with :

$arr
getarr()
Arr::get()

and many whitespace combos.

Dayle.
