### PR TITLE
Fix nested wheres (and modify eager loading constraints)

### DIFF
--- a/laravel/database/eloquent/query.php
+++ b/laravel/database/eloquent/query.php
@@ -166,11 +166,6 @@ class Query {
 
 		$query->model->includes = $this->nested_includes($relationship);
 
-		// We'll remove any of the where clauses from the relationship to give
-		// the relationship the opportunity to set the constraints for an
-		// eager relationship using a separate, specific method.
-		$query->table->reset_where();
-
 		// Constraints may be specified in-line for the eager load by passing
 		// a Closure as the value portion of the eager load.
 		$query->eagerly_constrain($results, $constraints);

--- a/laravel/database/eloquent/relationships/has_one_or_many.php
+++ b/laravel/database/eloquent/relationships/has_one_or_many.php
@@ -55,6 +55,10 @@ class Has_One_Or_Many extends Relationship {
 	 */
 	public function eagerly_constrain($results, Closure $constraints = null)
 	{
+		// We'll remove any constraints from the relationship if we have
+		// custom constraints specified on this eager load.
+		if ( ! is_null($constraints)) $this->table->reset();
+
 		$this->table->where_in($this->foreign_key(), $this->keys($results));
 
 		if ( ! is_null($constraints))

--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -196,6 +196,24 @@ class Query {
 	}
 
 	/**
+	 * Reset all constraints to their initial state.
+	 * 
+	 * @return void
+	 */
+	public function reset()
+	{
+		// Reset fields to null
+		foreach (array('selects', 'aggregate', 'joins', 'wheres', 'groupings', 'havings', 'orderings', 'limit', 'offset') as $field)
+		{
+			$this->$field = null;
+		}
+
+		// Reset other fields
+		$this->distinct = false;
+		$this->bindings = array();
+	}
+
+	/**
 	 * Reset the where clause to its initial state.
 	 *
 	 * @return void


### PR DESCRIPTION
This fixes my previous commit, which broke nested wheres.

Eager loading allows for setting all constraints now, but only resets constraints (all, not only WHERE clauses) if we have custom constraints set via a Closure.

Please review carefully!

---

P.S.: One could argue whether a change like the second commit should be done in small releases (then again, the next one won't be small anymore), but I'd say the feature is probably very rarely used, so that this should be fine.
