### PR TITLE
[View] Pass variables with more expressive methods

### DIFF
--- a/laravel/view.php
+++ b/laravel/view.php
@@ -551,4 +551,20 @@ class View implements ArrayAccess {
 		return $this->render();
 	}
 
+	/**
+	 * Magic Method for handling dynamic functions.
+	 *
+	 * This method handles calls to dynamic with helpers.
+	 */
+	public function __call($method, $parameters)
+	{
+		if (strpos($method, 'with_') === 0)
+		{
+			$key = substr($method, 5);
+			return $this->with($key, $parameters[0]);
+		}
+
+		throw new \Exception("Method [$method] is not defined on the View class.");
+	}
+
 }


### PR DESCRIPTION
So, right now, you would do this:

```
View::make('index')->with('foo', $bar);
```

This pull request allows to use

```
View::make('index')->with_foo($bar);
```

This is obviously inspired by dynamic where clauses, so I'd argue this feels very Laravel-ish.

---

Also, I could have sworn I have seen this (either implemented or suggested) somewhere, but I couldn't find it again - it's hard to search for example code - so please don't hurt me if this is a duplicate.
