### PR TITLE
Adding proxy support to Artisan bundle installer

### DIFF
--- a/laravel/cli/tasks/bundle/providers/provider.php
+++ b/laravel/cli/tasks/bundle/providers/provider.php
@@ -1,6 +1,7 @@
 <?php namespace Laravel\CLI\Tasks\Bundle\Providers;
 
 use Laravel\File;
+use Laravel\Proxy;
 
 abstract class Provider {
 
@@ -66,7 +67,11 @@ abstract class Provider {
 	 */
 	protected function download($url)
 	{
-		$remote = file_get_contents($url);
+		// Get proxy information from the user's OS, use file_get_contents
+		// with the context created
+		$proxy = Proxy::http();
+
+		$remote = file_get_contents($url, false, $proxy);
 
 		// If we were unable to download the zip archive correctly
 		// we'll bomb out since we don't want to extract the last

--- a/laravel/cli/tasks/bundle/repository.php
+++ b/laravel/cli/tasks/bundle/repository.php
@@ -1,5 +1,7 @@
 <?php namespace Laravel\CLI\Tasks\Bundle;
 
+use Laravel\Proxy;
+
 class Repository {
 
 	/**
@@ -17,11 +19,14 @@ class Repository {
 	 */
 	public function get($bundle)
 	{
+		// Get proxy information from the user's OS, use file_get_contents
+		// with the context created
+		$proxy = Proxy::http();
 		// The Bundle API will return a JSON string that we can decode and
 		// pass back to the consumer. The decoded array will contain info
 		// regarding the bundle's provider and location, as well as all
 		// of the bundle's dependencies.
-		$bundle = @file_get_contents($this->api.$bundle);
+		$bundle = @file_get_contents($this->api.$bundle, false, $proxy);
 
 		return json_decode($bundle, true);
 	}

--- a/laravel/proxy.php
+++ b/laravel/proxy.php
@@ -1,0 +1,31 @@
+<?php namespace Laravel; defined('DS') or die('No direct script access.');
+
+class Proxy {
+
+    /**
+     * Get proxy parameters from the operating system and configure a context.
+     *
+     * @return resource
+     */
+    public static function http()
+    {
+        $proxy = getenv('http_proxy');
+
+        if (is_null($proxy) || $proxy == '') return null;
+
+        $url = parse_url($proxy);
+
+        $params = array(
+            'request_fulluri' => true,
+            'proxy' => "tcp://{$url['host']}:{$url['port']}"
+        );
+
+        if (isset($url['user']))
+        {
+            $auth = base64_encode($url['user'] . ':' . $url['pass']);
+            $params['header'] = "Proxy-Authorization: Basic {$auth}";
+        }
+
+        return stream_context_create(array('http' => $params));
+    }
+}


### PR DESCRIPTION
Adding support to http_proxy in artisan bundle installer. The implementation will look for a env variable http_proxy, and configure a context to be used in the file_get_contents function calls. The class Laravel\Proxy can be used in other places where http proxy may be needed. This change is a proposal to fix the issue: https://github.com/laravel/laravel/issues/726
Signed-off-by: Fernando Mantoan contato@fernandomantoan.com
