### PR TITLE
Fixed Exception thrown when passing null $value to Form::submit(), Form::reset(), Form::button()

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -526,7 +526,7 @@ class Form {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function submit($value, $attributes = array())
+	public static function submit($value = null, $attributes = array())
 	{
 		return static::input('submit', null, $value, $attributes);
 	}
@@ -538,7 +538,7 @@ class Form {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function reset($value, $attributes = array())
+	public static function reset($value = null, $attributes = array())
 	{
 		return static::input('reset', null, $value, $attributes);
 	}
@@ -570,7 +570,7 @@ class Form {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	public static function button($value, $attributes = array())
+	public static function button($value = null, $attributes = array())
 	{
 		return '<button'.HTML::attributes($attributes).'>'.HTML::entities($value).'</button>';
 	}


### PR DESCRIPTION
Passing a null $value to Form::submit(), Form::reset() or Form::button() was throwing an Exception. I made the default $value = null for those methods. They result in the following respective valid HTML: <input type='submit'/> <input type='reset'/> <button></button>

Signed-off-by: Jakobud jake.e.wilson@gmail.com
