### PR TITLE
Fix pivot table name in Many-to-Many section in Eloquent documentation.

### DIFF
--- a/laravel/documentation/database/eloquent.md
+++ b/laravel/documentation/database/eloquent.md
@@ -242,7 +242,7 @@ Many-to-many relationships are the most complicated of the three relationships. 
 	id   - INTEGER
 	name - VARCHAR
 
-**Roles_Users:**
+**Role_User:**
 
     id      - INTEGER
 	user_id - INTEGER


### PR DESCRIPTION
The pivot table should be singular, not plural.
