### PR TITLE
Unexpected results with Eloquent::increment and decrement

### DIFF
--- a/laravel/database/eloquent/query.php
+++ b/laravel/database/eloquent/query.php
@@ -33,8 +33,8 @@ class Query {
 	 * @var array
 	 */
 	public $passthru = array(
-		'lists', 'only', 'insert', 'insert_get_id', 'update', 'increment',
-		'delete', 'decrement', 'count', 'min', 'max', 'avg', 'sum',
+		'lists', 'only', 'insert', 'insert_get_id', 'update',
+		'delete', 'count', 'min', 'max', 'avg', 'sum',
 	);
 
 	/**
@@ -93,6 +93,34 @@ class Query {
 		$paginator->results = $this->hydrate($this->model, $paginator->results);
 
 		return $paginator;
+	}
+
+	/**
+	 * Increment the value of a column by a given amount.
+	 *
+	 * @param  string  $column
+	 * @param  int     $amount
+	 * @return int
+	 */
+	public function increment($column, $amount = 1)
+	{
+		$this->where($this->model->key(), '=', $this->model->get_key());
+
+		return $this->table->increment($column, $amount);
+	}
+
+	/**
+	 * Decrement the value of a column by a given amount.
+	 *
+	 * @param  string  $column
+	 * @param  int     $amount
+	 * @return int
+	 */
+	public function decrement($column, $amount = 1)
+	{
+		$this->where($this->model->key(), '=', $this->model->get_key());
+
+		return $this->table->decrement($column, $amount);
 	}
 
 	/**


### PR DESCRIPTION
When calling `increment('column')` on an Eloquent model instance, I expect only the column of the row of that model to be incremented. This however is not the case, you'd have to explicitly set the where clause yourself before calling `increment`.

When `increment` is called on the Eloquent model, it is magically routed to `Eloquent\Query` from where it is directly routed to `Query`. From there the table is immediately updated and the result is returned. This commit sets the where clause in `Eloquent\Query` just before the operation is routed to `Query` and executed, thus resolving the problem.
