### PR TITLE
Independent previous next links for paginator

### DIFF
--- a/laravel/paginator.php
+++ b/laravel/paginator.php
@@ -387,7 +387,7 @@ class Paginator {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	protected function link($page, $text, $class, $independent, $attributes = array())
+	protected function link($page, $text, $class, $independent = false, $attributes = array())
 	{
 		$query = '?page='.$page.$this->appendage($this->appends);
 


### PR DESCRIPTION
After the switch to bootstrap style paginator slider, it was not really possible to make independent previous-next links.
This commit helps in creating independent previous next links along with providing attributes for them.
Usage:

```
{{ $listing->previous(null, true, ['class' => 'pull-left']) }}
{{ $listing->next(null, true, ['class' => 'pull-right']) }}

{{ $listing->previous('Go Back', true, ['class' => 'pull-left']) }}
{{ $listing->next('Next Page', true, ['class' => 'pull-right']) }}
```
