### PR TITLE
Allow Blade Echos to Span Several Lines

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -198,7 +198,7 @@ class Blade {
 	 */
 	protected static function compile_echos($value)
 	{
-		return preg_replace('/\{\{(.+?)\}\}/', '<?php echo $1; ?>', $value);
+		return preg_replace('/\{\{((.|\s)+?)\}\}/', '<?php echo $1; ?>', $value);
 	}
 
 	/**


### PR DESCRIPTION
Currently Blade cannot parse something like:

```
{{Form::select('month', array(
    '01' => 'January',
    '02' => 'February',
    '03' => 'March',
    '04' => 'April',
    '05' => 'May',
    '06' => 'June',
    '07' => 'July',
    '08' => 'August',
    '09' => 'September',
    '10' => 'October',
    '11' => 'November',
    '12' => 'December',
))}}
```

This should fix it.
