### PR TITLE
Fixed various URLs in the Contribution docs.

### DIFF
--- a/laravel/documentation/contents.md
+++ b/laravel/documentation/contents.md
@@ -113,6 +113,6 @@
 
 ### Contributing
 
-- [Laravel on GitHub](docs/contrib/github)
-- [Command Line](docs/contrib/command-line)
-- [TortoiseGit](docs/contrib/tortoisegit)
+- [Laravel on GitHub](/docs/contrib/github)
+- [Command Line](/docs/contrib/command-line)
+- [TortoiseGit](/docs/contrib/tortoisegit)

--- a/laravel/documentation/contrib/github.md
+++ b/laravel/documentation/contrib/github.md
@@ -31,5 +31,5 @@ Once certain milestones have been reached and/or Taylor Otwell and the Laravel t
 
 *Further Reading*
 
- - [Contributing to Laravel via Command-Line](docs/contrib/command-line)
- - [Contributing to Laravel using TortoiseGit](docs/contrib/tortoisegit)
+ - [Contributing to Laravel via Command-Line](/docs/contrib/command-line)
+ - [Contributing to Laravel using TortoiseGit](/docs/contrib/tortoisegit)


### PR DESCRIPTION
A few of the URLs in the contribution docs were incorrect.  This fixes them.

Signed-off-by: Jakobud <jakobud+github@gmail.com>
