### PR TITLE
Allow second param of HTML::link* methods to be null

### DIFF
--- a/laravel/html.php
+++ b/laravel/html.php
@@ -137,9 +137,11 @@ class HTML {
 	 * @param  bool    $https
 	 * @return string
 	 */
-	public static function link($url, $title, $attributes = array(), $https = null)
+	public static function link($url, $title = null, $attributes = array(), $https = null)
 	{
 		$url = URL::to($url, $https);
+
+		if (is_null($title)) $title = $url;
 
 		return '<a href="'.$url.'"'.static::attributes($attributes).'>'.static::entities($title).'</a>';
 	}
@@ -152,7 +154,7 @@ class HTML {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function link_to_secure($url, $title, $attributes = array())
+	public static function link_to_secure($url, $title = null, $attributes = array())
 	{
 		return static::link($url, $title, $attributes, true);
 	}
@@ -168,7 +170,7 @@ class HTML {
 	 * @param  bool    $https
 	 * @return string
 	 */
-	public static function link_to_asset($url, $title, $attributes = array(), $https = null)
+	public static function link_to_asset($url, $title = null, $attributes = array(), $https = null)
 	{
 		$url = URL::to_asset($url, $https);
 
@@ -183,7 +185,7 @@ class HTML {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function link_to_secure_asset($url, $title, $attributes = array())
+	public static function link_to_secure_asset($url, $title = null, $attributes = array())
 	{
 		return static::link_to_asset($url, $title, $attributes, true);
 	}
@@ -207,7 +209,7 @@ class HTML {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function link_to_route($name, $title, $parameters = array(), $attributes = array())
+	public static function link_to_route($name, $title = null, $parameters = array(), $attributes = array())
 	{
 		return static::link(URL::to_route($name, $parameters), $title, $attributes);
 	}
@@ -231,7 +233,7 @@ class HTML {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function link_to_action($action, $title, $parameters = array(), $attributes = array())
+	public static function link_to_action($action, $title = null, $parameters = array(), $attributes = array())
 	{
 		return static::link(URL::to_action($action, $parameters), $title, $attributes);
 	}
@@ -418,7 +420,7 @@ class HTML {
 	    {
 	        return call_user_func_array(static::$macros[$method], $parameters);
 	    }
-	    
+
 	    throw new \Exception("Method [$method] does not exist.");
 	}
 


### PR DESCRIPTION
Allow second param of HTML::link\* methods to be null, in which case the title of the link is the URL itself, 
similar to HTML::email() method.

Signed-off-by: Colin Viebrock colin@viebrock.ca
