### PR TITLE
Fixes #818, allows Query select to just be an Expression.

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -140,7 +140,7 @@ class Query {
 	 */
 	public function select($columns = array('*'))
 	{
-		$this->selects = (array) $columns;
+		$this->selects = is_array($columns) ? $columns : array($columns);
 		return $this;
 	}
 


### PR DESCRIPTION
When performing selects on the database if the select is just a raw expression then the typecasting of the object to an array causes the select to run incorrectly.

This is a fix suggested by @Vespakoen in #818.

Signed-off-by: Jason Lewis jason.lewis1991@gmail.com
