### PR TITLE
Allow aggregates on queries using group_by

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -690,8 +690,6 @@ class Query {
 			$sql = "SELECT {$aggregator}({$this->grammar->columnize($columns)}) FROM ({$this->grammar->select($this)}) AS aggregate";
 		}
 
-		$sql = $this->grammar->select($this);
-
 		$result = $this->connection->only($sql, $this->bindings);
 
 		// Reset the aggregate so more queries can be performed using the same


### PR DESCRIPTION
calling count(), avg() etc on queries which have groupings wraps the result set of the query in another query and then calls the aggregator on the result-set
