### PR TITLE
'exists' flag is not set on hydrated models

### DIFF
--- a/laravel/database/eloquent/query.php
+++ b/laravel/database/eloquent/query.php
@@ -122,6 +122,9 @@ class Query {
 			// we were to pass them in using the constructor or fill methods.
 			$new->fill_raw($result);
 
+            // Mark the model as existant in the database
+            $new->exists = true;
+
 			$models[] = $new;
 		}
 


### PR DESCRIPTION
I'm experiencing an issue where the `exists` flag is not set on Model instances retrieved from the database. Observing the sources, namely `laravel/database/eloquent/query.php` reveals this comment:

```
// We'll spin through the array of database results and hydrate a model
// for each one of the records. We will also set the "exists" flag to
// "true" so that the model will be updated when it is saved.
```

But no assignment to the `exists` flag takes place. I don't have full understanding of the hydration process, but setting this flag on the newly created model instance fixes this issue for me.

```
    foreach ((array) $results as $result)
    {
        $result = (array) $result;

        $new = new $class(array(), true);

        // We need to set the attributes manually in case the accessible property is
        // set on the array which will prevent the mass assignemnt of attributes if
        // we were to pass them in using the constructor or fill methods.
        $new->fill_raw($result);

        $new->exists = true; // <------------- this line added

        $models[] = $new;
    }
```
