### PR TITLE
Deleted an anchor of top of line. Defined "config", but it was reffered ...

### DIFF
--- a/laravel/documentation/session/config.md
+++ b/laravel/documentation/session/config.md
@@ -1,4 +1,3 @@
-<a name="config"></a>
 # Session Configuration
 
 ## Contents


### PR DESCRIPTION
Deleted an anchor of top of line. 

Defined "config" as an anchor, but it was reffered from no where. So, keep code simple.

Signed-off-by:HiroKws hiro.soft@gmail.com
