### PR TITLE
Add a last_query() function to Database connection class.

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -322,5 +322,17 @@ class Connection {
 	{
 		return $this->table($method);
 	}
+	
+	/**
+	 * Get the last query that was executed.
+	 * 
+	 * Returns false if no queries have been executed yet.
+	 *
+	 * @return string
+	 */
+	public static function last_query()
+	{
+		return end(static::$queries);
+	}
 
 }


### PR DESCRIPTION
This simple helper function was proposed on IRC.

It allows you to get the last query that was executed.
