### PR TITLE
[Auth] Eloquent driver does now allow login via object

### DIFF
--- a/laravel/auth/drivers/eloquent.php
+++ b/laravel/auth/drivers/eloquent.php
@@ -14,13 +14,13 @@ class Eloquent extends Driver {
 	{
 		// We return an object here either if the passed token is an integer (ID)
 		// or if we are passed a model object of the correct type
-		if (filter_var($id, FILTER_VALIDATE_INT) !== false)
+		if (filter_var($token, FILTER_VALIDATE_INT) !== false)
 		{
-			return $this->model()->find($id);
+			return $this->model()->find($token);
 		}
-		else if (get_class($id) == Config::get('auth.model'))
+		else if (get_class($token) == Config::get('auth.model'))
 		{
-			return $id;
+			return $token;
 		}
 	}
 


### PR DESCRIPTION
When passing an object to the `login()` method, the Eloquent driver doesn't allow me to login, even though this is supposed to work, trusting the documentation here.

So, code like this wont work:

```
Auth::login(MyUser::find(2));
```

While this, of course, works:

```
Auth::login(2);
```

The problem is this code in the Eloquent driver:

```
public function retrieve($id)
{
    if (filter_var($id, FILTER_VALIDATE_INT) !== false)
    {
        return $this->model()->find($id);
    }
}
```

This obviously doesn't allow for objects, which - in my humble opinion - should be allowed, as it has some benefits, when it comes to validating a user by object first.

---

Well, here's the pull request. I wrote this up as a bug report first but then thought "Meh, just fix it". Here we go.
