### PR TITLE
Missing semicolon breaking test runner

### DIFF
--- a/laravel/cli/tasks/test/runner.php
+++ b/laravel/cli/tasks/test/runner.php
@@ -83,7 +83,7 @@ class Runner extends Task {
 		
 		// fix the spaced directories problem when using the command line
 		// strings with spaces inside should be wrapped in quotes.
-		$path = escapeshellarg($path)
+		$path = escapeshellarg($path);
 
 		passthru('phpunit --configuration '.$path);
 


### PR DESCRIPTION
There was a missing semicolon breaking my attempts to run the test suite. :)
