### PR TITLE
Make the Fluent query's find() method work with joins.

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -560,7 +560,7 @@ class Query {
 	 */
 	public function find($id, $columns = array('*'))
 	{
-		return $this->where('id', '=', $id)->first($columns);
+		return $this->where($this->from.'.id', '=', $id)->first($columns);
 	}
 
 	/**


### PR DESCRIPTION
This works by prefixing the table name to the ID column so that ambiguity regarding the column name is avoided.

Fixes #1050.
