### PR TITLE
[Docs] Fix contribution page links

### DIFF
--- a/laravel/documentation/contents.md
+++ b/laravel/documentation/contents.md
@@ -113,6 +113,6 @@
 
 ### Contributing
 
-- [Laravel on GitHub](docs/contrib/github)
-- [Command Line](docs/contrib/command-line)
-- [TortoiseGit](docs/contrib/tortoisegit)
+- [Laravel on GitHub](/docs/contrib/github)
+- [Command Line](/docs/contrib/command-line)
+- [TortoiseGit](/docs/contrib/tortoisegit)


### PR DESCRIPTION
These only worked when in the root directory of the docs, as the links were relative and didn't have a slash at the beginning.
