### PR TITLE
Improving consistence of portuguese validation message

### DIFF
--- a/application/language/pt/validation.php
+++ b/application/language/pt/validation.php
@@ -32,11 +32,11 @@ return array(
 	),
 	"confirmed"      => "O :attribute confirmação não coincide.",
 	"different"      => "O :attribute e :other devem ser diferentes.",
-	"email"          => "O :attribute não é um e-mail válido",
+	"email"          => "O :attribute não é um e-mail válido.",
 	"exists"         => "O :attribute selecionado é inválido.",
 	"image"          => "O :attribute deve ser uma imagem.",
 	"in"             => "O :attribute selecionado é inválido.",
-	"integer"        => "O :attribute deve ser um inteiro",
+	"integer"        => "O :attribute deve ser um inteiro.",
 	"ip"             => "O :attribute deve ser um endereço IP válido.",
 	"match"          => "O formato :attribute é inválido.",
 	"max"            => array(
@@ -53,13 +53,13 @@ return array(
 	"not_in"         => "O :attribute selecionado é inválido.",
 	"numeric"        => "O :attribute deve ser um número.",
 	"required"       => "O campo :attribute deve ser preenchido.",
-	"same"           => "O :attribute e :other devem ser iguais",
+	"same"           => "O :attribute e :other devem ser iguais.",
 	"size"           => array(
 		"numeric" => "O :attribute deve ser :size.",
 		"file"    => "O :attribute deve ter :size kilobyte.",
 		"string"  => "O :attribute deve ter :size caracteres.",
 	),
-	"unique"         => "O :attribute já existe",
+	"unique"         => "Este :attribute já existe.",
 	"url"            => "O formato :attribute é inválido.",
 
 	/*


### PR DESCRIPTION
Pretty self descriptive, but just to clarify:

I'm adding periods to some messages that were missing it, aswell as changing "The :attribute already exists" to "This :attribute already exists". For instance:

"This email already exists" **instead of** "The email already exists".
