### PR TITLE
Allow bundles to respond to root requests.

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -191,7 +191,7 @@ class Bundle {
 
 		foreach (static::$bundles as $key => $value)
 		{
-			if (isset($value['handles']) and starts_with($uri, $value['handles'].'/'))
+			if (isset($value['handles']) and starts_with($uri, $value['handles'].'/') or $value['handles'] == '/')
 			{
 				return $key;
 			}

--- a/laravel/routing/router.php
+++ b/laravel/routing/router.php
@@ -206,7 +206,12 @@ class Router {
 				continue;
 			}
 
-			$uri = str_replace('(:bundle)', static::$bundle, $uri);
+			$uri = ltrim(str_replace('(:bundle)', static::$bundle, $uri), '/');
+			
+			if($uri == '')
+			{
+				$uri = '/';
+			}
 
 			// If the URI begins with a wildcard, we want to add this route to the
 			// array of "fallback" routes. Fallback routes are always processed


### PR DESCRIPTION
Just as the title says. This allows bundles to be registered to respond to root requests.

```
return array(
    'bundle' => array(
        'handles' => '/'
    )
);
```

If others could test this and let me know if it is working good for them that'd be great. I've tested it a bit on a bundle I'm working on and it seems to be working.

Note that named routes that are used with things such as `URL::to_route()`, etc, are adjusted accordingly. This means you can still use the `(:bundle)` placeholder in your routes.

First discussed in #876.

Signed-off-by: Jason Lewis jason.lewis1991@gmail.com
