### PR TITLE
[Docs] Localization page: Fix anchor name

### DIFF
--- a/laravel/documentation/localization.md
+++ b/laravel/documentation/localization.md
@@ -33,7 +33,7 @@ Next, you should create a corresponding **marketing.php** file within the **appl
 
 Nice! Now you know how to get started setting up your language files and directories. Let's keep localizing!
 
-<a name="basics"></a>
+<a name="get"></a>
 ## Retrieving A Language Line
 
 #### Retrieving a language line:


### PR DESCRIPTION
The submenu link to the section "Retrieving a language line" on the localization page did not work.

And yes, this was purposely targeted at `master`.
