### PR TITLE
Allow View file extensions to be dynamicly configured

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -43,6 +43,7 @@ class Blade {
 	 */
 	public static function sharpen()
 	{
+		View::$extensions[] = BLADE_EXT;
 		Event::listen(View::engine, function($view)
 		{
 			// The Blade view engine should only handle the rendering of views which

--- a/laravel/view.php
+++ b/laravel/view.php
@@ -38,6 +38,13 @@ class View implements ArrayAccess {
 	public static $names = array();
 
 	/**
+	 * All of the registered file extensions.
+	 *
+	 * @var array
+	 */
+	public static $extensions = array(EXT);
+
+	/**
 	 * The cache content of loaded view files.
 	 *
 	 * @var array
@@ -171,13 +178,12 @@ class View implements ArrayAccess {
 		// Views may have either the default PHP file extension or the "Blade"
 		// extension, so we will need to check for both in the view path
 		// and return the first one we find for the given view.
-		if (file_exists($path = $directory.$view.EXT))
+		foreach(static::$extensions as $ext)
 		{
-			return $path;
-		}
-		elseif (file_exists($path = $directory.$view.BLADE_EXT))
-		{
-			return $path;
+			if (file_exists($path = $directory.$view.$ext))
+			{
+				return $path;
+			}
 		}
 	}
 


### PR DESCRIPTION
Doing this would make integrating additional parsers into laravel extremely easy, take this as a simple example:

```
define('MD_EXT', '.md');
View::$extensions[] = MD_EXT;
Event::listen(View::engine, function($view)
{
    if ( ! str_contains($view->path, MD_EXT))
    {
        return;
    }
    dd('YAY markdown! ' . $view->path);
});


Route::get('/', function()
{
    return View::make('home.test');  // would load a file named home/test.md
});
```

Signed-off-by: William Cahill-Manley william@cahillmanley.com
