### PR TITLE
Feature/messages transform key

### DIFF
--- a/laravel/messages.php
+++ b/laravel/messages.php
@@ -42,6 +42,7 @@ class Messages {
 	public function add($key, $message)
 	{
 		if ($this->unique($key, $message)) $this->messages[$key][] = $message;
+		return $this;
 	}
 
 	/**
@@ -164,9 +165,9 @@ class Messages {
 
 		$all = array();
 
-		foreach ($this->messages as $messages)
+		foreach ($this->messages as $key => $message)
 		{
-			$all = array_merge($all, $this->transform($messages, $format));
+			$all = array_merge($all, $this->transform(array('key' => $key, 'messages' =>$message), $format));
 		}
 
 		return $all;
@@ -181,11 +182,13 @@ class Messages {
 	 */
 	protected function transform($messages, $format)
 	{
-		$messages = (array) $messages;
+		$key = $messages['key'];
+		$messages = (array) $messages['messages'];
 
-		foreach ($messages as $key => &$message)
+		foreach ($messages as &$message)
 		{
 			$message = str_replace(':message', $message, $format);
+			$message = str_replace(':key', $key, $message);
 		}
 
 		return $messages;


### PR DESCRIPTION
Currently, there's no ability to reference a key that a message
belongs to in the transform() function's formatting. I found a need
for it when applying classes to messages (success, error, etc) on
a site.

Example: 

``` php
$messages->all('<li class=":key">:message</li>');
```

I also added return $this; in the add() function to allow for method
chaining.

Example: 

``` php
$messages = IoC::resolve('messages')->add('succes', 'Successful action');
```
