### PR TITLE
IoC was unable to resolve the Laravel\Exception.

### DIFF
--- a/laravel/ioc.php
+++ b/laravel/ioc.php
@@ -156,7 +156,7 @@ class IoC {
 		// no binding registered for the abstraction so we need to bail out.
 		if ( ! $reflector->isInstantiable())
 		{
-			throw new Exception("Resolution target [$type] is not instantiable.");
+			throw new \Exception("Resolution target [$type] is not instantiable.");
 		}
 
 		$constructor = $reflector->getConstructor();
@@ -193,7 +193,7 @@ class IoC {
 			// we'll just bomb out with an error since we have nowhere to go.
 			if (is_null($dependency))
 			{
-				throw new Exception("Unresolvable dependency resolving [$parameter].");
+				throw new \Exception("Unresolvable dependency resolving [$parameter].");
 			}
 
 			$dependencies[] = static::resolve($dependency->name);


### PR DESCRIPTION
This allows IoC to resolve the Exception class when no dependencies are found for the resolving class.
