### PR TITLE
Turn profiler off using runtime Config

### DIFF
--- a/laravel/profiling/profiler.php
+++ b/laravel/profiling/profiler.php
@@ -27,7 +27,7 @@ class Profiler {
 		// We only want to send the profiler toolbar if the request is not an AJAX
 		// request, as sending it on AJAX requests could mess up JSON driven API
 		// type applications, so we will not send anything in those scenarios.
-		if ( ! Request::ajax())
+		if ( ! Request::ajax() and Config::get('application.profiler') )
 		{
 			static::$data['memory'] = get_file_size(memory_get_usage(true));
 			static::$data['memory_peak'] = get_file_size(memory_get_peak_usage(true));


### PR DESCRIPTION
just added a check in Profiler's render method to also look at Config::get('application.profiler') as laravel allows changing config during runtime. This allows turning off profiler for certain actions by doing Config::set('application.profiler', false)
