### PR TITLE
Added custom macros to Str Class

### DIFF
--- a/laravel/str.php
+++ b/laravel/str.php
@@ -10,6 +10,25 @@ class Str {
 	public static $pluralizer;
 
 	/**
+	 * The registered custom macros.
+	 *
+	 * @var array
+	 */
+	public static $macros = array();
+
+	/**
+	 * Registers a custom macro.
+	 *
+	 * @param  string   $name
+	 * @param  Closure  $macro
+	 * @return void
+	 */
+	public static function macro($name, $macro)
+	{
+		static::$macros[$name] = $macro;
+	}
+	
+	/**
 	 * Get the default string encoding for the application.
 	 *
 	 * This method is simply a short-cut to Config::get('application.encoding').
@@ -370,6 +389,23 @@ class Str {
 			default:
 				throw new \Exception("Invalid random string type [$type].");
 		}
+	}
+	
+	/**
+	 * Dynamically handle calls to custom macros.
+	 *
+	 * @param  string  $method
+	 * @param  array   $parameters
+	 * @return mixed
+	 */
+	public static function __callStatic($method, $parameters)
+	{
+	    if (isset(static::$macros[$method]))
+	    {
+	        return call_user_func_array(static::$macros[$method], $parameters);
+	    }
+
+	    throw new \Exception("Method [$method] does not exist.");
 	}
 
 }


### PR DESCRIPTION
Added the ability to use custom macros for the Str Class

for example... can be used to add possessive form conversion to a string

``` php
Str::macro('possessive', function($value)
{
    // append an apostrophe to indicate possession
    $value .= '\'';

    // append an s for all strings that do not end with the letter s
    if($value[Str::length($value)-2] != 's')
        $value .= 's';

    return $value;
});
```
