### PR TITLE
Removes status parameter for Response::view() in documentation section "Views & Responses"

### DIFF
--- a/laravel/documentation/views/home.md
+++ b/laravel/documentation/views/home.md
@@ -56,8 +56,7 @@ Sometimes you will need a little more control over the response sent to the brow
 
 #### Returning a custom response containing a view, with binding data:
 
-	$data = array('foo' => 'bar');
-	return Response::view('home', $data);
+	return Response::view('home', array('foo' => 'bar'));
 
 #### Returning a JSON response:
 


### PR DESCRIPTION
Documentation states that "return Response::view('home', 200, $headers);" can return a custom response with a view, a state code, and headers, but Response::view() does not take a status code as the second parameter, and the third parameter is actually the view binding data.
