### PR TITLE
Eloquent_to_array

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -280,12 +280,23 @@ function array_except($array, $keys)
  */
 function eloquent_to_json($models)
 {
+	return json_encode(eloquent_to_array($models));
+}
+
+/**
+ * Transform Eloquent models to an array.
+ *
+ * @param  Eloquent|array  $models
+ * @return object
+ */
+function eloquent_to_array($models)
+{
 	if ($models instanceof Laravel\Database\Eloquent\Model)
 	{
-		return json_encode($models->to_array());
+		return $models->to_array();
 	}
 
-	return json_encode(array_map(function($m) { return $m->to_array(); }, $models));
+	return array_map(function($m) { return $m->to_array(); }, $models);
 }
 
 /**


### PR DESCRIPTION
Occasionally, I've needed to convert individual model responses `to_array` before json encoding the entire array. I added an `eloquent_to_array` function which is then called `by eloquent_to_json`.

```
public static function bootstrap($id)
{
   $model = static::find($id);

   // this array will be converted to json
   return Response::json(array(
        'users' => $model->to_array(),
        'messages' => eloquent_to_array($model->messages()->get()),
        'accounts' => eloquent_to_array($model->accounts()->get())
   ));
}
```
