### PR TITLE
[Log] Don't stop writing log files when an event listener is defined

### DIFF
--- a/laravel/log.php
+++ b/laravel/log.php
@@ -41,23 +41,14 @@ class Log {
 	 */
 	public static function write($type, $message)
 	{
-		// If there is a listener for the log event, we'll delegate the logging
-		// to the event and not write to the log files. This allows for quick
-		// swapping of log implementations for debugging.
-		if (Event::listeners('laravel.log'))
-		{
-			Event::fire('laravel.log', array($type, $message));
-		}
+		// Notify all listeners about the log event, so that the behaviour can
+		// easily be enhanced for debugging.
+		Event::fire('laravel.log', array($type, $message));
 
-		// If there aren't listeners on the log event, we'll just write to the
-		// log files using the default conventions, writing one log file per
-		// day so the files don't get too crowded.
-		else
-		{
-			$message = static::format($type, $message);
-
-			File::append(path('storage').'logs/'.date('Y-m-d').'.log', $message);
-		}
+		// We make sure we only write one log file per day so the files don't
+		// get too crowded.
+		$message = static::format($type, $message);
+		File::append(path('storage').'logs/'.date('Y-m-d').'.log', $message);
 	}
 
 	/**


### PR DESCRIPTION
As described in [this forum topic](http://forums.laravel.com/viewtopic.php?id=2203), the default logging mechanism of writing to a file is completely overwritten and thus not executed when any event listener for the "laravel.log" event is registered.

This happens, for example, when the profiler is enabled.

This behaviour is obviously not what we want.

I am sure that my solution could be discussion-worthy still (that code was there for a reason), but on the other hand I don't really see a use case for completely overwriting the logging (that could be done by extending, too - maybe use a separate method for determining the log file name?).
