### PR TITLE
Added get an array of tables in the database.

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -325,6 +325,16 @@ class Connection {
 		return $this->config['driver'];
 	}
 
+    /**
+     * Get an array of tables in the database.
+     *
+     * @return array of tables
+     */
+    public function tables()
+    {
+        return $this->grammar()->tables();
+    }
+
 	/**
 	 * Magic Method for dynamically beginning queries on database tables.
 	 */

--- a/laravel/database/query/grammars/grammar.php
+++ b/laravel/database/query/grammars/grammar.php
@@ -461,4 +461,13 @@ class Grammar extends \Laravel\Database\Grammar {
 		return trim($sql);
 	}
 
+    /**
+     * Generate an SQL statement for query tables
+     *
+     * @return string
+     */
+    public function tables() {
+        return array();
+    }
+
 }

--- a/laravel/database/query/grammars/mysql.php
+++ b/laravel/database/query/grammars/mysql.php
@@ -9,4 +9,26 @@ class MySQL extends Grammar {
 	 */
 	protected $wrapper = '`%s`';
 
+    /**
+     * Get an array of tables
+     *
+     * @return array
+     */
+    public function tables()
+    {
+        $tables = array();
+
+        if ($this->connection instanceof \Laravel\Database\Connection)
+        {
+            $sql = "SHOW TABLES FROM {$this->connection->config['database']}";
+            $results = $this->connection->pdo->query($sql)->fetchAll(\PDO::FETCH_BOTH);
+
+            array_walk($results, function($r) use (&$tables) {
+                $tables[] = $r[0];
+            });
+        }
+
+        return $tables;
+    }
+
 }

--- a/laravel/database/query/grammars/postgres.php
+++ b/laravel/database/query/grammars/postgres.php
@@ -17,4 +17,27 @@ class Postgres extends Grammar {
 		return $this->insert($query, $values)." RETURNING $column";
 	}
 
+    /**
+     * Get an array of tables
+     *
+     * @return array
+     */
+    public function tables()
+    {
+        $tables = array();
+
+        if ($this->connection instanceof \Laravel\Database\Connection)
+        {
+            $schema = isset($this->connection->config['schema']) ? $this->connection->config['schema'] : 'public';
+            $sql = "SELECT table_name AS name FROM INFORMATION_SCHEMA.tables WHERE table_schema = '{$schema}'";
+            $results = $this->connection->query($sql);
+
+            array_walk($results, function($r) use (&$tables) {
+                $tables[] = $r->name;
+            });
+        }
+
+        return $tables;
+    }
+
 }

--- a/laravel/database/query/grammars/sqlite.php
+++ b/laravel/database/query/grammars/sqlite.php
@@ -21,4 +21,26 @@ class SQLite extends Grammar
 		return 'ORDER BY '.implode(', ', $sql);
 	}
 
+    /**
+     * Get an array of tables
+     *
+     * @return array
+     */
+    public function tables()
+    {
+        $tables = array();
+
+        if ($this->connection instanceof \Laravel\Database\Connection)
+        {
+            $sql = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name";
+            $results = $this->connection->query($sql);
+
+            array_walk($results, function($r) use (&$tables) {
+                $tables[] = $r->name;
+            });
+        }
+
+        return $tables;
+    }
+
 }

--- a/laravel/database/query/grammars/sqlserver.php
+++ b/laravel/database/query/grammars/sqlserver.php
@@ -137,4 +137,26 @@ class SQLServer extends Grammar {
 		return '';
 	}
 
+    /**
+     * Get an array of tables
+     *
+     * @return array
+     */
+    public function tables()
+    {
+        $tables = array();
+
+        if ($this->connection instanceof \Laravel\Database\Connection)
+        {
+            $sql = "SELECT table_name AS name FROM INFORMATION_SCHEMA.tables";
+            $results = $this->connection->query($sql);
+
+            array_walk($results, function($r) use (&$tables) {
+                $tables[] = $r->name;
+            });
+        }
+
+        return $tables;
+    }
+
 }

--- a/laravel/documentation/database/raw.md
+++ b/laravel/documentation/database/raw.md
@@ -44,6 +44,16 @@ Laravel provides a few other methods to make querying your database simple. Here
 
 	$email = DB::only('select email from users where id = 1');
 
+#### Getting an array of tables in the database:
+
+    $tables = DB::tables();
+
+or
+
+	$tables = DB::connection('sqlite')->tables();
+
+> **Note:** If no connection name is specified, the **default** connection's database tables will be returned.
+
 <a name="pdo-connections"></a>
 ## PDO Connections
 


### PR DESCRIPTION
Signed-off-by: Rack Lin racklin@gmail.com
#### Getting an array of tables in the database:

```
$tables = DB::tables();
```

or

```
$tables = DB::connection('sqlite')->tables();
```

> **Note:** If no connection name is specified, the **default** connection's database tables will be returned.
