### PR TITLE
Allow Input::json() to return array instead of object

### DIFF
--- a/laravel/input.php
+++ b/laravel/input.php
@@ -102,13 +102,14 @@ class Input {
 	/**
 	 * Get the JSON payload for the request.
 	 *
+	 * @param  bool    $as_array
 	 * @return object
 	 */
-	public static function json()
+	public static function json($as_array = false)
 	{
 		if ( ! is_null(static::$json)) return static::$json;
 
-		return static::$json = json_decode(Request::foundation()->getContent());
+		return static::$json = json_decode(Request::foundation()->getContent(), $as_array);
 	}
 
 	/**


### PR DESCRIPTION
I had a need for this on a project recently, though it might be nice to have in the core. Default is still to return an object.
