### PR TITLE
Don't capture newlines in Blade::matcher

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -435,7 +435,7 @@ class Blade {
 	 */
 	public static function matcher($function)
 	{
-		return '/(\s*)@'.$function.'(\s*\(.*\))/';
+		return '/([^\S\n]*)@'.$function.'(\s*\(.*\))/';
 	}
 
 	/**


### PR DESCRIPTION
Capturing all whitespace in the matcher function causes cases like the following to compile incorrectly:

``` html
@foreach ($a as $b)
  @custom
@endforeach
```

If @custom here is an extension that gets replaced with {{ custom() }} for example, this would result in:

``` php
<?php foreach ($a as $b)<?php echo custom(); ?>: ?>
```

Signed-off-by: Dominic Adelaar dom@casiotone.org
