### PR TITLE
Extend Auth::Attempt()

### DIFF
--- a/laravel/auth/drivers/eloquent.php
+++ b/laravel/auth/drivers/eloquent.php
@@ -21,7 +21,7 @@ class Eloquent extends Driver {
 	/**
 	 * Attempt to log a user into the application.
 	 *
-	 * @param  array  $arguments
+	 * @param  array $arguments
 	 * @return void
 	 */
 	public function attempt($arguments = array())

--- a/laravel/auth/drivers/fluent.php
+++ b/laravel/auth/drivers/fluent.php
@@ -25,7 +25,7 @@ class Fluent extends Driver {
 	/**
 	 * Attempt to log a user into the application.
 	 *
-	 * @param  array  $arguments
+	 * @param  array $arguments
 	 * @return void
 	 */
 	public function attempt($arguments = array())
@@ -49,7 +49,7 @@ class Fluent extends Driver {
 	/**
 	 * Get the user from the database table.
 	 *
-	 * @param  mixed  $array
+	 * @param  array  $arguments
 	 * @return mixed
 	 */
 	protected function get_user($arguments)


### PR DESCRIPTION
Signed-off-by: Jeffrey Way jeffrey@envato.com

Allows you to run `Auth::attempt()` against multiple fields, rather than just username + password.
