### PR TITLE
Fix pull request #879

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -728,7 +728,7 @@ abstract class Model {
 			if (array_key_exists($key, $this->$source)) return !empty($this->{$source}[$key]);
 		}
 		
-		if (method_exists($this, $key)) return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This simplifies my code from pull request #879 - it makes sense to use `isset()` when implementing `isset()`.

Small bug fix:
This also makes sure that we don't accidentally return false if a key is set in the relationships array that exists in the attributes array too (but with value NULL).
