### PR TITLE
Artisan route task was ignoring the specified route

### DIFF
--- a/laravel/cli/tasks/route.php
+++ b/laravel/cli/tasks/route.php
@@ -14,7 +14,7 @@ class Route extends Task {
 	 */
 	public function call($arguments = array())
 	{
-		if ( ! count($arguments) == 2)
+		if ( count($arguments) != 2)
 		{
 			throw new \Exception("Please specify a request method and URI.");
 		}
@@ -41,7 +41,7 @@ class Route extends Task {
 		// We'll call the router using the method and URI specified by
 		// the developer on the CLI. If a route is found, we will not
 		// run the filters, but simply dump the result.
-		$route = Router::route(Request::method(), URI::current());
+		$route = Router::route(Request::method(), $_SERVER['REQUEST_URI']);
 
 		if ( ! is_null($route))
 		{


### PR DESCRIPTION
In the `call()` method, the exception wasn't being thrown if only 1 or more than 2 arguments were passed to the method. Fixed conditional statement to only accept exactly 2 arguments.

In the `route()` method, `URI::current()` was evaluating as '/' in all situations. It was never evaluating as the route that you specified when executing the command. This could be part of a larger underlying bug with Symfony's `HttpFoundation\Request` class. It might be a band-aid fix, but replacing `URI::current()` with `$_SERVER['REQUEST_URI']` allows the method to run the correct route.

These fixes uncovered what I believe is potentially another bug. When `var_dump($route->response())` is run, "NULL" and a newline is appended to the output. It's something to do with `var_dump()`, as echo `$route->response()` echo's the correct output without the extra "NULL".

Signed-off-by: Jakobud jake.e.wilson@gmail.com
