### PR TITLE
Added migrate:rebuild command to clean and reconstruct the database

### DIFF
--- a/laravel/cli/tasks/migrate/migrator.php
+++ b/laravel/cli/tasks/migrate/migrator.php
@@ -140,6 +140,25 @@ class Migrator extends Task {
 	}
 
 	/**
+	 * Reset the database to pristine state and run all migrations
+	 *
+	 * @param  array  $arguments
+	 * @return void
+	 */
+	public function rebuild()
+	{
+		// Clean the database
+		$this->reset();
+
+		echo PHP_EOL;
+
+		// Re-run all migrations
+		$this->migrate();
+
+		echo 'The database was successfully rebuilt'.PHP_EOL;
+	}
+
+	/**
 	 * Install the database tables used by the migration system.
 	 *
 	 * @return void

--- a/laravel/documentation/database/migrations.md
+++ b/laravel/documentation/database/migrations.md
@@ -33,7 +33,7 @@ You can easily create migrations through Laravel's "Artisan" CLI. It looks like 
 
 Now, check your **application/migrations** folder. You should see your brand new migration! Notice that it also contains a timestamp. This allows Laravel to run your migrations in the correct order.
 
-You may also create migrations for a bundle. 
+You may also create migrations for a bundle.
 
 **Creating a migration for a bundle:**
 
@@ -70,3 +70,7 @@ When you roll back a migration, Laravel rolls back the entire migration "operati
 **Roll back all migrations that have ever run:**
 
 	php artisan migrate:reset
+
+**Roll back everything and run all migrations again:**
+
+	php artisan migrate:rebuild


### PR DESCRIPTION
This is a command for something I do almost ten times a day in testing phase : cleaning the database and running all migrations to return it to a clean state.
This basically just does `php artisan migrate:reset && php artisan migrate`. Whether you have seeding migrations or not, I consider this really useful.
