### PR TITLE
Change some Markdown to fit other md files' format.

### DIFF
--- a/laravel/documentation/contrib/command-line.md
+++ b/laravel/documentation/contrib/command-line.md
@@ -1,28 +1,29 @@
 # Contributing to Laravel via Command-Line
 
 ## Contents
- - [Getting Started](#getting-started)
- - [Forking Laravel](#forking-laravel)
- - [Cloning Laravel](#cloning-laravel)
- - [Adding your Fork](#adding-your-fork)
- - [Creating Branches](#creating-branches)
- - [Committing](#committing)
- - [Submitting a Pull Request](#submitting-a-pull-request)
- - [What's Next?](#whats-next)
 
-<a name='getting-started'></a>
+- [Getting Started](#getting-started)
+- [Forking Laravel](#forking-laravel)
+- [Cloning Laravel](#cloning-laravel)
+- [Adding your Fork](#adding-your-fork)
+- [Creating Branches](#creating-branches)
+- [Committing](#committing)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [What's Next?](#whats-next)
+
+<a name="getting-started"></a>
 ## Getting Started
 
 This tutorial explains the basics of contributing to a project on [GitHub](https://github.com/) via the command-line. The workflow can apply to most projects on GitHub, but in this case, we will be focused on the [Laravel](https://github.com/laravel/laravel) project. This tutorial is applicable to OSX, Linux and Windows.
 
 This tutorial assumes you have installed [Git](http://git-scm.com/) and you have created a [GitHub account](https://github.com/signup/free). If you haven't already, look at the [Laravel on GitHub](/docs/contrib/github) documentation in order to familiarize yourself with Laravel's repositories and branches.
 
-<a name='forking-laravel'></a>
+<a name="forking-laravel"></a>
 ## Forking Laravel
 
 Login to GitHub and visit the [Laravel Repository](https://github.com/laravel/laravel). Click on the **Fork** button. This will create your own fork of Laravel in your own GitHub account. Your Laravel fork will be located at **https://github.com/username/laravel** (your GitHub username will be used in place of *username*).
 
-<a name='cloning-laravel'></a>
+<a name="cloning-laravel"></a>
 ## Cloning Laravel
 
 Open up the command-line or terminal and make a new directory where you can make development changes to Laravel:
@@ -36,7 +37,7 @@ Next, clone the Laravel repository (not your fork you made):
 
 > **Note**: The reason you are cloning the original Laravel repository (and not the fork you made) is so you can always pull down the most recent changes from the Laravel repository to your local repository.
 
-<a name='adding-your-fork'></a>
+<a name="adding-your-fork"></a>
 ## Adding your Fork
 
 Next, it's time to add the fork you made as a **remote repository**:
@@ -49,7 +50,7 @@ Remember to replace *username** with your GitHub username. *This is case-sensiti
 
 Now you have a pristine clone of the Laravel repository along with your fork as a remote repository. You are ready to begin branching for new features or fixing bugs.
 
-<a name='creating-branches'></a>
+<a name="creating-branches"></a>
 ## Creating Branches
 
 First, make sure you are working in the **develop** branch. If you submit changes to the **master** branch, it is unlikely they will be pulled in anytime in the near future. For more information on this, read the documentation for [Laravel on GitHub](/docs/contrib/github). To switch to the develop branch:
@@ -76,7 +77,7 @@ Or if there is a new feature to add or change to the documentation that you want
 
 Now that you have created your own branch and have switched to it, it's time to make your changes to the code. Add your new feature or fix that bug.
 
-<a name='committing'></a>
+<a name="committing"></a>
 ## Committing
 
 Now that you have finished coding and testing your changes, it's time to commit them to your local repository. First, add the files that you changed/added:
@@ -87,10 +88,10 @@ Next, commit the changes to the repository:
 
 	# git commit -s -m "I added some more stuff to the Localization documentation."
 
- - **-s** means that you are signing-off on your commit with your name. This tells the Laravel team know that you personally agree to your code being added to the Laravel core.
- - **-m** is the message that goes with your commit. Provide a brief explanation of what you added or changed.
+"- **-s** means that you are signing-off on your commit with your name. This tells the Laravel team know that you personally agree to your code being added to the Laravel core.
+"- **-m** is the message that goes with your commit. Provide a brief explanation of what you added or changed.
 
-<a name='pushing-to-your-fork'></a>
+<a name="pushing-to-your-fork"></a>
 ## Pushing to your Fork
 
 Now that your local repository has your committed changes, it's time to push (or sync) your new branch to your fork that is hosted in GitHub:
@@ -99,19 +100,19 @@ Now that your local repository has your committed changes, it's time to push (or
 
 Your branch has been successfully pushed to your fork on GitHub.
 
-<a name='submitting-a-pull-request'></a>
+<a name="submitting-a-pull-request"></a>
 ## Submitting a Pull Request
 
 The final step is to submit a pull request to the Laravel repository. This means that you are requesting that the Laravel team pull and merge your changes to the Laravel core. In your browser, visit your Laravel fork at [https://github.com/username/laravel](https://github.com/username/laravel). Click on **Pull Request**. Next, make sure you choose the proper base and head repositories and branches:
 
- - **base repo:** laravel/laravel
- - **base branch:** develop
- - **head repo:** username/laravel
- - **head branch:** feature/localization-docs
+- **base repo:** laravel/laravel
+- **base branch:** develop
+- **head repo:** username/laravel
+- **head branch:** feature/localization-docs
 
 Use the form to write a more detailed description of the changes you made and why you made them. Finally, click **Send pull request**. That's it! The changes you made have been submitted to the Laravel team.
 
-<a name='whats-next'></a>
+<a name="whats-next"></a>
 ## What's Next?
 
 Do you have another feature you want to add or another bug you need to fix? First, make sure you always base your new branch off of the develop branch:

--- a/laravel/documentation/contrib/github.md
+++ b/laravel/documentation/contrib/github.md
@@ -6,19 +6,19 @@
 - [Repositories](#repositoriess)
 - [Branches](#branches)
 
-<a name='the-basics'></a>
+<a name="the-basics"></a>
 ## The Basics
 
 Because Laravel's development and source control is done through GitHub, anyone is able to make contributions to it. Anyone can fix bugs, add features or improve the documentation.
 
 After submitting proposed changes to the project, the Laravel team will review the changes and make the decision to commit them to Laravel's core.
 
-<a name='repositories'></a>
+<a name="repositories"></a>
 ## Repositories
 
 Laravel's home on GitHub is at [github.com/laravel](https://github.com/laravel). Laravel has several repositories. For basic contributions, the only repository you need to pay attention to is the **laravel** repository, located at [github.com/laravel/laravel](https://github.com/laravel/laravel).
 
-<a name='branches'></a>
+<a name="branches"></a>
 ## Branches
 
 The **laravel** repository has multiple branches, each serving a specific purpose:

--- a/laravel/documentation/contrib/tortoisegit.md
+++ b/laravel/documentation/contrib/tortoisegit.md
@@ -1,47 +1,48 @@
 # Contributing to Laravel using TortoiseGit
 
 ## Contents
- - [Getting Started](#getting-started)
- - [Forking Laravel](#forking-laravel)
- - [Cloning Laravel](#cloning-laravel)
- - [Adding your Fork](#adding-your-fork)
- - [Creating Branches](#creating-branches)
- - [Committing](#committing)
- - [Submitting a Pull Request](#submitting-a-pull-request)
- - [What's Next?](#whats-next)
 
-<a name='getting-started'></a>
+- [Getting Started](#getting-started)
+- [Forking Laravel](#forking-laravel)
+- [Cloning Laravel](#cloning-laravel)
+- [Adding your Fork](#adding-your-fork)
+- [Creating Branches](#creating-branches)
+- [Committing](#committing)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+- [What's Next?](#whats-next)
+
+<a name="getting-started"></a>
 ## Getting Started
 
 This tutorial explains the basics of contributing to a project on [GitHub](https://github.com/) using [TortoiseGit](http://code.google.com/p/tortoisegit/) for Windows. The workflow can apply to most projects on GitHub, but in this case, we will be focused on the [Laravel](https://github.com/laravel/laravel) project.
 
 This tutorial assumes you have installed TortoiseGit for Windows and you have created a GitHub account. If you haven't already, look at the [Laravel on GitHub](/docs/contrib/github) documentation in order to familiarize yourself with Laravel's repositories and branches.
 
-<a name='forking-laravel'></a>
+<a name="forking-laravel"></a>
 ## Forking Laravel
 
 Login to GitHub and visit the [Laravel Repository](https://github.com/laravel/laravel). Click on the **Fork** button. This will create your own fork of Laravel in your own GitHub account. Your Laravel fork will be located at **https://github.com/username/laravel** (your GitHub username will be used in place of *username*).
 
-<a name='cloning-laravel'></a>
+<a name="cloning-laravel"></a>
 ## Cloning Laravel
 
 Open up Windows Explorer and create a new directory where you can make development changes to Laravel.
 
- - Right-click the Laravel directory to bring up the context menu. Click on **Git Clone...**
- - Git clone
+- Right-click the Laravel directory to bring up the context menu. Click on **Git Clone...**
+- Git clone
   - **Url:** https://github.com/laravel/laravel.git
   - **Directory:** the directory that you just created in the previous step
   - Click **OK**
 
 > **Note**: The reason you are cloning the original Laravel repository (and not the fork you made) is so you can always pull down the most recent changes from the Laravel repository to your local repository.
 
-<a name='adding-your-fork'></a>
+<a name="adding-your-fork"></a>
 ## Adding your Fork
 
 After the cloning process is complete, it's time to add the fork you made as a **remote repository**.
 
- - Right-click the Laravel directory and goto **TortoiseGit > Settings**
- - Goto the **Git/Remote** section. Add a new remote:
+- Right-click the Laravel directory and goto **TortoiseGit > Settings**
+- Goto the **Git/Remote** section. Add a new remote:
   - **Remote**: fork
   - **URL**: https://github.com/username/laravel.git
   - Click **Add New/Save**
@@ -49,12 +50,12 @@ After the cloning process is complete, it's time to add the fork you made as a *
 
 Remember to replace *username* with your GitHub username. *This is case-sensitive*.
 
-<a name='creating-branches'></a>
+<a name="creating-branches"></a>
 ## Creating Branches
 
 Now you are ready to create a new branch for your new feature or bug-fix. When you create a new branch, use a self-descriptive naming convention. For example, if you are going to fix a bug in Eloquent, name your branch *bug/eloquent*. Or if you were going to make changes to the localization documentation, name your branch *feature/localization-docs*. A good naming convention will encourage organization and help others understand the purpose of your branch.
 
- - Right-click the Laravel directory and goto **TortoiseGit > Create Branch**
+- Right-click the Laravel directory and goto **TortoiseGit > Create Branch**
   - **Branch:** feature/localization-docs
   - **Base On Branch:** remotes/origin/develop
   - **Check** *Track*
@@ -67,47 +68,47 @@ This will create your new *feature/localization-docs* branch and switch you to i
 
 Now that you have created your own branch and have switched to it, it's time to make your changes to the code. Add your new feature or fix that bug.
 
-<a name='committing'></a>
+<a name="committing"></a>
 ##Committing
 
 Now that you have finished coding and testing your changes, it's time to commit them to your local repository:
 
- - Right-click the Laravel directory and goto **Git Commit -> "feature/localization-docs"...**
- - Commit
+-  Right-click the Laravel directory and goto **Git Commit -> "feature/localization-docs"...**
+- Commit
   - **Message:** Provide a brief explaination of what you added or changed
   - Click **Sign** - This tells the Laravel team know that you personally agree to your code being added to the Laravel core
   - **Changes made:** Check all changed/added files
   - Click **OK**
 
-<a name='pushing-to-your-fork'></a>
+<a name="pushing-to-your-fork"></a>
 ## Pushing to your Fork
 
 Now that your local repository has your committed changes, it's time to push (or sync) your new branch to your fork that is hosted in GitHub:
 
 - Right-click the Laravel directory and goto **Git Sync...**
 - Git Syncronization
- - **Local Branch:** feature/localization-docs
- - **Remote Branch:** leave this blank
- - **Remote URL:** fork
- - Click **Push**
- - When asked for "username:" enter your GitHub *case-sensitive* username
- - When asked for "password:" enter your GitHub *case-sensitive* account
+  - **Local Branch:** feature/localization-docs
+  - **Remote Branch:** leave this blank
+  - **Remote URL:** fork
+  - Click **Push**
+  - When asked for "username:" enter your GitHub *case-sensitive* username
+  - When asked for "password:" enter your GitHub *case-sensitive* account
 
 Your branch has been successfully pushed to your fork on GitHub.
 
-<a name='submitting-a-pull-request'></a>
+<a name="submitting-a-pull-request"></a>
 ## Submitting a Pull Request
 
 The final step is to submit a pull request to the Laravel repository. This means that you are requesting that the Laravel team pull and merge your changes to the Laravel core. In your browser, visit your Laravel fork at [https://github.com/username/laravel](https://github.com/username/laravel). Click on **Pull Request**. Next, make sure you choose the proper base and head repositories and branches:
 
- - **base repo:** laravel/laravel
- - **base branch:** develop
- - **head repo:** username/laravel
- - **head branch:** feature/localization-docs
+- **base repo:** laravel/laravel
+- **base branch:** develop
+- **head repo:** username/laravel
+- **head branch:** feature/localization-docs
 
 Use the form to write a more detailed description of the changes you made and why you made them. Finally, click **Send pull request**. That's it! The changes you made have been submitted to the Laravel team.
 
-<a name='whats-next'></a>
+<a name="whats-next"></a>
 ## What's Next?
 
 Do you have another feature you want to add or another bug you need to fix? Just follow the same instructions as before in the [Creating Branches](#creating-branches) section. Just remember to always create a new branch for every new feature/fix and don't forget to always base your new branches off of the *remotes/origin/develop* branch.


### PR DESCRIPTION
Three md files on contrib folder are different with other md files at the minor Markdown format. So looks not beautiful when see Markdown directory. (By this fixes, no changed to see on github web site  and through web browser with access docs of Laravel)
- changed '...' to "..." in anchor tags
- started with - (without space) on first level list items. And adjusted 2nd level items' start position.
- insterted brank line after ## contents

Signed-off-by: HiroKws <hiro@linux-eejv.(none)>
