### PR TITLE
Fixed IoC::resolve forces singleton issue.

### DIFF
--- a/laravel/ioc.php
+++ b/laravel/ioc.php
@@ -124,7 +124,7 @@ class IoC {
 		// If the requested type is registered as a singleton, we want to cache off
 		// the instance in memory so we can return it later without creating an
 		// entirely new instances of the object on each subsequent request.
-		if (isset(static::$registry[$type]['singleton']))
+		if (isset(static::$registry[$type]['singleton']) && static::$registry[$type]['singleton'] === true)
 		{
 			static::$singletons[$type] = $object;
 		}


### PR DESCRIPTION
In the IoC resolve method, the 'singleton' property is checked using isset() instead of boolean checked. 
Since the register method uses compact, the singleton parameter is always set.

same as issue #385, but not fixed in master and develop branches.

Signed-off-by: Rack Lin racklin@gmail.com
