### PR TITLE
Update file path to home/index view in the default home/index.blade.php.

### DIFF
--- a/application/views/home/index.blade.php
+++ b/application/views/home/index.blade.php
@@ -29,7 +29,7 @@
 
 				<p>And the view sitting before you can be found at:</p>
 
-				<pre>{{ path('app') }}views/home/index.php</pre>
+				<pre>{{ path('app') }}views/home/index.blade.php</pre>
 
 				<h2>Grow in knowledge.</h2>
 


### PR DESCRIPTION
Small fix. The path displayed in the `home/index.blade.php` that's supposed to point to itself still points to the old `index.php`.

Signed-off-by: Johnson Page jwpage@gmail.com
