### PR TITLE
Fixes XSS vulnerability in Profiler

### DIFF
--- a/laravel/profiling/profiler.php
+++ b/laravel/profiling/profiler.php
@@ -148,6 +148,7 @@ class Profiler {
 			$binding = Database::connection()->pdo->quote($binding);
 
 			$sql = preg_replace('/\?/', $binding, $sql, 1);
+			$sql = htmlspecialchars($sql);
 		}
 
 		static::$data['queries'][] = array($sql, $time);


### PR DESCRIPTION
The profiler doesn't sanitize the queries on the SQL tab which can allow an attacker to forge specially crafted queries to attack other visitors, steal cookies, and perform unauthorized browser actions. It does depend on how the developer has developed the application but nevertheless it should be patched. Even if the attack fails it can still render as HTML so the full query doesn't always show.

At first it was hard for me to provide a working PoC (Proof of concept) as the system adds slashes to the quotes in order to, I assume, prevent SQL injection (I haven't check if that's the database or the profiler's doing) but I did manage to forge this:

``` php
$input = '<IFRAME SRC=http://www.mybb.com/></IFRAME>';
$query = DB::query("SELECT * FROM `mybb_users` WHERE `username` = ?", array($input));
```

This results in:

http://i.imgur.com/VA4r2.png

But should be:

http://i.imgur.com/hebkV.png

This pull request fixes an XSS vulnerability in the Profiler. It shouldn't affect any other functionality as far as I'm aware.
