### PR TITLE
Fixes language URI routing issue

### DIFF
--- a/laravel/laravel.php
+++ b/laravel/laravel.php
@@ -137,7 +137,7 @@ $languages[] = Config::get('application.language');
 
 foreach ($languages as $language)
 {
-	if (preg_match("#^{$language}(/.*)?$#i", $uri))
+	if (preg_match("#^{$language}(?:$|/)#i", $uri))
 	{
 		Config::set('application.language', $language);
 


### PR DESCRIPTION
**Issue:** I have a route for `GET /entries`, but always returns a 404. The route is configured properly in the code.

**Cause of issue:** Laravel tries to detect if a language key is passed at the beginning of the URI. In this case, English (en) is a valid language key, and the system is trying to internally re-route `/entries` to `/en/tries` which is throwing the 404.

**Fix:** I have altered the code to use a regular expression to see if the language code is the only segment present, or if there is a slash after it.
