### PR TITLE
Huge performance increase on Eloquents relationships

### DIFF
--- a/laravel/database/eloquent/relationships/belongs_to.php
+++ b/laravel/database/eloquent/relationships/belongs_to.php
@@ -87,16 +87,17 @@ class Belongs_To extends Relationship {
 	{
 		$foreign = $this->foreign_key();
 
-		foreach ($children as &$child)
+		$parents_hash = array();
+		foreach ($parents as $parent)
 		{
-			$parent = array_first($parents, function($k, $v) use (&$child, $foreign)
-			{
-				return $v->get_key() == $child->$foreign;
-			});
+			$parents_hash[$parent->get_key()] = $parent;
+		}
 
-			if ( ! is_null($parent))
+		foreach ($children as $child)
+		{
+			if (array_key_exists($child->$foreign, $parents_hash))
 			{
-				$child->relationships[$relationship] = $parent;
+				$child->relationships[$relationship] = $parents_hash[$child->$foreign];
 			}
 		}
 	}

--- a/laravel/database/eloquent/relationships/has_many.php
+++ b/laravel/database/eloquent/relationships/has_many.php
@@ -91,14 +91,18 @@ class Has_Many extends Has_One_Or_Many {
 	{
 		$foreign = $this->foreign_key();
 
-		foreach ($parents as &$parent)
+		$children_hash = array();
+		foreach ($children as $child)
 		{
-			$matching = array_filter($children, function($v) use (&$parent, $foreign)
-			{
-				return $v->$foreign == $parent->get_key();
-			});
+			$children_hash[$child->$foreign][] = $child;
+		}
 
-			$parent->relationships[$relationship] = array_values($matching);
+		foreach ($parents as $parent)
+		{
+			if (array_key_exists($parent->get_key(), $children_hash))
+			{
+				$parent->relationships[$relationship] = $children_hash[$parent->get_key()];
+			}
 		}
 	}
 

--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -328,14 +328,18 @@ class Has_Many_And_Belongs_To extends Relationship {
 	{
 		$foreign = $this->foreign_key();
 
-		foreach ($parents as &$parent)
+		$children_hash = array();
+		foreach ($children as $child)
 		{
-			$matching = array_filter($children, function($v) use (&$parent, $foreign)
-			{
-				return $v->pivot->$foreign == $parent->get_key();
-			});
+			$children_hash[$child->pivot->$foreign][] = $child;
+		}
 
-			$parent->relationships[$relationship] = array_values($matching);
+		foreach ($parents as $parent)
+		{
+			if (array_key_exists($parent->get_key(), $children_hash))
+			{
+				$parent->relationships[$relationship] = $children_hash[$parent->get_key()];
+			}
 		}
 	}
 

--- a/laravel/database/eloquent/relationships/has_one.php
+++ b/laravel/database/eloquent/relationships/has_one.php
@@ -38,14 +38,21 @@ class Has_One extends Has_One_Or_Many {
 	{
 		$foreign = $this->foreign_key();
 
-		foreach ($parents as &$parent)
+		$children_hash = array();
+		foreach ($children as $child)
 		{
-			$matching = array_first($children, function($k, $v) use (&$parent, $foreign)
+			if (array_key_exists($child->pivot->$foreign, $children_hash))
 			{
-				return $v->$foreign == $parent->get_key();
-			});
+				continue;
+			}
 
-			$parent->relationships[$relationship] = $matching;
+			$children_hash[$child->pivot->$foreign] = $child;
+		}
+
+		foreach ($parents as $parent)
+		{
+			if (array_key_exists($parent->get_key(), $children_hash))
+				$parent->relationships[$relationship] = $children_hash[$parent->get_key()];
 		}
 	}
 


### PR DESCRIPTION
The current Eloquent's iteration method to match relationships, specially has_many and has_many_and_belongs_to are quite slow. It iterates over one edge of the relationship and then uses array_filter and array_first to identify the models on the other edge that match.

I did some improvements on Relationship::match method. And created a small benchmark to compare performance: paste.laravel.com/7dt

With 250 children matching 50 parents, the results on my Macbook Pro were:

```
Current Iteration: 187ms (total array iterations = 12550)
Optimized Iteration: 3ms (total array iterations = 300)
```

The great thing is that this method I'm suggesting grows linearly with the number of models, while the other grows exponentially and if you try to load more models, it's time will increase even more and so it's CPU and memory usage.

On small applications that load 20-30 items per page, this passes unnoticed. But for Laravel to reach enterprise class, this kind of optimization is necessary.
