### PR TITLE
fixed setting length for integer fields in Schema builder

### DIFF
--- a/laravel/database/schema/grammars/mysql.php
+++ b/laravel/database/schema/grammars/mysql.php
@@ -338,7 +338,7 @@ class MySQL extends Grammar {
 	 */
 	protected function type_integer(Fluent $column)
 	{
-		return 'INT';
+		return 'INT('.$column->length.')';
 	}
 
 	/**


### PR DESCRIPTION
fixed setting length for integer fields in Schema builder
