### PR TITLE
type boolean is tinyint(1)

### DIFF
--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -383,7 +383,7 @@ class MySQL extends Grammar {
 	 */
 	protected function type_boolean(Fluent $column)
 	{
-		return 'TINYINT';
+		return 'TINYINT(1)';
 	}
 
 	/**


### PR DESCRIPTION
switched from default "tinyint" which creates a tinyint(4) to the
standard mysql boolean type "tinyint(1)"
