### PR TITLE
Changing CSRF failure error code to 403.

### DIFF
--- a/application/routes.php
+++ b/application/routes.php
@@ -102,7 +102,7 @@ Route::filter('after', function($response)
 
 Route::filter('csrf', function()
 {
-	if (Request::forged()) return Response::error('500');
+	if (Request::forged()) return Response::error('403');
 });
 
 Route::filter('auth', function()


### PR DESCRIPTION
Previously, the error code returned in application/routes.php
on a forged request/CSRF failure returned a 500 error. A 500
indicates a fatal PHP error or a server error, not what is
actually happening.

A 403 error makes more sense in this situation.
