### PR TITLE
Fixed Bundle::handles() to properly get the bundle with the most specific URI

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -188,19 +188,20 @@ class Bundle {
 	public static function handles($uri)
 	{
 		$uri = rtrim($uri, '/').'/';
-		$bundle = NULL;
+		$bundle = null;
 
 		foreach (static::$bundles as $key => $value)
 		{
 			if (isset($value['handles']) and starts_with($uri, $value['handles'].'/') or $value['handles'] == '/')
 			{
-				if(strlen($bundle) < strlen($key)) {
+				if (strlen($bundle) < strlen($key))
+				{
 					$bundle = $key;
 				}
 			}
 		}
 
-		return isset($bundle) ? $bundle : DEFAULT_BUNDLE;
+		return $bundle ?: DEFAULT_BUNDLE;
 	}
 
 	/**


### PR DESCRIPTION
For instance we have registered two bundles (bundles.php):

<code>array(
'cms'=>array('handles'=>'cms'),
'cms-pages'=>array('handles'=>'cms/pages')
)
</code>

Then if we fired this:

<code>Bundle::handles('cms/pages')</code>

We would get 'cms' as the bundle responsible to handle the URI instead of 'cms-pages'.

Much love to Laravel,

Bryan te Beek

Signed-off-by: Bryan te Beek bryantebeek@gmail.com
