### PR TITLE
Eloquent auth: Check whether token is an object.

### DIFF
--- a/laravel/auth/drivers/eloquent.php
+++ b/laravel/auth/drivers/eloquent.php
@@ -18,7 +18,7 @@ class Eloquent extends Driver {
 		{
 			return $this->model()->find($token);
 		}
-		else if (is_object($token) && get_class($token) == Config::get('auth.model'))
+		else if (is_object($token) and get_class($token) == Config::get('auth.model'))
 		{
 			return $token;
 		}


### PR DESCRIPTION
This caused errors in some cases where for some reason PHP was thinking the returned value was a string.

I think this was caused by having two separate Laravel installations on localhost, with the same default cookie name.
I know, my fault, still hard to debug and somewhat annoying.
