### PR TITLE
Added support UUIDs as primary key

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -98,6 +98,20 @@ abstract class Model {
 	 */
 	public static $per_page = 20;
 
+    /**
+   	 * Indicates if the model using uuid as primary key.
+   	 *
+   	 * @var bool
+   	 */
+   	public static $key_is_uuid = false;
+
+    /**
+   	 * Indicates if the model using uuid as primary key and need automatically generate UUIDs when new records are created otherwise using database default.
+   	 *
+   	 * @var bool
+   	 */
+   	public static $key_generate_uuid = false;
+
 	/**
 	 * Create a new Eloquent model instance.
 	 *
@@ -419,11 +433,14 @@ abstract class Model {
 		// then we can consider the insert successful.
 		else
 		{
+            // Generated uuid for primay key
+            if ($this->key_is_uuid() && $this->key_generate_uuid() && !is_string($this->get_key())) $this->set_key(Str::uuid());
+
 			$id = $this->query()->insert_get_id($this->attributes, $this->key());
 
 			$this->set_key($id);
 
-			$this->exists = $result = is_numeric($this->get_key());
+			$this->exists = $result = $this->key_is_uuid() ? is_string($this->get_key()) : is_numeric($this->get_key());
 
 			if ($result) $this->fire_event('created');
 		}
@@ -756,7 +773,7 @@ abstract class Model {
 	 */
 	public function __call($method, $parameters)
 	{
-		$meta = array('key', 'table', 'connection', 'sequence', 'per_page', 'timestamps');
+		$meta = array('key', 'table', 'connection', 'sequence', 'per_page', 'timestamps', 'key_is_uuid', 'key_generate_uuid');
 
 		// If the method is actually the name of a static property on the model we'll
 		// return the value of the static property. This makes it convenient for

--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -2,6 +2,7 @@
 
 use Laravel\Fluent;
 use Laravel\Database\Schema\Table;
+use Laravel\Database\Expression;
 
 class MySQL extends Grammar {
 
@@ -128,7 +129,7 @@ class MySQL extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+            return " DEFAULT ".($column->default instanceof Expression ? $column->default : "'".$column->default."'");
 		}
 	}
 
@@ -417,5 +418,16 @@ class MySQL extends Grammar {
 	{
 		return 'BLOB';
 	}
+
+    /**
+   	 * Generate the data-type definition for a uuid.
+   	 *
+   	 * @param  Fluent  $column
+   	 * @return string
+   	 */
+   	protected function type_uuid(Fluent $column)
+   	{
+   		return 'VARCHAR(36)';
+   	}
 
 }

--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -2,6 +2,7 @@
 
 use Laravel\Fluent;
 use Laravel\Database\Schema\Table;
+use Laravel\Database\Expression;
 
 class Postgres extends Grammar {
 
@@ -101,7 +102,7 @@ class Postgres extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+            return " DEFAULT ".($column->default instanceof Expression ? $column->default : "'".$column->default."'");
 		}
 	}
 
@@ -403,5 +404,16 @@ class Postgres extends Grammar {
 	{
 		return 'BYTEA';
 	}
+
+    /**
+   	 * Generate the data-type definition for a uuid.
+   	 *
+   	 * @param  Fluent  $column
+   	 * @return string
+   	 */
+   	protected function type_uuid(Fluent $column)
+   	{
+   		return 'UUID';
+   	}
 
 }

--- a/laravel/database/schema/grammars/sqlite.php
+++ b/laravel/database/schema/grammars/sqlite.php
@@ -2,6 +2,7 @@
 
 use Laravel\Fluent;
 use Laravel\Database\Schema\Table;
+use Laravel\Database\Expression;
 
 class SQLite extends Grammar {
 
@@ -127,7 +128,7 @@ class SQLite extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return ' DEFAULT '.$this->wrap($column->default);
+            return " DEFAULT ".($column->default instanceof Expression ? $column->default : $this->wrap($column->default));
 		}
 	}
 
@@ -347,5 +348,16 @@ class SQLite extends Grammar {
 	{
 		return 'BLOB';
 	}
+
+    /**
+   	 * Generate the data-type definition for a uuid.
+   	 *
+   	 * @param  Fluent  $column
+   	 * @return string
+   	 */
+   	protected function type_uuid(Fluent $column)
+   	{
+   		return 'VARCHAR';
+   	}
 
 }

--- a/laravel/database/schema/grammars/sqlserver.php
+++ b/laravel/database/schema/grammars/sqlserver.php
@@ -2,6 +2,7 @@
 
 use Laravel\Fluent;
 use Laravel\Database\Schema\Table;
+use Laravel\Database\Expression;
 
 class SQLServer extends Grammar {
 
@@ -108,7 +109,7 @@ class SQLServer extends Grammar {
 	{
 		if ( ! is_null($column->default))
 		{
-			return " DEFAULT '".$column->default."'";
+            return " DEFAULT ".($column->default instanceof Expression ? $column->default : "'".$column->default."'");
 		}
 	}
 
@@ -421,5 +422,16 @@ class SQLServer extends Grammar {
 	{
 		return 'VARBINARY(MAX)';
 	}
+
+    /**
+   	 * Generate the data-type definition for a uuid.
+   	 *
+   	 * @param  Fluent  $column
+   	 * @return string
+   	 */
+   	protected function type_uuid(Fluent $column)
+   	{
+   		return 'NVARCHAR(36)';
+   	}
 
 }

--- a/laravel/database/schema/table.php
+++ b/laravel/database/schema/table.php
@@ -358,6 +358,17 @@ class Table {
 		return $this->column(__FUNCTION__, compact('name'));
 	}
 
+    /**
+   	 * Add a uuid column to the table.
+   	 *
+   	 * @param  string  $name
+   	 * @return Fluent
+   	 */
+   	public function uuid($name)
+   	{
+   		return $this->column(__FUNCTION__, compact('name'));
+   	}
+
 	/**
 	 * Set the database connection for the table operation.
 	 *

--- a/laravel/str.php
+++ b/laravel/str.php
@@ -347,4 +347,75 @@ class Str {
 		}
 	}
 
+    /**
+     * Generate a random UUID
+     *
+     * @see http://www.ietf.org/rfc/rfc4122.txt
+     * @return string RFC 4122 UUID
+     */
+    public static function uuid() {
+		$node = $_SERVER['SERVER_ADDR'];
+		$pid = null;
+
+		if (strpos($node, ':') !== false) {
+			if (substr_count($node, '::')) {
+				$node = str_replace('::', str_repeat(':0000', 8 - substr_count($node, ':')) . ':', $node);
+			}
+			$node = explode(':', $node) ;
+			$ipv6 = '' ;
+
+			foreach ($node as $id) {
+				$ipv6 .= str_pad(base_convert($id, 16, 2), 16, 0, STR_PAD_LEFT);
+			}
+			$node =  base_convert($ipv6, 2, 10);
+
+			if (strlen($node) < 38) {
+				$node = null;
+			} else {
+				$node = crc32($node);
+			}
+		} elseif (empty($node)) {
+			$host = $_SERVER['HOSTNAME'];
+
+			if (empty($host)) {
+				$host = $_SERVER['HOST'];
+			}
+
+			if (!empty($host)) {
+				$ip = gethostbyname($host);
+
+				if ($ip === $host) {
+					$node = crc32($host);
+				} else {
+					$node = ip2long($ip);
+				}
+			}
+		} elseif ($node !== '127.0.0.1') {
+			$node = ip2long($node);
+		} else {
+			$node = null;
+		}
+
+		if (empty($node)) {
+			$node = crc32(Config::get('application.key'));
+		}
+
+		if (function_exists('zend_thread_id')) {
+			$pid = zend_thread_id();
+		} else {
+			$pid = getmypid();
+		}
+
+		if (!$pid || $pid > 65535) {
+			$pid = mt_rand(0, 0xfff) | 0x4000;
+		}
+
+		list($timeMid, $timeLow) = explode(' ', microtime());
+		$uuid = sprintf("%08x-%04x-%04x-%02x%02x-%04x%08x", (int)$timeLow, (int)substr($timeMid, 2) & 0xffff,
+					mt_rand(0, 0xfff) | 0x4000, mt_rand(0, 0x3f) | 0x80, mt_rand(0, 0xff), $pid, $node);
+
+		return $uuid;
+	}
+
+
 }


### PR DESCRIPTION
_Added support UUIDs as primary key and generated uuid automatically when new record created._

Because Eloquent not fetch table's columns type from database, so i add two variables to indicates you want to using UUID as primary key and automatically generate UUID or using database default.  (Is added variables  that is a good way?)

``` php
class Test extends Eloquent {
     public static $table = 'tests';
     public static $key_is_uuid = true;
     public static $key_generate_uuid = true; // auto generate UUID in eloquent.
}
```

_Schema support DB::raw express in migration_

``` php
Schema::create('test', function($table)
{
    $table->uuid('id')->default(DB::raw('uuid_generate_v4()'));
    $table->string('test')->default('i am static string default');
    $table->string('name');
    $table->timestamps();
});

```
