### PR TITLE
This dumps the mixed variable and it preserves both spaces and line brea...

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -38,6 +38,18 @@ function dd($value)
 }
 
 /**
+ * Dump the given value in a readable manner and kill the script.
+ *
+ * @param  mixed  $value
+ * @return void
+ */
+function pdd($value)
+{
+	echo '<pre>';
+	die(var_dump($value));
+}
+
+/**
  * Get an item from an array using "dot" notation.
  *
  * <code>


### PR DESCRIPTION
...ks instead of putting the var_dump all into one line like dd().
