### PR TITLE
Problem with manual running of Artisan tasks

### DIFF
--- a/laravel/cli/command.php
+++ b/laravel/cli/command.php
@@ -125,7 +125,7 @@ class Command {
 		// the requested method may be executed.
 		if (file_exists($path = Bundle::path($bundle).'tasks/'.$task.EXT))
 		{
-			require $path;
+			require_once $path;
 
 			$task = static::format($bundle, $task);
 


### PR DESCRIPTION
When running an Artisan task from within your application using `Command::run`, it fails when the same task is ran more than once. Every time the task is resolved, its file is included using `require` leading to duplicate class definitions. By using `require_once` this problem is avoided.
