### PR TITLE
Pull strhuman

### DIFF
--- a/laravel/str.php
+++ b/laravel/str.php
@@ -232,6 +232,26 @@ class Str {
 	}
 
 	/**
+	 * Convert a slug into a human-readable string
+	 *
+	 * <code>
+	 *		// Returns "this is my blog post"
+	 *		$str = Str::human('this_is_my_blog_post');
+	 *		$str = Str::human('this-is-my-blog-post');
+	 * </code>
+	 *
+	 * @param  string  $slug
+	 * @return string
+	 */
+	public static function human($slug, $replace = array('_', '-', '+'))
+	{
+		$slug = static::ascii($slug);
+
+		// Replace underscores and dashes with spaces
+		return trim(str_replace($replace, ' ', $slug));
+	}
+
+	/**
 	 * Convert a string to 7-bit ASCII.
 	 *
 	 * This is helpful for converting UTF-8 strings for usage in URLs, etc.


### PR DESCRIPTION
To be used with Str::title() or ucfirst() to convert slugs and
url-encoded strings into human-readable text.

The second (optional) parameter contains an array of characters to
replace with spaces. The default is `array('_', '-', '+')`.
Suggestions for default values is welcome.

Also, this method currently leaves the string's capitalization as-is.
Feedback on whether it should include any/what capitalization?

Signed-off-by: Kelly Banman kelly.banman@gmail.com
