### PR TITLE
[Schema] Allow boolean default values

### DIFF
--- a/laravel/database/schema/grammars/grammar.php
+++ b/laravel/database/schema/grammars/grammar.php
@@ -96,4 +96,19 @@ abstract class Grammar extends \Laravel\Database\Grammar {
 		return $this->{'type_'.$column->type}($column);
 	}
 
+	/**
+	 * Format a value so that it can be used in SQL DEFAULT clauses.
+	 * @param  mixed   $value
+	 * @return string
+	 */
+	protected function default_value($value)
+	{
+		if (is_bool($value))
+		{
+			return intval($value);
+		}
+
+		return strval($value);
+	}
+
 }

--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -128,7 +128,7 @@ class MySQL extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+			return " DEFAULT '".$this->default_value($column->default)."'";
 		}
 	}
 

--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -101,7 +101,7 @@ class Postgres extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+			return " DEFAULT '".$this->default_value($column->default)."'";
 		}
 	}
 

--- a/laravel/database/schema/grammars/sqlite.php
+++ b/laravel/database/schema/grammars/sqlite.php
@@ -127,7 +127,7 @@ class SQLite extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return ' DEFAULT '.$this->wrap($column->default);
+			return ' DEFAULT '.$this->wrap($this->default_value($column->default));
 		}
 	}
 

--- a/laravel/database/schema/grammars/sqlserver.php
+++ b/laravel/database/schema/grammars/sqlserver.php
@@ -108,7 +108,7 @@ class SQLServer extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+			return " DEFAULT '".$this->default_value($column->default)."'";
 		}
 	}
 


### PR DESCRIPTION
In the schema, it is possible to add so-called "boolean" columns (which are essential smallints or whatnot). As they are called "boolean", I think it should be possible to specify a boolean default value in the `default()` helper - makes sense, no?

As the boolean value `false` will automatically be converted to an empty string (and not a 0) when automatically casted by PHP, this currently breaks the generated SQL.
