### PR TITLE
Adding third parameter (filename) to upload method.

### DIFF
--- a/laravel/documentation/files.md
+++ b/laravel/documentation/files.md
@@ -34,7 +34,7 @@
 
 #### Moving a $_FILE to a permanent location:
 
-	Input::upload('picture', 'path/to/pictures');
+	Input::upload('picture', 'path/to/pictures', 'filename.ext');
 
 > **Note:** You can easily validate file uploads using the [Validator class](/docs/validation).
 


### PR DESCRIPTION
Docs currently show two parameters, which is incorrect.

Should be:

Input::upload('picture', 'path/to/pictures/', 'filename.ext');
