### PR TITLE
[Eloquent] Don't use hard-coded primary key column

### DIFF
--- a/laravel/database/eloquent/query.php
+++ b/laravel/database/eloquent/query.php
@@ -51,6 +51,18 @@ class Query {
 	}
 
 	/**
+	 * Find a record by the primary key.
+	 *
+	 * @param  int     $id
+	 * @param  array   $columns
+	 * @return object
+	 */
+	public function find($id, $columns = array('*'))
+	{
+		return $this->where($this->model->key(), '=', $id)->first($columns);
+	}
+
+	/**
 	 * Get the first model result for the query.
 	 *
 	 * @param  array  $columns
@@ -93,6 +105,18 @@ class Query {
 		$paginator->results = $this->hydrate($this->model, $paginator->results);
 
 		return $paginator;
+	}
+
+	/**
+	 * Insert an array of values into the database table and return the ID.
+	 *
+	 * @param  array   $values
+	 * @param  string  $column
+	 * @return int
+	 */
+	public function insert_get_id($values, $column = 'id')
+	{
+		return $this->table->insert_get_id($values, $this->model->key());
 	}
 
 	/**


### PR DESCRIPTION
In two small cases, the ID was still hard-coded in the Fluent class.

This was leading to problems, as Eloquent makes use of the Fluent class, but wasn't "overwriting" these methods.

@taylorotwell While we're at it: could you explain why you chose this weird construct using `__call()` to pass methods to the normal database query (Fluent) class instead of simply extending the Fluent query class for Eloquent queries?
