### PR TITLE
Calling Eloquent::table() statically gives unexpected results

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -517,7 +517,7 @@ abstract class Model {
 	 *
 	 * @return string
 	 */
-	public function table()
+	public function _table()
 	{
 		return static::$table ?: strtolower(Str::plural(class_basename($this)));
 	}
@@ -751,7 +751,7 @@ abstract class Model {
 	 */
 	public function __call($method, $parameters)
 	{
-		$meta = array('key', 'table', 'connection', 'sequence', 'per_page', 'timestamps');
+		$meta = array('key', 'connection', 'sequence', 'per_page', 'timestamps');
 
 		// If the method is actually the name of a static property on the model, we'll
 		// return the value of the static property. This makes it convenient for
@@ -761,7 +761,7 @@ abstract class Model {
 			return static::$$method;
 		}
 
-		$underscored = array('with', 'find');
+		$underscored = array('with', 'find', 'table');
 
 		// Some methods need to be accessed both statically and non-statically so we'll
 		// keep underscored methods of those methods and intercept calls to them


### PR DESCRIPTION
PHP has a quirk (at least the versions I tested with, 5.3.10 and 5.3.13) that when an instance method is called statically, it will not be routed through `__callStatic` first. Vice versa is also true, but not a problem in this case.

Thus, calling `EloquentModel::table()` calls the instance method normally, which results in static calls and class determination being made to the class which called the method statically.

This is (hopefully) a bug in PHP, but converting `table()` to be a static method fixes the problem.

Note that the change in `__call` is likely to not make any difference, as PHP does never actually get there. This may be different on other versions of PHP.

---

PHP test script:

``` php
<?php

class Model
{
    public static function static_method()
    {
        echo get_called_class(), PHP_EOL;
        echo __FUNCTION__, PHP_EOL;
    }

    public function instance_method()
    {
        echo get_class($this), PHP_EOL;
        echo __FUNCTION__, PHP_EOL;
    }

    public function __call($method, $parameters)
    {
        echo __FUNCTION__, PHP_EOL;
    }

    public static function __callStatic($method, $parameters)
    {
        echo __FUNCTION__, PHP_EOL;
    }
}

class Context
{
    public function call()
    {
        $model = new Model();
        $model->static_method();

        echo PHP_EOL;

        Model::instance_method();

        echo PHP_EOL, PHP_EOL;
    }
}

Context::call();

$context = new Context();
$context->call();
```

outputs:

```
Model
static_method

Model
instance_method


Model
static_method

Context
instance_method
```

As you can see, calling the instance method from an instance yields the wrong results.
