### PR TITLE
Added application-key generator url to application key comments

### DIFF
--- a/application/config/application.php
+++ b/application/config/application.php
@@ -51,6 +51,10 @@ return array(
 	| remains secret and it should not be shared with anyone. Make it about 32
 	| characters of random gibberish.
 	|
+	| You can generate a random application key by visiting:
+	|
+	| 	http://laravel.com/application-key
+	|
 	*/
 
 	'key' => 'YourSecretKeyGoesHere!',


### PR DESCRIPTION
This adds some text to the application key comments. It notifies the developer that they can visit the following url http://laravel.com/application-key in order to quickly and easily generate a 32 character random string they can copy/paste as their application key.

At the time of submitting this pull request, the above URL does not exist. I have submitted a pull request to add this route (and it's functionality) to the laravel.com repository.

This particular pull request should not be accepted until the pull request for laravel.com is accepted, since, obviously the URL will give a 404 until then.

Please reference the following pull request for the laravel.com repository:

https://github.com/laravel/laravel.com/pull/18

Signed-off-by: Jakobud <jakobud+github@gmail.com>
