### PR TITLE
Input documentation fix.

### DIFF
--- a/laravel/documentation/input.md
+++ b/laravel/documentation/input.md
@@ -145,4 +145,4 @@ Sometimes you may wish to merge or replace the current input. Here's how:
 
 #### Replacing the entire input array with new data:
 
-	Input::merge(array('doctor' => 'Bones', 'captain' => 'Kirk'));
+	Input::replace(array('doctor' => 'Bones', 'captain' => 'Kirk'));


### PR DESCRIPTION
Documentation says "Replacing the entire input" but calls Input::merge()
instead of Input::replace().

Signed-off-by: Spencer Deinum spencerdeinum@gmail.com
