### PR TITLE
Render Response objects when casting as string

### DIFF
--- a/laravel/response.php
+++ b/laravel/response.php
@@ -334,4 +334,14 @@ class Response {
 		}
 	}
 
+	/**
+	 * Render the response when cast to string
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->render();
+	}
+
 }


### PR DESCRIPTION
Allows for expected behaviour when calling casting `Response` objects as strings.

Signed-off-by: Kelly Banman kelly.banman@gmail.com
