### PR TITLE
Improving migration template

### DIFF
--- a/laravel/cli/tasks/migrate/stub.php
+++ b/laravel/cli/tasks/migrate/stub.php
@@ -1,6 +1,8 @@
 <?php
 
 class {{class}} {
+	
+	private $table = '';
 
 	/**
 	 * Make changes to the database.
@@ -9,7 +11,16 @@ class {{class}} {
 	 */
 	public function up()
 	{
-		//
+		/*
+		Schema::create($this->table, function($table) {
+			$table->increments('id');
+			$table->timestamps();
+		});
+		
+		DB::table($this->table)->insert(Array(
+			//
+		));
+		*/
 	}
 
 	/**
@@ -19,7 +30,9 @@ class {{class}} {
 	 */
 	public function down()
 	{
-		//
+		/*
+		Schema::drop($this->table);
+		*/
 	}
 
 }


### PR DESCRIPTION
`artisan migrate:make` already creates helper methods with a single comment line. This goes one step further to provide examples of common tasks. I know _I_ certainly hate typing them out every time. :)
