### PR TITLE
Auth token now nulled on logout

### DIFF
--- a/laravel/auth/drivers/driver.php
+++ b/laravel/auth/drivers/driver.php
@@ -127,6 +127,8 @@ abstract class Driver {
 		$this->cookie($this->recaller(), null, -2000);
 
 		Session::forget($this->token());
+
+    $this->token = null;
 	}
 
 	/**

--- a/laravel/tests/cases/auth.test.php
+++ b/laravel/tests/cases/auth.test.php
@@ -294,9 +294,6 @@ class AuthTest extends PHPUnit_Framework_TestCase {
 
 		Auth::logout();
 
-		// A workaround since Cookie will is only stored in memory, until Response class is called.
-		Auth::driver()->token = null;
-
 		$this->assertNull(Auth::user());
 
 		$this->assertFalse(isset(Session::$instance->session['data']['laravel_auth_drivers_fluent_login']));


### PR DESCRIPTION
If the token is not nulled on logout, a (poor) path going like this would work (incorrectly) :
Auth::attempt($data); // Successful login
...
Auth::logout(); // Successful logout
...
Auth::check(); // -> True!

Originally noticed this behavior in a test on a custom auth backend. 

Also modified the appropriate test case to reflect this modification (this behavior was hidden due to an added workaround in the test cases).

Signed-off-by: Joel Marcotte <skaner // @gmail.com>
