### PR TITLE
Added option to not die when using dd().

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -30,14 +30,16 @@ function __($key, $replacements = array(), $language = null)
  * Dump the given value and kill the script.
  *
  * @param  mixed  $value
+ * @param  bool   $die
  * @return void
  */
-function dd($value)
+function dd($value, $die = true)
 {
 	echo "<pre>";
 	var_dump($value);
 	echo "</pre>";
-	die;
+	if ( $die )
+		die;
 }
 
 /**
@@ -584,7 +586,7 @@ function get_cli_option($option, $default = null)
 
 	return value($default);
 }
-	
+
 /**
  * Calculate the human-readable file size (with proper units).
  *


### PR DESCRIPTION
This minor change allows you to pass an optional second bool parameter to the `dd()` function like so:

```
dd($variable, false);
```

This will make it so `dd()` does not die at the end of the function.  This allows a developer to `dd()` multiple variables throughout his code without the code dying at the first `dd()`.

Example:

```
$taco= whatever();

dd($taco, false);  // will var_dump() but not die

$burrito= hello( $taco );

dd($burrito, false);  // will var_dump but not die

dd($soda);  // will var_dump and then die;

echo "This won't be seen";
```

This is a very minor addition but it can definitely be a bonus to code debugging.

Signed-off-by: Jakobud <jakobud+github@gmail.com>
