### PR TITLE
add method to ensure file was actually uploaded

### DIFF
--- a/laravel/input.php
+++ b/laravel/input.php
@@ -217,7 +217,10 @@ class Input {
 	public static function file_uploaded($key)
 	{
 		$file = static::file($key);
-		return static::has_file($key) and $file['error'] === 0;
+
+		if (is_null($file)) return false;
+
+		return $file['error'] === 0;	
 	}
 
 	/**


### PR DESCRIPTION
added `file_uploaded` method. Found that when had a form which had an optional image uploader there is no way to check if the a file was actually uploaded. 

i.e

``` php
if (Input::has_file('optional_image_field')) {
    //custom image upload logic
}
```

would always return true even if an image hadn't been uploaded, because it is present in the form (so also in the `$_FILES` array). `file_uploaded` method checks the error code of the file in the `$_FILES` array to make sure the image was actually uploaded (errorcode = 0) - http://www.php.net/manual/en/features.file-upload.errors.php.

``` php
if (Input::file_uploaded('optional_image_field')) {
    //custom image upload logic
}
```

Signed-off-by: Mike Barrett mike182uk@gmail.com
