### PR TITLE
Fix where $selected=0 and $value is a string

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -446,7 +446,7 @@ class Form {
 		}
 		else
 		{
-			$selected = ($value === $selected) ? 'selected' : null;
+			$selected = ((string)$value == (string)$selected) ? 'selected' : null;
 		}
 
 		$attributes = array('value' => HTML::entities($value), 'selected' => $selected);


### PR DESCRIPTION
This code:

```
echo Form::select('field, array( 0 => 'Empty', 'work' => 'Work', 'home'=>'Home' ), 0 );
```

will end up generating this HTML:

```
<select name="field">
<option value="0" selected="selected">Empty</option>
<option value="work" selected="selected">Work</option>
<option value="home" selected="selected">Home</option>
</select>
```

i.e. every option is selected, because `'string' == 0`.  Switching the check from `==` to `===` fixes this.

Signed-off-by: Colin Viebrock colin@viebrock.ca
