### PR TITLE
Fix in sqlserver grammar primary key function

### DIFF
--- a/laravel/database/schema/grammars/sqlserver.php
+++ b/laravel/database/schema/grammars/sqlserver.php
@@ -138,7 +138,7 @@ class SQLServer extends Grammar {
 	{
 		$name = $command->name;
 
-		$columns = $this->columnize($columns);
+		$columns = $this->columnize($command->$columns);
 
 		return 'ALTER TABLE '.$this->wrap($table)." ADD CONSTRAINT {$name} PRIMARY KEY ({$columns})";
 	}


### PR DESCRIPTION
Fixes issue #727, changed $columns (an undefined variable) to $command->columns
