### PR TITLE
Artisan test command fix

### DIFF
--- a/laravel/cli/tasks/test/runner.php
+++ b/laravel/cli/tasks/test/runner.php
@@ -82,7 +82,8 @@ class Runner extends Task {
 		$path = path('base').'phpunit.xml';
 		
 		// fix the spaced directories problem when using the command line
-		$path = str_replace(" ", "\\ ", $path);
+		// strings with spaces inside should be wrapped in quotes.
+		$path = escapeshellarg($path)
 
 		passthru('phpunit --configuration '.$path);
 


### PR DESCRIPTION
When using the test command of the Artisan CLI, directories containing spaces weren't escaped with a leading \ before the space.

This pull fixes that problem.

Signed-off-by: Luca Degasperi dega.luca@gmail.com
