### PR TITLE
Fixing bug in IoC::resolve

### DIFF
--- a/laravel/ioc.php
+++ b/laravel/ioc.php
@@ -114,7 +114,7 @@ class IoC {
 		// its nested dependencies recursively until they are each resolved.
 		if ($concrete == $type or $concrete instanceof Closure)
 		{
-			$object = static::build($concrete);
+			$object = static::build($concrete, $parameters);
 		}
 		else
 		{


### PR DESCRIPTION
Parameters passed in IoC::resolve are not passed in static::build()
