### PR TITLE
[Session] Trigger garbage collection (sweep) manually

### DIFF
--- a/laravel/session/payload.php
+++ b/laravel/session/payload.php
@@ -298,13 +298,29 @@ class Payload {
 		$this->cookie($config);
 
 		// Some session drivers implement the Sweeper interface meaning that
-		// they must clean up expired sessions manually. If the driver is a
-		// sweeper, we'll calculate if we need to run garbage collection.
+		// they must clean up expired sessions manually. Here we'll calculate
+		// if we need to run garbage collection.
 		$sweepage = $config['sweepage'];
 
-		if ($this->driver instanceof Sweeper and (mt_rand(1, $sweepage[1]) <= $sweepage[0]))
+		if (mt_rand(1, $sweepage[1]) <= $sweepage[0])
 		{
-			$this->driver->sweep(time() - ($config['lifetime'] * 60));
+			$this->sweep();
+		}
+	}
+
+	/**
+	 * Clean up expired sessions.
+	 *
+	 * If the session driver is a sweeper, it must clean up expired sessions
+	 * from time to time. This method triggers garbage collection.
+	 * 
+	 * @return void
+	 */
+	public function sweep()
+	{
+		if ($this->driver instanceof Sweeper)
+		{
+			$this->driver->sweep(time() - (Config::get('session.lifetime') * 60));
 		}
 	}
 


### PR DESCRIPTION
I extracted a public method `sweep()` in the Session payload class.

This allows for manually triggering garbage collection in session drivers.
