### PR TITLE
Added a getInner method for retrieving the inner exception

### DIFF
--- a/laravel/database/exception.php
+++ b/laravel/database/exception.php
@@ -25,6 +25,16 @@ class Exception extends \Exception {
 	}
 
 	/**
+	 * Get the inner exception.
+	 *
+	 * @return Exception
+	 */
+	public function getInner()
+	{
+		return $this->inner;
+	}
+
+	/**
 	 * Set the exception message to include the SQL and bindings.
 	 *
 	 * @param  string  $sql


### PR DESCRIPTION
In some cases it is required to get the inner exception to retrieve the error code from it and determine what went wrong.

Signed-off-by: Dejan Geci dejan.geci@gmail.com
