### PR TITLE
[Forms] Radio group helper

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -409,6 +409,39 @@ class Form {
 
 		return '<select'.HTML::attributes($attributes).'>'.implode('', $html).'</select>';
 	}
+	
+	/**
+	 * Create a group of radio buttons.
+	 *
+	 * <code>
+	 *		// Create a radio group consisting of two options
+	 *		echo Form::radiogroup('option', array(1 => 'Yes', 0 => 'No'));
+	 *
+	 *		// Create a radio group with a default selected value
+	 *		echo Form::radiogroup('option', array(1 => 'Yes', 0 => 'No'), 1);
+	 * </code>
+	 *
+	 * @param  string  $name
+	 * @param  array   $options
+	 * @param  string  $selected
+	 * @param  array   $attributes
+	 * @return string
+	 */
+	public static function radiogroup($name, $options = array(), $selected = null, $attributes = array())
+	{
+		$attributes['id'] = static::id($name, $attributes);
+
+		$attributes['name'] = $name;
+
+		$html = array();
+
+		foreach ($options as $value => $display)
+		{
+			$html[] = static::radio($value, $display, $value == $selected, $attributes);
+		}
+
+		return implode('', $html);
+	}
 
 	/**
 	 * Create a HTML select element optgroup.


### PR DESCRIPTION
As radio buttons usually come in a herd, a helper for a typical radio group would be quite helpful. Typically, it would have the same API as the`Form::select` helper.

If I remember correctly, that would make it something like this:

```
Form::radiogroup('name', array(1 => 'option one', 2 => 'option two', 1, array())
```

(with the third parameter being the selected option (could be `NULL`, too) and the fourth parameter an associative array of HTML attributes to be set.

---

Why this is not yet ready for being merged:
Radio groups don't make sense without lavels wrapping or at least preceding every option, so I am looking for comments and innovative input here.
