### PR TITLE
Trimming whitespace before doctype tag

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -68,7 +68,7 @@ class Blade {
 			// Once the view has been compiled, we can simply set the path to the
 			// compiled view on the view instance and call the typical "get"
 			// method on the view to evaluate the compiled PHP view.
-			return $view->get();
+			return ltrim($view->get());
 		});
 	}
 


### PR DESCRIPTION
When using layouts and sections theres some unnecessary whitespace occurring before the doctype tag.
