### PR TITLE
Extend Auth::attempt

### DIFF
--- a/laravel/auth/drivers/eloquent.php
+++ b/laravel/auth/drivers/eloquent.php
@@ -26,23 +26,28 @@ class Eloquent extends Driver {
 	 */
 	public function attempt($arguments = array())
 	{
-		$username = Config::get('auth.username');
+	    $user = $this->model()->where(function($query) use($arguments) {
+	        $username = Config::get('auth.username');
+	        $query->where($username, '=', $arguments['username']);
 
-		$user = $this->model()->where($username, '=', $arguments['username'])->first();
+	        foreach( array_except($arguments, array('username', 'password')) as $column => $val )
+	        {
+	            $query->where($column, '=', $val);
+	        }
+	    })->first();
 
-		// This driver uses a basic username and password authentication scheme
-		// so if the credentials match what is in the database we will just
-		// log the user into the application and remember them if asked.
-		$password = $arguments['password'];
+	    // If the credentials match what is in the database we will just
+	    // log the user into the application and remember them if asked.
+	    $password = $arguments['password'];
 
-		$password_field = Config::get('auth.password', 'password');
+	    $password_field = Config::get('auth.password', 'password');
 
-		if ( ! is_null($user) and Hash::check($password, $user->get_attribute($password_field)))
-		{
-			return $this->login($user->id, array_get($arguments, 'remember'));
-		}
+	    if ( ! is_null($user) and Hash::check($password, $user->get_attribute($password_field)))
+	    {
+	        return $this->login($user->id, array_get($arguments, 'remember'));
+	    }
 
-		return false;
+	    return false;
 	}
 
 	/**

--- a/laravel/auth/drivers/fluent.php
+++ b/laravel/auth/drivers/fluent.php
@@ -30,10 +30,9 @@ class Fluent extends Driver {
 	 */
 	public function attempt($arguments = array())
 	{
-		$user = $this->get_user($arguments['username']);
+		$user = $this->get_user($arguments);
 
-		// This driver uses a basic username and password authentication scheme
-		// so if the credentials match what is in the database we will just
+		// If the credentials match what is in the database we will just
 		// log the user into the application and remember them if asked.
 		$password = $arguments['password'];
 
@@ -48,18 +47,24 @@ class Fluent extends Driver {
 	}
 
 	/**
-	 * Get the user from the database table by username.
+	 * Get the user from the database table by username and any other optional params.
 	 *
-	 * @param  mixed  $value
+	 * @param  array $arguments
 	 * @return mixed
 	 */
-	protected function get_user($value)
+	protected function get_user($arguments)
 	{
 		$table = Config::get('auth.table');
 
-		$username = Config::get('auth.username');
+		return DB::table($table)->where(function($query) use($arguments) {
+	        $username = Config::get('auth.username');
+	        $query->where($username, '=', $arguments['username']);
 
-		return DB::table($table)->where($username, '=', $value)->first();
+	        foreach( array_except($arguments, array('username', 'password')) as $column => $val )
+	        {
+	            $query->where($column, '=', $val);
+	        }
+	    })->first();
 	}
 
 }

--- a/laravel/documentation/auth/usage.md
+++ b/laravel/documentation/auth/usage.md
@@ -32,7 +32,7 @@ You can compare an unhashed value against a hashed one using the **check** metho
 <a name="login"></a>
 ## Logging In
 
-Logging a user into your application is simple using the **attempt** method on the Auth class. Simply pass the username and password of the user to the method. The credentials should be contained in an array, which allows for maximum flexibility across drivers, as some drivers may require a different number of arguments. The login method will return **true** if the credentials are valid. Otherwise, **false** will be returned:
+Logging a user into your application is simple using the **attempt** method on the Auth class. Simply pass the username and password of the user to the method, along with any other optional values that should be verified. The credentials should be contained in an array, which allows for maximum flexibility across drivers, as some drivers may require a different number of arguments. The login method will return **true** if the credentials are valid. Otherwise, **false** will be returned:
 
 	$credentials = array('username' => 'example@gmail.com', 'password' => 'secret');
 


### PR DESCRIPTION
With these changes, when attempting to login a user, in addition to ensuring that the username and password match what's stored in the DB, we can also provide additional params to be verified, like this:

``` php
$creds = [
    'username'   => Input::get('email'),
    'password'   => Input::get('password'),
    'enabled'    => 1
];

if ( Auth::attempt($creds) ) { ... }
```
