### PR TITLE
Fixing a bug with saving data to pivot table

### DIFF
--- a/laravel/database/eloquent/pivot.php
+++ b/laravel/database/eloquent/pivot.php
@@ -26,7 +26,7 @@ class Pivot extends Model {
 	public function __construct($table, $connection = null)
 	{
 		$this->pivot_table = $table;
-		$this->connection = $connection;
+		static::$connection = $connection;
 
 		parent::__construct(array(), true);
 	}
@@ -39,16 +39,6 @@ class Pivot extends Model {
 	public function table()
 	{
 		return $this->pivot_table;
-	}
-
-	/**
-	 * Get the connection used by the pivot table.
-	 *
-	 * @return string
-	 */
-	public function connection()
-	{
-		return $this->connection;
 	}
 
 }


### PR DESCRIPTION
Right now, doing this:

```
$user = $role->users()->where_user_id($user_id)->first();
$user->pivot->status = 'A';
$user->pivot->save();
```

results in this:

```
Unhandled Exception
Message:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'connection' in 'field list'

SQL: UPDATE `user_venue` SET `connection` = ?, `updated_at` = ?, `instructor_type` = ? WHERE `id` = ?

Bindings: array (
  0 => NULL,
  1 => '2012-06-03 15:26:28',
  2 => 'MAIN',
  3 => '135',
)
```

This pull fixes that by using the Pivot class's inherited **static** `connection`. (Previously, assigning `$this->connection = $connection;` was causing connection to be inserted into the model's attributes by the Model class's magic method.

Does that make sense? Anyway, this fixes that.
