### PR TITLE
segment pattern to match a single segment, also matches UTF-8 segments.

### DIFF
--- a/laravel/routing/router.php
+++ b/laravel/routing/router.php
@@ -76,6 +76,7 @@ class Router {
 	public static $patterns = array(
 		'(:num)' => '([0-9]+)',
 		'(:any)' => '([a-zA-Z0-9\.\-_%=]+)',
+		'(:segment)' => '([^/]+)',
 		'(:all)' => '(.*)',
 	);
 
@@ -87,6 +88,7 @@ class Router {
 	public static $optional = array(
 		'/(:num?)' => '(?:/([0-9]+)',
 		'/(:any?)' => '(?:/([a-zA-Z0-9\.\-_%=]+)',
+		'/(:segment?)' => '(?:/([^/]+)',
 		'/(:all?)' => '(?:/(.*)',
 	);
 


### PR DESCRIPTION
(:any) pattern doesn't match all characters, (:all) pattern doesn't match a single segment. (:segment) pattern matches a single segment consisting any characters.
