### PR TITLE
Fix eager loading constraints

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -257,7 +257,7 @@ abstract class Model {
 	{
 		$includes = (array) $includes;
 
-		$given_includes = array();
+		$this->includes = array();
 
 		foreach ($includes as $relationship => $constraints)
 		{
@@ -269,26 +269,8 @@ abstract class Model {
 				list($relationship, $constraints) = array($constraints, null);
 			}
 
-			$given_includes[$relationship] = $constraints;
+			$this->includes[$relationship] = $constraints;
 		}
-
-		$relationships = array_keys($given_includes);
-		$implicits = array();
-
-		foreach ($relationships as $relationship)
-		{
-			$parts = explode('.', $relationship);
-
-			$prefix = '';
-			foreach ($parts as $part)
-			{
-				$implicits[$prefix.$part] = null;
-				$prefix .= $part.'.';
-			}
-		}
-
-		// Add all implicit includes to the explicit ones
-		$this->includes = $given_includes + $implicits;
 
 		return $this;
 	}

--- a/laravel/database/eloquent/query.php
+++ b/laravel/database/eloquent/query.php
@@ -127,7 +127,7 @@ class Query {
 
 		if (count($results) > 0)
 		{
-			foreach ($this->model->includes as $relationship => $constraints)
+			foreach ($this->model_includes() as $relationship => $constraints)
 			{
 				// If the relationship is nested, we will skip loading it here and let
 				// the load method parse and set the nested eager loads on the right
@@ -196,7 +196,7 @@ class Query {
 	{
 		$nested = array();
 
-		foreach ($this->model->includes as $include => $constraints)
+		foreach ($this->model_includes() as $include => $constraints)
 		{
 			// To get the nested includes, we want to find any includes that begin
 			// the relationship and a dot, then we will strip off the leading
@@ -208,6 +208,32 @@ class Query {
 		}
 
 		return $nested;
+	}
+
+	/**
+	 * Get the eagerly loaded relationships for the model.
+	 *
+	 * @return array
+	 */
+	protected function model_includes()
+	{
+		$relationships = array_keys($this->model->includes);
+		$implicits = array();
+
+		foreach ($relationships as $relationship)
+		{
+			$parts = explode('.', $relationship);
+
+			$prefix = '';
+			foreach ($parts as $part)
+			{
+				$implicits[$prefix.$part] = NULL;
+				$prefix .= $part.'.';
+			}
+		}
+
+		// Add all implicit includes to the explicit ones
+		return $this->model->includes + $implicits;
 	}
 
 	/**


### PR DESCRIPTION
Eager loading constraints were broken by pull request #799. I fixed that now.

This change also moves some code to the Model class over from the Query class. This actually has benefits, as it makes manipulating the includes after assembling the query easier. (I want to do stuff like that in FluxBB's extension system.)

We really need unit tests...
