### PR TITLE
Fixed Memcached get connection instance typo in __callStatic method.

### DIFF
--- a/laravel/memcached.php
+++ b/laravel/memcached.php
@@ -68,7 +68,7 @@ class Memcached {
 	 */
 	public static function __callStatic($method, $parameters)
 	{
-		return call_user_func_array(array(static::instance(), $method), $parameters);
+		return call_user_func_array(array(static::connection(), $method), $parameters);
 	}
 
 }


### PR DESCRIPTION
static::instance() undefined, it must be static::connection().

Signed-off-by: Rack Lin racklin@gmail.com
