### PR TITLE
Made validate_active_url() return empty strings as false. 

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -560,7 +560,10 @@ class Validator {
 	{
 		$url = str_replace(array('http://', 'https://', 'ftp://'), '', Str::lower($value));
 
-		return checkdnsrr($url);
+		if(!empty($url))
+			return checkdnsrr($url);
+		else
+			return false;
 	}
 
 	/**


### PR DESCRIPTION
Otherwise got a could not check check dns on empty string error if user entered 'http://' which would not be caught by 'required' because it's removed in this function.
