### PR TITLE
JSONP support added to JSON response type.

### DIFF
--- a/laravel/response.php
+++ b/laravel/response.php
@@ -93,9 +93,16 @@ class Response {
 	 */
 	public static function json($data, $status = 200, $headers = array())
 	{
-		$headers['Content-Type'] = 'application/json; charset=utf-8';
+		//check if callback function is specified
+		$callback = Input::get('callback');
 
-		return new static(json_encode($data), $status, $headers);
+		if ($callback) {
+			$headers['Content-Type'] = 'application/javascript';
+			return new static(Input::get('callback') . '(' . json_encode($data) . ')', $status, $headers);
+		} else {
+			$headers['Content-Type'] = 'application/json';
+			return new static(json_encode($data), $status, $headers);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If the request includes a callback parameter - typically used for JSONP requests, then wrap the JSON response accordingly so that it will be picked up.

This means the same response call can be used in the controller regardless of the origin of the request.
