### PR TITLE
Support for MySQL character sets and collation

### DIFF
--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -33,6 +33,16 @@ class MySQL extends Grammar {
 			$sql .= ' ENGINE = '.$table->engine;
 		}
 
+		if ( ! is_null($table->charset))
+		{
+			$sql .= ' DEFAULT CHARACTER SET = '.$table->charset;
+		}
+
+		if ( ! is_null($table->collation))
+		{
+			$sql .= ' COLLATE = '.$table->collation;
+		}
+
 		return $sql;
 	}
 
@@ -77,7 +87,7 @@ class MySQL extends Grammar {
 			// types to the correct types.
 			$sql = $this->wrap($column).' '.$this->type($column);
 
-			$elements = array('unsigned', 'nullable', 'defaults', 'incrementer');
+			$elements = array('unsigned', 'charset', 'collate', 'nullable', 'defaults', 'incrementer');
 
 			foreach ($elements as $element)
 			{
@@ -144,6 +154,42 @@ class MySQL extends Grammar {
 		if ($column->type == 'integer' and $column->increment)
 		{
 			return ' AUTO_INCREMENT PRIMARY KEY';
+		}
+	}
+
+	/**
+	 * Get the SQL syntax for specifying a column's character set.
+	 *
+	 * @param  Table   $table
+	 * @param  Fluent  $column
+	 * @return string
+	 */
+	protected function charset(Table $table, Fluent $column)
+	{
+		// Character sets only apply to text-based columns.  There are other MySQL
+		// column types that are supported (char, enum, set) but these aren't
+		// (yet) supported by Laravel.
+		if (in_array($column->type, array('string', 'text')) && $column->charset)
+		{
+			return ' CHARACTER SET '.$column->charset;
+		}
+	}
+
+	/**
+	 * Get the SQL syntax for specifying a column's character set.
+	 *
+	 * @param  Table   $table
+	 * @param  Fluent  $column
+	 * @return string
+	 */
+	protected function collate(Table $table, Fluent $column)
+	{
+		// Character sets only apply to text-based columns.  There are other MySQL
+		// column types that are supported (char, enum, set) but these aren't
+		// (yet) supported by Laravel.
+		if (in_array($column->type, array('string', 'text')) && $column->collate)
+		{
+			return ' COLLATE '.$column->collate;
 		}
 	}
 

--- a/laravel/database/schema/table.php
+++ b/laravel/database/schema/table.php
@@ -26,6 +26,20 @@ class Table {
 	public $engine;
 
 	/**
+	 * The character set that should be used for the table.
+	 *
+	 * @var string
+	 */
+	public $charset;
+
+	/**
+	 * The collation that should be used for the table.
+	 *
+	 * @var string
+	 */
+	public $collation;
+
+	/**
 	 * The columns that should be added to the table.
 	 *
 	 * @var array
@@ -48,6 +62,12 @@ class Table {
 	public function __construct($name)
 	{
 		$this->name = $name;
+		// Set the default character set for the table to be the same as the
+		// character set in the database configuration.  This can be overridden
+		// with the charset() method.
+		// 
+		// Is there a better way to retrieve this value from the database config?
+		$this->charset = \Laravel\Config::get('database.connections.mysql.charset');
 	}
 
 	/**
@@ -70,6 +90,26 @@ class Table {
 	public function primary($columns, $name = null)
 	{
 		return $this->key(__FUNCTION__, $columns, $name);
+	}
+
+	/**
+	 * Set an alternative character set for the table.
+	 * 
+	 * @param string $charset
+	 */
+	public function charset($charset)
+	{
+		$this->charset = $charset;
+	}
+
+	/**
+	 * Set an alternative collation for the table.
+	 * 
+	 * @param string $collation
+	 */
+	public function collate($collation)
+	{
+		$this->collation = $collation;
 	}
 
 	/**


### PR DESCRIPTION
This commit adds support for setting character set and/or collations for MySQL.  This is useful where the database system's default character set and/or collation is not set to the character set/collation desired for the table/column.

The default character set is the value set in the charset option in the MySQL database configuration in /application/config/database.php

The default collation is set by the MySQL server.

Tables and columns can both have their character set/collation set individually.

Example migration:

``` php
/**
 * File: /application/migrations/2012_07_02_193607_create_mixed_charset_table.php
 */

class Create_Mixed_Charset_Table {

    /**
     * Make changes to the database.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('my_mixed_table', function($table) {
            $table->charset('utf8'); // same as default
            // $table->collate('utf8_unicode_ci'); // default is 'utf_general_ci'

            $table->increments('id');

            // uses table default values
            $table->string('text_default', 100);

            // force Latin 1, collation is default for this charset
            $table->string('text_latin1', 100)->charset('latin1');

            // force a specific collation
            $table->string('text_utf8_unicode_ci', 100)->collate('utf8_unicode_ci');

            // force Latin 1 with a specific collation
            $table->string('text_latin1_german_ci', 100)->charset('latin1')->collate('latin1_german1_ci');
        });
    }

    /**
     * Revert the changes to the database.
     *
     * @return void
     */
    public function down()
    {
        Schema::drop('my_mixed_table');
    }

}
```

This results in the following SQL:

``` sql
CREATE TABLE `my_mixed_table` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `text_default` varchar(100) NOT NULL,
  `text_latin1` varchar(100) CHARACTER SET latin1 NOT NULL,
  `text_utf8` varchar(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
  `text_latin1_german` varchar(100) CHARACTER SET latin1 COLLATE latin1_german1_ci NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8
```

Note that specifying an invalid character set or collation will result in a SQL error.
