### PR TITLE
Session::extend() failing due to missing use statement.

### DIFF
--- a/laravel/session.php
+++ b/laravel/session.php
@@ -1,4 +1,4 @@
-<?php namespace Laravel;
+<?php namespace Laravel; use Closure;
 
 class Session {
 


### PR DESCRIPTION
The `Closure` class was type-hinted on an argument, but not imported via `use`.
