### PR TITLE
'AJAXful' routing

### DIFF
--- a/laravel/routing/controller.php
+++ b/laravel/routing/controller.php
@@ -327,7 +327,7 @@ abstract class Controller {
 			$action = "action_{$method}";
 		}
 
-		if ($this->ajaxful && Request::ajax())
+		if ($this->ajaxful and Request::ajax())
 		{
 			$action = "ajax_{$action}";
 		}


### PR DESCRIPTION
I have made this change in just about every project I've built using Laravel, so I thought I would share it. If it's bad or wrong or not useful, that's fine, but I thought I would put it out there.

This "AJAXful" routing works pretty much like the RESTful routing; it prepends "ajax_" to your controller actions when the request is an AJAX one.

Here's a RESTful and AJAXful controller example:

``` php

<?php

class MyController extends Base_Controller {
    public $restful = true;
    public $ajaxful = true;

    public function get_index()
    {
        return View::make('my.nifty_view');
    }

    public function ajax_get_index()
    {
        return json_encode(array('my_nifty_content' => 'Hooray, AJAX'));
    }
}

```

Likewise, for non-RESTful controllers:

``` php

<?php

class MyController extends Base_Controller {
    public $restful = false;
    public $ajaxful = true;

    public function action_index()
    {
        return View::make('my.nifty_view');
    }

    public function ajax_action_index()
    {
        return json_encode(array('my_nifty_content' => 'Hooray, AJAX'));
    }
}

```

Pretty straightforward, but it's been helpful for me.
