### PR TITLE
Removed passing of first column name to count in paginate

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -706,7 +706,7 @@ class Query {
 		// all of the ordreings and put them back on the query.
 		list($orderings, $this->orderings) = array($this->orderings, null);
 
-		$total = $this->count(reset($columns));
+		$total = $this->count();
 
 		$page = Paginator::page($total, $per_page);
 


### PR DESCRIPTION
Removed using the column passed in because if you pass a column like
this 'table.column_name AS table_column_name' it will cause the query
to throw an error as it tries to wrap 'table.column_name AS
table_column_name' so that in the query it is "SELECT
COUNT(table.column_name AS table_column_name)….." which is invalid.

As far a pagination goes I don't see this change as affecting it much
at all.
