### PR TITLE
Implement logger_treshold option to filter which Log type should be appended to Laravel log files. 

### DIFF
--- a/application/config/application.php
+++ b/application/config/application.php
@@ -139,6 +139,19 @@ return array(
 
 	/*
 	|--------------------------------------------------------------------------
+	| Logger Threshold
+	|--------------------------------------------------------------------------
+	|
+	| Here, you can specify which log threshold should be added logs file when
+	| Logger Class log any message, for example a Log::info() might not be useful
+	| in production environment but it's might be useful in development.
+	|
+	*/
+
+	'logger_threshold' => null,
+
+	/*
+	|--------------------------------------------------------------------------
 	| Class Aliases
 	|--------------------------------------------------------------------------
 	|

--- a/laravel/log.php
+++ b/laravel/log.php
@@ -45,9 +45,15 @@ class Log {
 		// to the event for debugging.
 		Event::fire('laravel.log', array($type, $message));
 
-		$message = static::format($type, $message);
+		$threshold = (array) Config::get('application.logger_treshold', array());
 
-		File::append(path('storage').'logs/'.date('Y-m-d').'.log', $message);
+		switch (true)
+		{
+			case empty($treshold) :
+			case in_array($type, $treshold) :
+				File::append(path('storage').'logs/'.date('Y-m-d').'.log', static::format($type, $message));
+				break;
+		}
 	}
 
 	/**


### PR DESCRIPTION
And at the same time remove unrelevant if condition where it's no longer implemented, having any `laravel.log` event no longer block from writing to log files.
