### PR TITLE
Added a method to fluently set belongs-to relation

### DIFF
--- a/laravel/database/eloquent/relationships/belongs_to.php
+++ b/laravel/database/eloquent/relationships/belongs_to.php
@@ -119,9 +119,6 @@ class Belongs_To extends Relationship {
 	
 	public function bind($id)
 	{
-		if((int) $this->foreign_value() === (int) $id)
-			return $this->base;
-
 		$this->base->fill(array($this->foreign => $id))->save();
 
 		return $this->base;


### PR DESCRIPTION
This method spun off from a discussion in IRC. What this enables is this:

$user->comments()->insert($comment_data)->article()->bind($article->id)
