### PR TITLE
Simplify extending the database session driver

### DIFF
--- a/laravel/session/drivers/database.php
+++ b/laravel/session/drivers/database.php
@@ -10,7 +10,7 @@ class Database extends Driver implements Sweeper {
 	 *
 	 * @var Connection
 	 */
-	private $connection;
+	protected $connection;
 
 	/**
 	 * Create a new database session driver.


### PR DESCRIPTION
The database connection instance was `private`, not `protected` (which is used almost anywhere else - any reason for `private` being used here?), thus making it not available in subclasses of the database session driver.
