### PR TITLE
[Eloquent] Bug with eager loading relationships and isset()

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -725,7 +725,7 @@ abstract class Model {
 	{
 		foreach (array('attributes', 'relationships') as $source)
 		{
-			if (array_key_exists($key, $this->$source)) return true;
+			if (array_key_exists($key, $this->$source)) return !is_null($this->$source[$key]);
 		}
 		
 		if (method_exists($this, $key)) return true;


### PR DESCRIPTION
When eager loading a relationship does not return a result, the element that is added to the model's `$relationship` array (the key being the name of the relationship) is set to `NULL`.

That itself is not a problem, as lazy loading will return `NULL`, too, if the related entity simply does not exist. So, we'd obviously have to make sure the entity is not `NULL` before accessing it. Like this, for example:

```
isset($this->rel) && // ...whatever you wanted to do
```

However, `isset()` currently returns `true` (which it should not for `NULL` values). I fixed that in this pull request.

---

If that seems too hacky, we should instead make sure that a relationship does not get added to the `$relationships` array if eager loading (lazy loading, too, probably) returns an empty result set.
