### PR TITLE
Using wildcard without closure and using (:1)...

### DIFF
--- a/laravel/documentation/routing.md
+++ b/laravel/documentation/routing.md
@@ -84,7 +84,9 @@ In the following example the first parameter is the route that you're "registeri
 	{
 		//
 	});
+#### Using wildcard without closure:
 
+	Route::get('page/(:any)/(:any)', '(:1)@(:2)');
 <a name="the-404-event"></a>
 ## The 404 Event
 


### PR DESCRIPTION
adding a small change to explain (:1) and using wildcard without closure
this is enough to understant it all and use it.

```
#### Using wildcard without closure:

    Route::get('page/(:any)/(:any)', '(:1)@(:2)');
```

https://github.com/laravel/laravel/issues/1085#issuecomment-7666214
