### PR TITLE
Foreign key creation ignores database prefix

### DIFF
--- a/laravel/database/schema/grammars/grammar.php
+++ b/laravel/database/schema/grammars/grammar.php
@@ -21,7 +21,7 @@ abstract class Grammar extends \Laravel\Database\Grammar {
 		// command is being executed and the referenced table are wrapped.
 		$table = $this->wrap($table);
 
-		$on = $this->wrap($command->on);
+		$on = $this->wrap_table($command->on);
 
 		// Next we need to columnize both the command table's columns as well as
 		// the columns referenced by the foreign key. We'll cast the referenced


### PR DESCRIPTION
As mentioned in [this forum post](http://forums.laravel.com/viewtopic.php?pid=9052#p9052), the schema's foreign key helper currently ignores the database prefix configured in the connection object.

Fixed now. :)
