### PR TITLE
Ignore NULL values when determining whether a model object is dirty

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -536,7 +536,7 @@ abstract class Model {
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! isset($this->original[$key]) or $value !== $this->original[$key])
+			if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])
 			{
 				$dirty[$key] = $value;
 			}


### PR DESCRIPTION
Due to the use of `isset`, `NULL` values in model objects' attributes were causing the model to think it's dirty. Changing the check to use `array_key_exists()` fixes this.
