### PR TITLE
Avoid unnecessary end() in Table::command() function

### DIFF
--- a/laravel/database/schema/table.php
+++ b/laravel/database/schema/table.php
@@ -407,9 +407,7 @@ class Table {
 	{
 		$parameters = array_merge(compact('type'), $parameters);
 
-		$this->columns[] = new Fluent($parameters);
-
-		return end($this->columns);
+		return $this->columns[] = new Fluent($parameters);
 	}
 
 }


### PR DESCRIPTION
Very small optimization.
