### PR TITLE
Mark a bundle as started before firing the event.

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -107,9 +107,9 @@ class Bundle {
 		// start script for reverse routing efficiency purposes.
 		static::routes($bundle);
 
-		Event::fire("laravel.started: {$bundle}");
-
 		static::$started[] = strtolower($bundle);
+
+		Event::fire("laravel.started: {$bundle}");
 	}
 
 	/**


### PR DESCRIPTION
It is not possible to execute any code that tries to start the bundle itself in a bundle's start.php. That is because the bundle isn't marked as started until it's start.php has run.

Code that does this is `Command::run()`, for example.

This patch allows to register event listeners for the event that signals that the bundle has started in the start.php file. That way, calling code such as `Command::run()` can be deferred until the bundle has started properly.

The other alternative - and this is where I'd like some input - would be to mark the bundle as started just before the start.php file is included. That makes things even easier. Agreed?
