### PR TITLE
Helpful handling of View errors

### DIFF
--- a/laravel/view.php
+++ b/laravel/view.php
@@ -359,10 +359,10 @@ class View implements ArrayAccess {
 			$view = $this;
 			set_error_handler(function($errno, $errstr, $errfile, $errline, $errcontext) use ($view, $__contents)
 			{
-				if (in_array($errno, Config::get('error.ignore', array())))
+				if (in_array($errno, Config::get('error.ignore', array())) || ! strrpos($errstr, 'eval'))
 				{
-					// Error level is to be ignored
-					return;
+					// Error level is to be ignored or it's not an eval error
+					return false;
 				}
 				$path = str_replace(path('base'), '', $view->path);
 				echo $errstr.' on line '.$errline.' of '.$path.':';


### PR DESCRIPTION
It can be frustrating debugging errors inside Views because they are parsed by eval(), which strips you of valuable debugging information like the file and line number.
This patches laravel/view.php to restore that data and even print out some context to the error:

Since this prints unparsed source code, production apps should include E_RECOVERABLE_ERROR (along with notices and warnings) in the 'ignore' parameter of `application/config/error.php`.

If someone wants to refine this some more to make it more core-worthy, please do!

Signed-off-by: Kelly Banman kelly.banman@gmail.com
