### PR TITLE
[Docs] Fix bundle routing link

### DIFF
--- a/laravel/documentation/contents.md
+++ b/laravel/documentation/contents.md
@@ -18,7 +18,7 @@
 	- [Route Groups](/docs/routing#groups)
 	- [Named Routes](/docs/routing#named-routes)
 	- [HTTPS Routes](/docs/routing#https-routes)
-	- [Bundle Routing](/docs/routing#bundle-routing)
+	- [Bundle Routes](/docs/routing#bundle-routes)
 	- [CLI Route Testing](/docs/routing#cli-route-testing)
 - [Controllers](/docs/controllers)
 	- [The Basics](/docs/controllers#the-basics)


### PR DESCRIPTION
The "bundle routing" link in the extendable "Routing" section in the menu didn't work properly
