### PR TITLE
fixing problems with validate_match() + unit test

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -84,7 +84,7 @@ class Validator {
 	{
 		foreach ($rules as $key => &$rule)
 		{
-			$rule = (is_string($rule)) ? explode('|', $rule) : $rule;
+			$rule = (is_string($rule)) ? str_getcsv($rule, '|', '"', '\\') : $rule;
 		}
 
 		$this->rules = $rules;
@@ -642,7 +642,7 @@ class Validator {
 	 */
 	protected function validate_match($attribute, $value, $parameters)
 	{
-		return preg_match($parameters[0], $value);
+		return preg_match(join(',', $parameters), $value);
 	}
 
 	/**
@@ -1136,7 +1136,7 @@ class Validator {
 		// "max:3" specifies that the value may only be 3 characters long.
 		if (($colon = strpos($rule, ':')) !== false)
 		{
-			$parameters = str_getcsv(substr($rule, $colon + 1));
+			$parameters = explode(',', substr($rule, $colon + 1));
 		}
 
 		return array(is_numeric($colon) ? substr($rule, 0, $colon) : $rule, $parameters);


### PR DESCRIPTION
## Problem/Bug

You can't use a ',' or '|' in a regex string of a match validation rule. If you apply a validation rule like `match:/^[0-9]{1,10}/` or `match:/^[0|9]{1,10}/`, you would encounter the error `preg_match(): No ending delimiter '/' found`. This happens because the parameter `/^[0-9]{1,10}/` is splited on the ',' into an array and only the first element of that array is passed to the `preg_match()` function (see line 645):

```
protected function validate_match($attribute, $value, $parameters)
{
    return preg_match($parameters[0], $value);

}
```
## Fix

Joining the parameter array into a string and pass it to the `preg_match()` function.

```
protected function validate_match($attribute, $value, $parameters)
{
    return preg_match(join(",", $parameters), $value);
}
```

To solve the problem with '|' in regex I modified the parsing of the rules by using 
the `str_getcsv()` function. So you could enclose your match rule in two " like 
in csv-files `$rules = array('test' => '"match:/^[a|z]{1,5}$/"');`.
Now the problem is that you couldn't use a " in your regex string, because " 
is the string delimiter for the rule fields. But instead of a " you can now use '\x22'.

```
$rules = array('test' => 'size:5|"match:/^[\x22|a|z]{1,5}$/"');
```

Keep in mind, that you have to use a single quoted regex string, because the \x22 will
be replaced by a " and results in an error (`preg_match(): Unknown modifier '"'`).
## Summary/Documentation
- Completly backward compatible
- Unit tested
- If you want to use a validation rule with an argument containing a '|' you have to enclose 
  the whole rule in ": `$rules = array('test' => size:2|"in:.,|,:"');`
- If you want to use the match rule with a " and a '|' in your regex string than 
  you have to you have to enclose the whole rule in two '"' (see above), replace the
  " with '\x22' and use single quoted string only: `$rules = array('test' => 'size:5|"match:/^[\x22|a|z]{1,5}$/"');`
## Tip

If you have a very complicated regex c&p from the internet it could be easier to
register a small custom validation rule containing a preg_match() and your regex.
:-)

Happy coding,
Christian
