### PR TITLE
Including render and render_each into parentheses balancer

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -148,7 +148,7 @@ class Blade {
 		// layout from the top of the template. By convention, it must be
 		// located on the first line of the template contents.
 		preg_replace_callback(
-			'/^@layout\s*?(\s*?\(.+?\))(\r?\n)?/',
+			'/^@layout\s*?(\s*?\(.*?\))(\r?\n)?/',
 			function($matches) use (&$value)
 			{
 				$value = substr( $value, strlen( $matches[0] ) ).'@include'.$matches[1];


### PR DESCRIPTION
as stated by getplatform.com team, this was causing issues if not balanced.

also added an optional space in the @layout regex; removed the CRLF for the @layout replace (don't know why i put it there in the first place); made space before and after "as" in foreachelse mandatory; deprecated compile_render and compile_render method as of this pull;
