### PR TITLE
Add simple array item removal support to array_forget

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -150,7 +150,8 @@ function array_forget(&$array, $key)
 	{
 		$array = array_diff($array, $keys);
 	}
-	else {
+	else
+	{
 		// This loop functions very similarly to the loop in the "set" method.
 		// We will iterate over the keys, setting the array value to the new
 		// depth at each iteration. Once there is only one key left, we will


### PR DESCRIPTION
This is a small push. Right now, `array_forget` will only remove items using dot notation, like:

``` php
$array = array(
  'name' => array(
    'first' => 'Joe',
    'last' => 'Johnson'
  )
);

array_forget($array, 'name.last');
```

But, it would also be nice if you could simply remove single items from a simple array too - just for convenience. Like this:

``` php
$array = array('joe', 'bob', 'jane', 'jack');
array_forget($array, 'jane'); // joe, bob, jack
```

Currently, you can't, but this commit allows for that.

Signed-off-by: Jeffrey Way jeffrey@envato.com
