### PR TITLE
Feature/eloquent update timestamp

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -218,9 +218,11 @@ abstract class Model {
 	{
 		$model = new static(array(), true);
 
-		if (static::$timestamps) $attributes['updated_at'] = new \DateTime;
+		$model->fill($attributes);
 
-		return $model->query()->where($model->key(), '=', $id)->update($attributes);
+		if (static::$timestamps) $model->timestamp();
+
+		return $model->query()->where($model->key(), '=', $id)->update($model->attributes);
 	}
 
 	/**


### PR DESCRIPTION
Calling update() on an eloquent model has no way of overriding
the timestamp that should be set if $timestamps is set on the
model. This changes that so it uses the timestamp() function
which is an easy way to over ride the type of timestamps used.
