### PR TITLE
Fixed namespace issue when registering a session driver with the extend ...

### DIFF
--- a/laravel/session.php
+++ b/laravel/session.php
@@ -1,4 +1,4 @@
-<?php namespace Laravel;
+<?php namespace Laravel; use Closure;
 
 class Session {
 


### PR DESCRIPTION
There is a namespace issue when you want to register a custom session driver with the extend method because the session class doesn't use the Closure namespace. 
