### PR TITLE
Fix for #638: Handle empty arrays in where_in() gracefully

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -297,11 +297,14 @@ class Query {
 	 */
 	public function where_in($column, $values, $connector = 'AND', $not = false)
 	{
-		$type = ($not) ? 'where_not_in' : 'where_in';
+		if (!empty($values))
+		{
+			$type = ($not) ? 'where_not_in' : 'where_in';
 
-		$this->wheres[] = compact('type', 'column', 'values', 'connector');
+			$this->wheres[] = compact('type', 'column', 'values', 'connector');
 
-		$this->bindings = array_merge($this->bindings, $values);
+			$this->bindings = array_merge($this->bindings, $values);
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
This allows for empty arrays being passed to Fluent's where_in() not causing an invalid query (#638).

Some people said that it's not the framework's responsibility to do this kind of error-checking, but I'd argue that this allows people to avoid adding boilerplate around queries all the time (also, you lose the benefits of the fluent query interface if you have to do error checking to modify the query).
