### PR TITLE
fix full-text index sql statement for postgres

### DIFF
--- a/laravel/database/schema/grammars/postgres.php
+++ b/laravel/database/schema/grammars/postgres.php
@@ -166,7 +166,7 @@ class Postgres extends Grammar {
 
 		$columns = $this->columnize($command->columns);
 
-		return "CREATE INDEX {$name} ON ".$this->wrap($table)." USING gin({$columns})";
+		return "CREATE INDEX {$name} ON ".$this->wrap($table)." USING gin(to_tsvector('english', {$columns}))";
 	}
 
 	/**


### PR DESCRIPTION
in postgresql an full-text index need a tsvector field type, with this fix any text column type can have an full-text index.

Signed-off-by: Ramon Soares eu@ramonsoares.com
