### PR TITLE
Added a prefilled stub for migrations

### DIFF
--- a/laravel/cli/tasks/migrate/migrator.php
+++ b/laravel/cli/tasks/migrate/migrator.php
@@ -184,6 +184,7 @@ class Migrator extends Task {
 		}
 
 		list($bundle, $migration) = Bundle::parse($arguments[0]);
+		$table = array_get($arguments, 1);
 
 		// The migration path is prefixed with the date timestamp, which
 		// is a better way of ordering migrations than a simple integer
@@ -200,7 +201,7 @@ class Migrator extends Task {
 
 		$file = $path.$prefix.'_'.$migration.EXT;
 
-		File::put($file, $this->stub($bundle, $migration));
+		File::put($file, $this->stub($bundle, $migration, $table));
 
 		echo "Great! New migration created!";
 
@@ -217,9 +218,14 @@ class Migrator extends Task {
 	 * @param  string  $migration
 	 * @return string
 	 */
-	protected function stub($bundle, $migration)
+	protected function stub($bundle, $migration, $table = null)
 	{
-		$stub = File::get(path('sys').'cli/tasks/migrate/stub'.EXT);
+		$stub = $table
+			? File::get(path('sys').'cli/tasks/migrate/stub_scaffold'.EXT)
+			: File::get(path('sys').'cli/tasks/migrate/stub'.EXT);
+
+		// Replace the table name
+		if($table) $stub = str_replace('{{table}}', $table, $stub);
 
 		$prefix = Bundle::class_prefix($bundle);
 

--- a/laravel/cli/tasks/migrate/stub_scaffold.php
+++ b/laravel/cli/tasks/migrate/stub_scaffold.php
@@ -1,0 +1,28 @@
+<?php
+
+class {{class}} {
+
+  /**
+   * Make changes to the database.
+   *
+   * @return void
+   */
+  public function up()
+  {
+    Schema::create('{{table}}', function($table)
+    {
+      $table->increments('id');
+    });
+  }
+
+  /**
+   * Revert the changes to the database.
+   *
+   * @return void
+   */
+  public function down()
+  {
+    Schema::drop('{{table}}');
+  }
+
+}


### PR DESCRIPTION
I have created a lot of migrations since I started using Laravel, and over the time, **nearly 100% of them looked like this** :

``` php
<?php
class {{class}}
{
  /**
   * Make changes to the database.
   *
   * @return void
   */
  public function up()
  {
    Schema::create('{{table}}', function($table)
    {
      $table->increments('id');
      // More fields
    });
  }

  /**
   * Revert the changes to the database.
   *
   * @return void
   */
  public function down()
  {
    Schema::drop('{{table}}');
  }
}
```

So that's pretty much what this pull request does : it allows you to do `artisan migrate:make create_users users` where `create_users` is the migration name and `users` is the table name.
I wonder if some sort of shortcut might in some way be created, allowing the migration name to be determined by the table's name (ie. users -> create_users, etc.) which pretty much seems to be the convention anyway.

I really think Laravel should merge Bob, as all the scaffolding options it offers not only put Laravel on the level of Rails's `scaffold`, but it would really help newcomers a lot when trying to create new controllers, models, migrations etc. It offers a solid base convention on which they can learn and bootstrap. 
Well that's just my opinion anyway. 
