### PR TITLE
Canonical URL helper

### DIFF
--- a/laravel/url.php
+++ b/laravel/url.php
@@ -189,7 +189,7 @@ class URL {
 
 		if ( ! is_null($route))
 		{
-			return static::explicit($route, $action, $parameters);
+			return static::explicit($route, $parameters);
 		}
 		// If no route was found that handled the given action, we'll just
 		// generate the URL using the typical controller routing setup
@@ -204,11 +204,10 @@ class URL {
 	 * Generate an action URL from a route definition
 	 *
 	 * @param  array   $route
-	 * @param  string  $action
 	 * @param  array   $parameters
 	 * @return string
 	 */
-	protected static function explicit($route, $action, $parameters)
+	protected static function explicit($route, $parameters)
 	{
 		$https = array_get(current($route), 'https', null);
 


### PR DESCRIPTION
This adds the helper method `URL::canonical()` that returns the full URL

Very useful for SEO and other games.

---

Not done yet:
- I still need to figure out how to find out whether the current route was registered as secure.
- Documentation will have to be added.
