### PR TITLE
Allow aggregates to work with group_by

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -678,7 +678,16 @@ class Query {
 		// We'll set the aggregate value so the grammar does not try to compile
 		// a SELECT clause on the query. If an aggregator is present, it's own
 		// grammar function will be used to build the SQL syntax.
-		$this->aggregate = compact('aggregator', 'columns');
+		if(! $this->groupings)
+		{
+			$this->aggregate = compact('aggregator', 'columns');
+			$sql = $this->grammar->select($this);
+		}
+		else
+		{
+			if (is_null($this->selects)) $this->select(array('*'));
+			$sql = "SELECT {$aggregator}({$this->grammar->columnize($columns)}) FROM ({$this->grammar->select($this)}) AS aggregate";
+		}
 
 		$sql = $this->grammar->select($this);
 


### PR DESCRIPTION
Modified the aggregate method so that when it is called on a query which has groupings, the current query would be called as a sub query on which the aggregating function would be applied
