### PR TITLE
Auto loading of bundles in artisan.

### DIFF
--- a/laravel/cli/artisan.php
+++ b/laravel/cli/artisan.php
@@ -11,6 +11,28 @@ use Laravel\Request;
  */
 Bundle::start(DEFAULT_BUNDLE);
 
+/*
+|--------------------------------------------------------------------------
+| Auto-Start Other Bundles
+|--------------------------------------------------------------------------
+|
+| Bundles that are used throughout the application may be auto-started
+| so they are immediately available on every request without needing
+| to explicitly start them within the application.
+|
+*/
+
+foreach (Bundle::$bundles as $bundle => $config)
+{
+	if (
+		! empty($config['auto']) && is_array($config['auto'])
+		&& ! empty($config['auto']['cli']) && $config['auto']['cli']
+	)
+	{
+		Bundle::start($bundle);
+	}
+}
+
 /**
  * The default database connection may be set by specifying a value
  * for the "database" CLI option. This allows migrations to be run

--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -88,7 +88,14 @@ Bundle::start(DEFAULT_BUNDLE);
 
 foreach (Bundle::$bundles as $bundle => $config)
 {
-	if ($config['auto']) Bundle::start($bundle);
+	if (
+		$config['auto'] === true
+		|| (! empty($config['auto']) && is_array($config['auto'])
+		&& ! empty($config['auto']['web']) && $config['auto']['web'])
+	)
+	{
+		Bundle::start($bundle);
+	}
 }
 
 /*


### PR DESCRIPTION
This pull request adds the ability to autoload bundles in artisan while preserving the current functionality. It works as follows...

// In bundles.php
// new functionality for auto
// autoloading of composer bundle in web and cli environments
return [
  'composer' => ['auto' => ['cli' => true, 'web' => true]],
];

// In bundles.php
// current functionality
// autoloading of composer bundle in web environment only
return [
  'composer' => ['auto' => true],
]; 
