### PR TITLE
Change postgresql boolean column type to BOOLEAN

### DIFF
--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -357,7 +357,7 @@ class Postgres extends Grammar {
 	 */
 	protected function type_boolean(Fluent $column)
 	{
-		return 'SMALLINT';
+		return 'BOOLEAN';
 	}
 
 	/**


### PR DESCRIPTION
Creating a boolean column with `Schema` under postgreSQL results in a `SMALLINT` column type. Unlike MySQL, PostgreSQL has a real boolean type distinct from small integers.

If you don't agree with this change, could you point out how one might use Schema to create proprietary column types such as the above?
