### PR TITLE
Added UNSIGNED to mysql grammar inrementer()

### DIFF
--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -143,7 +143,7 @@ class MySQL extends Grammar {
 	{
 		if ($column->type == 'integer' and $column->increment)
 		{
-			return ' AUTO_INCREMENT PRIMARY KEY';
+			return ' UNSIGNED AUTO_INCREMENT PRIMARY KEY';
 		}
 	}
 


### PR DESCRIPTION
Added UNSIGNED to the mysql grammar file because auto increment fields
only run upwards, it's a waste of space to provide negative values by
the default SIGNED state of INT.
