### PR TITLE
Feature: Str::limit_exact    limits a string including its custom ending to a specified length

### DIFF
--- a/laravel/documentation/strings.md
+++ b/laravel/documentation/strings.md
@@ -25,6 +25,7 @@ The **Str** class also provides three convenient methods for manipulating string
 #### Limiting the number of characters in a string:
 
 	echo Str::limit($string, 10);
+	echo Str::limit_exact($string, 10);
 
 #### Limiting the number of words in a string:
 

--- a/laravel/str.php
+++ b/laravel/str.php
@@ -131,6 +131,31 @@ class Str {
 	}
 
 	/**
+	 * Limit the number of chracters in a string including custom ending
+	 * 
+	 * <code>
+	 *		// Returns "Taylor..."
+	 *		echo Str::limit_exact('Taylor Otwell', 9);
+	 *
+	 *		// Limit the number of characters and append a custom ending
+	 *		echo Str::limit_exact('Taylor Otwell', 9, '---');
+	 * </code>
+	 * 
+	 * @param  string  $value
+	 * @param  int     $limit
+	 * @param  string  $end
+	 * @return string
+	 */
+	public static function limit_exact($value, $limit = 100, $end = '...')
+	{
+		if (static::length($value) <= $limit) return $value;
+
+		$limit -= static::length($end);
+
+		return static::limit($value, $limit, $end);
+	}
+
+	/**
 	 * Limit the number of words in a string.
 	 *
 	 * <code>


### PR DESCRIPTION
Slight extension of the current Str::limit method

Where the limit method limits the input's length and then adds the ending, limit_exact limits the length of the input and it's ending to an exact length.  It is the same as using the limit method and reducing the limit by the length of the ending.

This is useful when you want to specify the exact length you want returned (ie 140 for a tweet, etc)
