### PR TITLE
Update laravel/helpers.php. Bug or feature?

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -23,7 +23,7 @@ function e($value)
  */
 function __($key, $replacements = array(), $language = null)
 {
-	return Laravel\Lang::line($key, $replacements, $language);
+	return Lang::line($key, $replacements, $language);
 }
 
 /**


### PR DESCRIPTION
Updated function __([...]):

If the Lang-Class is extended, the shortcut-version __() won't use the extending class's functions.
See http://forums.laravel.com/viewtopic.php?pid=15696 to understand what I mean.

Is this a bug, or a feature?
