### PR TITLE
Changed a line which causes "illegal string offset" error to be thrown i...

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -249,7 +249,7 @@ class Validator {
 		{
 			return false;
 		}
-		elseif ( ! is_null(Input::file($attribute)) and $value['tmp_name'] == '')
+		elseif ( ! is_null(Input::file($attribute)) and is_array($value) and $value['tmp_name'] == '')
 		{
 			return false;
 		}


### PR DESCRIPTION
...n php5.4 on trying to access $value['tmp_name']
