### PR TITLE
Request::ip() doesn't return default 

### DIFF
--- a/laravel/request.php
+++ b/laravel/request.php
@@ -102,7 +102,8 @@ class Request {
 	 */
 	public static function ip($default = '0.0.0.0')
 	{
-		return value(static::foundation()->getClientIp(), $default);
+		$client_ip = static::foundation()->getClientIp();
+		return $client_ip === NULL ? $default : $client_ip;
 	}
 
 	/**


### PR DESCRIPTION
While unit testing I found that providing a default IP address to
Request::ip() returns NULL in a CLI environment.
