### PR TITLE
Handle empty arrays in where_in() gracefully

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -297,6 +297,21 @@ class Query {
 	 */
 	public function where_in($column, $values, $connector = 'AND', $not = false)
 	{
+		// Handle an empty value list
+		if (empty($values))
+		{
+			// "NOT IN ()" will cause the WHERE clause to match all rows
+			if ($not)
+			{
+				return $this->raw_where('1 = 1', array(), $connector);
+			}
+			// "IN ()" will cause the WHERE clause to match no rows
+			else
+			{
+				return $this->raw_where('1 != 1', array(), $connector);
+			}
+		}
+
 		$type = ($not) ? 'where_not_in' : 'where_in';
 
 		$this->wheres[] = compact('type', 'column', 'values', 'connector');


### PR DESCRIPTION
BAM! This finally fixes #638.

This makes sure that empty arrays passed to where_in() return an empty result set (empty array for SELECT queries, `0` for UPDATE and DELETE).

I believe this is the kind of graceful handling of empty arrays we should have for empty arrays in IN clauses.

---

Regarding #638: there is a difference in how to handle `WHERE IN` and `WHERE NOT IN`. Doing the latter with an empty array obviously means that the condition doesn't exclude any rows, thus it is ignored.
