### PR TITLE
Performance fix for HTML Class.

### DIFF
--- a/laravel/html.php
+++ b/laravel/html.php
@@ -10,6 +10,13 @@ class HTML {
 	public static $macros = array();
 
 	/**
+	 * Cache application encoding locally to save expensive calls to config::get().
+	 *
+	 * @var string
+	 */
+	public static $encoding = null;
+
+	/**
 	 * Registers a custom macro.
 	 *
 	 * @param  string   $name
@@ -31,7 +38,8 @@ class HTML {
 	 */
 	public static function entities($value)
 	{
-		return htmlentities($value, ENT_QUOTES, Config::get('application.encoding'), false);
+		if(static::$encoding===null) static::$encoding = Config::get('application.encoding');
+		return htmlentities($value, ENT_QUOTES, static::$encoding, false);
 	}
 
 	/**
@@ -42,7 +50,8 @@ class HTML {
 	 */
 	public static function decode($value)
 	{
-		return html_entity_decode($value, ENT_QUOTES, Config::get('application.encoding'));
+		if(static::$encoding===null) static::$encoding = Config::get('application.encoding');
+		return html_entity_decode($value, ENT_QUOTES, static::$encoding);
 	}
 
 	/**
@@ -55,7 +64,8 @@ class HTML {
 	 */
 	public static function specialchars($value)
 	{
-		return htmlspecialchars($value, ENT_QUOTES, Config::get('application.encoding'), false);
+		if(static::$encoding===null) static::$encoding = Config::get('application.encoding');
+		return htmlspecialchars($value, ENT_QUOTES, static::$encoding, false);
 	}
 
 	/**


### PR DESCRIPTION
Hello,

We've recently started using laravel for a number of internal web-apps, but have run in to a couple of issues when load testing. The underlying issue being that the config::get method is significantly more expensive than a standard array access. This is compounded by it being invoked a 100-1000 times per page load.

This pull request includes a change we've made to attempt to mitigate this issue, which functions by caching the application.encoding variable within the HTML class. To use one of our apps as an example, for a large form this reduced the number of calls to config::get from 1200+ invocations (72ms) to 125 (9ms).

All core unit-test's pass with this change in place.

Thank you,
Carl
