### PR TITLE
Fix Query::lists() for empty resultsets

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -605,7 +605,7 @@ class Query {
 		// set the keys on the array of values using the array_combine
 		// function provided by PHP, which should give us the proper
 		// array form to return from the method.
-		if ( ! is_null($key))
+		if ( ! is_null($key) && count($results))
 		{
 			return array_combine(array_map(function($row) use ($key)
 			{


### PR DESCRIPTION
`array_combine()` doesn't work with empty arrays, so this patch just prevents it from being called when there are no rows to call it on.

Test case:

```
$results = DB::table('users')->where_id(0)->lists('email', 'id');
```
