### PR TITLE
Add Routing Wildcard '(:all)' to Documentation

### DIFF
--- a/laravel/documentation/routing.md
+++ b/laravel/documentation/routing.md
@@ -78,6 +78,13 @@ In the following example the first parameter is the route that you're "registeri
 		//
 	});
 
+#### Catching the remaining URI without limitations:
+
+	Route::get('files/(:all)', function($path)
+	{
+		//
+	});
+
 #### Allowing a URI segment to be optional:
 
 	Route::get('page/(:any?)', function($page = 'index')


### PR DESCRIPTION
Found an (:all) selector in the source, might be worth adding.

http://laravel.com/api/source-class-Laravel.Routing.Router.html#79

``` php
public static $patterns = array(
         '(:num)' => '([0-9]+)',
         '(:any)' => '([a-zA-Z0-9\.\-_%]+)',
         '(:all)' => '(.*)',
);
```
