### PR TITLE
Force UTF-8 charset on JSON responses

### DIFF
--- a/laravel/response.php
+++ b/laravel/response.php
@@ -93,7 +93,7 @@ class Response {
 	 */
 	public static function json($data, $status = 200, $headers = array())
 	{
-		$headers['Content-Type'] = 'application/json';
+		$headers['Content-Type'] = 'application/json; charset=utf-8';
 
 		return new static(json_encode($data), $status, $headers);
 	}
@@ -113,7 +113,7 @@ class Response {
 	 */
 	public static function eloquent($data, $status = 200, $headers = array())
 	{
-		$headers['Content-Type'] = 'application/json';
+		$headers['Content-Type'] = 'application/json; charset=utf-8';
 
 		return new static(eloquent_to_json($data), $status, $headers);
 	}


### PR DESCRIPTION
As suggested in [this forum topic](http://forums.laravel.com/viewtopic.php?id=1638), I made sure JSON responses are always sent explicitly as UTF-8 (which fixes a display bug).

The RFC says that JSON "SHOULD" be sent as UTF-8, so that makes sense.
