### PR TITLE
Removes status parameter for Response::view() in documentation section "Views & Responses"

### DIFF
--- a/laravel/documentation/views/home.md
+++ b/laravel/documentation/views/home.md
@@ -56,7 +56,7 @@ Sometimes you will need a little more control over the response sent to the brow
 
 #### Returning a custom response containing a view:
 
-	return Response::view('home', 200, $headers);
+	return Response::view('home', $headers);
 
 #### Returning a JSON response:
 


### PR DESCRIPTION
Documentation states that "return Response::view('home', 200, $headers);" but Response::view() does not take a status code as the second parameter.
