### PR TITLE
[#1261] get_key now pulls from $original instead

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -544,7 +544,7 @@ abstract class Model {
 	 */
 	public function get_key()
 	{
-		return get_array($this->original, static::$key);
+		return array_get($this->original, static::$key);
 	}
 
 	/**


### PR DESCRIPTION
This is in reference to issue #1261, where Model->get_key() returns
the key from the $attributes instead of from the $original property.
This breaks the functionality of a model with a primary key that may
change, as the SQL generated will be something like:

UPDATE `model` SET `key` = 'new-key' WHERE `key` = 'new-key';

Which won't update the model in the database.
