### PR TITLE
Get rid of duplicate code for DROP TABLE in schema grammars.

### DIFF
--- a/laravel/database/schema/grammars/grammar.php
+++ b/laravel/database/schema/grammars/grammar.php
@@ -51,6 +51,18 @@ abstract class Grammar extends \Laravel\Database\Grammar {
 	}
 
 	/**
+	 * Generate the SQL statement for a drop table command.
+	 *
+	 * @param  Table   $table
+	 * @param  Fluent  $command
+	 * @return string
+	 */
+	public function drop(Table $table, Fluent $command)
+	{
+		return 'DROP TABLE '.$this->wrap($table);
+	}
+
+	/**
 	 * Drop a constraint from the table.
 	 *
 	 * @param  Table   $table

--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -225,18 +225,6 @@ class MySQL extends Grammar {
 	}
 
 	/**
-	 * Generate the SQL statement for a drop table command.
-	 *
-	 * @param  Table    $table
-	 * @param  Fluent   $command
-	 * @return string
-	 */
-	public function drop(Table $table, Fluent $command)
-	{
-		return 'DROP TABLE '.$this->wrap($table);
-	}
-
-	/**
 	 * Generate the SQL statement for a drop column command.
 	 *
 	 * @param  Table    $table

--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -211,18 +211,6 @@ class Postgres extends Grammar {
 	}
 
 	/**
-	 * Generate the SQL statement for a drop table command.
-	 *
-	 * @param  Table    $table
-	 * @param  Fluent   $command
-	 * @return string
-	 */
-	public function drop(Table $table, Fluent $command)
-	{
-		return 'DROP TABLE '.$this->wrap($table);
-	}
-
-	/**
 	 * Generate the SQL statement for a drop column command.
 	 *
 	 * @param  Table    $table

--- a/laravel/database/schema/grammars/sqlite.php
+++ b/laravel/database/schema/grammars/sqlite.php
@@ -214,18 +214,6 @@ class SQLite extends Grammar {
 	}
 
 	/**
-	 * Generate the SQL statement for a drop table command.
-	 *
-	 * @param  Table   $table
-	 * @param  Fluent  $command
-	 * @return string
-	 */
-	public function drop(Table $table, Fluent $command)
-	{
-		return 'DROP TABLE '.$this->wrap($table);
-	}
-
-	/**
 	 * Generate the SQL statement for a drop unique key command.
 	 *
 	 * @param  Table   $table

--- a/laravel/database/schema/grammars/sqlserver.php
+++ b/laravel/database/schema/grammars/sqlserver.php
@@ -225,18 +225,6 @@ class SQLServer extends Grammar {
 	}
 
 	/**
-	 * Generate the SQL statement for a drop table command.
-	 *
-	 * @param  Table   $table
-	 * @param  Fluent  $command
-	 * @return string
-	 */
-	public function drop(Table $table, Fluent $command)
-	{
-		return 'DROP TABLE '.$this->wrap($table);
-	}
-
-	/**
 	 * Generate the SQL statement for a drop column command.
 	 *
 	 * @param  Table    $table


### PR DESCRIPTION
Speaks for itself.

The implementation was the same for every driver and this is pretty standard SQL, so this gets rid of some duplicate code.
