### PR TITLE
Allow PHPUnit test stub to be defined in userland

### DIFF
--- a/laravel/cli/tasks/test/runner.php
+++ b/laravel/cli/tasks/test/runner.php
@@ -119,7 +119,7 @@ class Runner extends Task {
 	{
 		$path = path('sys').'cli/tasks/test/';
 
-		$stub = File::get(path('app').'tests/stub.xml');
+		$stub = File::get($directory.'/stub.xml');
 
 		if ($stub === null)
 		{


### PR DESCRIPTION
After some discussion in #891, I decided that I would like to have more control over the PHPUnit configuration. To solve this, I have moved stub.xml into userland. I've also kept the original stub.xml as a fallback in case the user decides to delete their stub.xml, although I realise this creates some code duplication - what do you guys think?

While I was at it, I also wanted to be able to have more control over how my tests run. This is solved by passing `$_SERVER['argv']` through to `phpunit`, which allows you to do something like `php artisan test --verbose`. The only 'gotcha' with this is that Laravel has a funny way of parsing options, so if you want to do something like `php artisan test --configuration my/custom/config.xml` you actually need to do `php artisan test --configuration=my/custom/config.xml` 
