### PR TITLE
Namespace Laravel's CRLF define.

### DIFF
--- a/laravel/core.php
+++ b/laravel/core.php
@@ -12,7 +12,7 @@
 */
 
 define('EXT', '.php');
-define('CRLF', "\r\n");
+define('Laravel\CRLF', "\r\n");
 define('BLADE_EXT', '.blade.php');
 define('DEFAULT_BUNDLE', 'application');
 define('MB_STRING', (int) function_exists('mb_get_info'));


### PR DESCRIPTION
If another PHP library attempts to define CRLF again this will cause an
error. We've been using this on our website for quite a while so im
pretty sure this won't break anything, Laravel seems to be properly
namespaced.

This could probably be done for some of the other constants too but I don't think they are defined as often as CRLF is.

Signed-off-by: Spencer Deinum spencerdeinum@gmail.com
