### PR TITLE
Exceptions don't currently render out their response, this fixes that.

### DIFF
--- a/laravel/error.php
+++ b/laravel/error.php
@@ -39,9 +39,9 @@ class Error {
 		// Using events gives the developer more freedom.
 		else
 		{
-			$response = Event::first('500');
-
-			return Response::prepare($response)->send();
+			$response = Response::prepare(Event::first('500'));
+			$response->render();
+			return $response->send();
 		}
 
 		exit(1);


### PR DESCRIPTION
If you clone the `develop` branch and add `throw new Exception('Oh no!');` inside the `home@action_index` method you'll get a beautiful stack trace. Perfect.

Now, update `application/config/error.php` and set `detail` to `false` and you'll get a WSOD. The reason seems to be that the default 500 error state never actually calls the response's `render` method. This pull fixes that.

Note: I think only the 500 event requires the `render` method be called. I added it to the 404 event to keep the code in sync. It didn't seem to break anything but someone with more experience with the codebase may recommend removing it from the 404 event.
