### PR TITLE
Many-to-many sync: always work with arrays

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -141,7 +141,7 @@ class Has_Many_And_Belongs_To extends Relationship {
 
 		if (count($detach) > 0)
 		{
-			$this->detach(array_diff($current, $ids));
+			$this->detach($detach);
 		}
 	}
 


### PR DESCRIPTION
When fetching an array of values from input, the value might be `null` if nothing was selected (instead of an empty array).

As this feels like a somewhat common use-case, this type-casting should be handled in the `sync()` method, I'd say.

http://forums.laravel.com/viewtopic.php?id=3057
