### PR TITLE
Added a seed method to :migrate

### DIFF
--- a/application/seeds/seed.php
+++ b/application/seeds/seed.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Seed
+|--------------------------------------------------------------------------
+|
+| Code here will be run when `artisan migrate:seed` is called. Any valid
+| PHP is allowed, however it is recommended you keep this file focused on
+| setting up required data for the application to function.
+|
+| For example,
+| for ($i=0; $i<100; $i++)
+| {
+|     $location = new Location();
+|     $location->name = 'Sample Location '.$i;
+|     $location->save();
+| }
+|
+| $role = new Role();
+| $role->name = 'Publishers';
+| $role->save();
+|
+| $role = new Role();
+| $role->name = 'Editors';
+| $role->save();
+|
+| $role = new Role();
+| $role->name = 'Guests';
+| $role->save();
+|
+| $user = new User();
+| $user->roles()->attach(1)
+| $user->name = 'admin';
+| $user->password = '';
+| $user->save();
+|
+| $user = new User();
+| $user->roles()->attach(2)
+| $user->name = 'john';
+| $user->password = '';
+| $user->save();
+*/

--- a/laravel/cli/tasks/migrate/migrator.php
+++ b/laravel/cli/tasks/migrate/migrator.php
@@ -94,6 +94,35 @@ class Migrator extends Task {
 	}
 
 	/**
+	 * Seed the application with some default data.
+	 *
+	 * @return void
+	 */
+	public function seed($bundle = null)
+	{
+		if (empty($bundle))
+		{
+			$bundles = array_merge(Bundle::names(), array('application'));
+		}
+		else
+		{
+			$bundles = array($bundle);
+		}
+
+		foreach ($bundles as $bundle)
+		{
+			$path = Bundle::path($bundle).'seeds'.DS.'seed.php';
+
+			if (file_exists($path))
+			{
+				require $path;
+			}
+		}
+		
+		echo "Seed data installed successfully.";
+	}
+
+	/**
 	 * Rollback the latest migration command.
 	 *
 	 * @param  array  $arguments


### PR DESCRIPTION
The idea is to standardize how data is inserted into a new project and is intentionally very basic to retain some flexibility.

The idea is that running `php artisan migrate:seed` will find any `seeds/seed.php` files in your application or bundles. It will then blindly run that code. You can prime caches, setup your fixtures, etc…

Additionally, passing a bundle will only run the seed for that bundle, so `php artisan migrate:seed admin` will only seed the `admin` bundle.

This probably isn't ready to be blindly merged in, but I thought I'd submit it in case anyone else was working on something similar.
