### PR TITLE
Fix insert() method for related models.

### DIFF
--- a/laravel/database/eloquent/relationships/has_one_or_many.php
+++ b/laravel/database/eloquent/relationships/has_one_or_many.php
@@ -7,8 +7,10 @@ class Has_One_Or_Many extends Relationship {
 	/**
 	 * Insert a new record for the association.
 	 *
+	 * If save is successful, the model will be returned, otherwise false.
+	 *
 	 * @param  Model|array  $attributes
-	 * @return bool
+	 * @return Model|false
 	 */
 	public function insert($attributes)
 	{
@@ -16,7 +18,7 @@ class Has_One_Or_Many extends Relationship {
 		{
 			$attributes->set_attribute($this->foreign_key(), $this->base->get_key());
 			
-			return $attributes->save();
+			return $attributes->save() ? $attributes : false;
 		}
 		else
 		{


### PR DESCRIPTION
As described in [this forum topic](http://forums.laravel.com/viewtopic.php?id=2257), passing a model object to a relationship's `insert()` method caused problems, if custom attribute setters were specified.

The reason for this is that the model wasn't filled with the raw attribute data. Instead, every attribute's value was passed to the attribute's setter method (if it existed), causing e.g. duplicate hashing of passwords.

In fact, the copying of the attributes of the model object passed to `insert()` to an entirely new object is completely unnecessary. Instead, we can simply set the foreign key and then save the model directly.
