### PR TITLE
Update LaravelRequest.php to alllow PUT/DELETE/PATCH on PHP5.4 built-in server

### DIFF
--- a/laravel/vendor/Symfony/Component/HttpFoundation/LaravelRequest.php
+++ b/laravel/vendor/Symfony/Component/HttpFoundation/LaravelRequest.php
@@ -13,7 +13,8 @@ class LaravelRequest extends Request {
     {
         $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
 
-        if (0 === strpos($request->server->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+        if ((0 === strpos($request->server->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+    		|| (0 === strpos($request->server->get('HTTP_CONTENT_TYPE'), 'application/x-www-form-urlencoded')))
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))
         ) {
             parse_str($request->getContent(), $data);


### PR DESCRIPTION
This will allow the built in PHP 5.4 server to interpret PUT, DELETE, and PATCH content.

It uses the HTTP_CONTENT_TYPE variable instead of CONTENT_TYPE. Symfony hasn't adapted for this yet.
