### PR TITLE
Add URL::to_language and HTML::link_to_language localization helpers

### DIFF
--- a/laravel/documentation/urls.md
+++ b/laravel/documentation/urls.md
@@ -59,6 +59,17 @@ Sometimes you may need to generate a URL to a named route, but also need to spec
 
 	$url = URL::to_action('user@profile', array($username));
 
+<a name="urls-to-a-different-language"></a>
+## URLs To A Different Language
+
+#### Generating a URL to the same page in another language:
+
+	$url = URL::to_language('fr');
+
+#### Generating a URL to your home page in another language:
+
+	$url = URL::to_language('fr', true);
+
 <a name="urls-to-assets"></a>
 ## URLs To Assets
 

--- a/laravel/documentation/views/html.md
+++ b/laravel/documentation/views/html.md
@@ -87,6 +87,17 @@ For example, the < symbol should be converted to its entity representation. Conv
 
 	echo HTML::link_to_action('user@profile', 'User Profile', array($username));
 
+<a name="links-to-a-different-language"></a>
+## Links To A Different Language
+
+#### Generating a link to the same page in another language:
+
+	echo HTML::link_to_language('fr');
+
+#### Generating a link to your home page another language
+
+	echo HTML::link_to_language('fr', true);
+
 <a name="mail-to-links"></a>
 ## Mail-To Links
 
@@ -119,7 +130,7 @@ The "mailto" method on the HTML class obfuscates the given e-mail address so it 
 	echo HTML::ol(array('Get Peanut Butter', 'Get Chocolate', 'Feast'));
 
 	echo HTML::ul(array('Ubuntu', 'Snow Leopard', 'Windows'));
-	
+
 	echo HTML::dl(array('Ubuntu' => 'An operating system by Canonical', 'Windows' => 'An operating system by Microsoft'));
 
 <a name="custom-macros"></a>

--- a/laravel/html.php
+++ b/laravel/html.php
@@ -239,6 +239,19 @@ class HTML {
 	}
 
 	/**
+	 * Generate an HTML link to a different language
+	 *
+	 * @param  string  $language
+	 * @param  string  $title
+	 * @param  array   $attributes
+	 * @return string
+	 */
+	public static function link_to_language($language, $title = null, $attributes = array())
+	{
+		return static::link(URL::to_language($language), $title, $attributes);
+	}
+
+	/**
 	 * Generate an HTML mailto link.
 	 *
 	 * The E-Mail address will be obfuscated to protect it from spam bots.
@@ -347,7 +360,7 @@ class HTML {
 
 		return '<'.$type.static::attributes($attributes).'>'.$html.'</'.$type.'>';
 	}
-	
+
 	/**
 	 * Generate a definition list.
 	 *
@@ -360,13 +373,13 @@ class HTML {
 		$html = '';
 
 		if (count($list) == 0) return $html;
-		
+
 		foreach ($list as $term => $description)
 		{
 			$html .= '<dt>'.static::entities($term).'</dt>';
 			$html .= '<dd>'.static::entities($description).'</dd>';
 		}
-		
+
 		return '<dl'.static::attributes($attributes).'>'.$html.'</dl>';
 	}
 

--- a/laravel/tests/cases/url.test.php
+++ b/laravel/tests/cases/url.test.php
@@ -105,6 +105,26 @@ class URLTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://localhost/index.php/url/test/taylor/otwell', URL::to_route('url-test-2', array('taylor', 'otwell')));
 	}
 
+	/**
+	 * Test the URL::to_language method.
+	 *
+	 * @group laravel
+	 */
+	public function testToLanguageMethodGeneratesURLsToDifferentLanguage()
+	{
+		URI::$uri = 'foo/bar';
+		Config::set('application.languages', array('sp', 'fr'));
+		Config::set('application.language', 'sp');
+
+		$this->assertEquals('http://localhost/index.php/fr/foo/bar', URL::to_language('fr'));
+		$this->assertEquals('http://localhost/index.php/fr/', URL::to_language('fr', true));
+
+		Config::set('application.index', '');
+		$this->assertEquals('http://localhost/fr/foo/bar', URL::to_language('fr'));
+
+		$this->assertEquals('http://localhost/sp/foo/bar', URL::to_language('en'));
+	}
+
 
 	/**
 	 * Test language based URL generation.

--- a/laravel/url.php
+++ b/laravel/url.php
@@ -295,6 +295,31 @@ class URL {
 	}
 
 	/**
+	 * Get the URL to switch language, keeping the current page or not
+	 *
+	 * @param  string  $language  The new language
+	 * @param  boolean $reset     Whether navigation should be reset
+	 * @return string             An URL
+	 */
+	public static function to_language($language, $reset = false)
+	{
+		// Get the url to use as base
+		$url = $reset ? URL::home() : URL::to(URI::current());
+
+		// Validate the language
+		if (!in_array($language, Config::get('application.languages')))
+		{
+			return $url;
+		}
+
+		// Get the language we're switching from and the one we're going to
+		$from = '/'.Config::get('application.language').'/';
+		$to   = '/'.$language.'/';
+
+		return str_replace($from, $to, $url);
+	}
+
+	/**
 	 * Substitute the parameters in a given URI.
 	 *
 	 * @param  string  $uri


### PR DESCRIPTION
This adds two helpers for a very common task in localized websites : creating links that point to different languages. The functions are very straightforward :

``` php
// Points to the french version, keeping current page
URL::to_language('fr') 

// Points to the french version, reseting page to home (mywebsite/fr/)
URL::to_language('fr', $reset = true)

// Generate a link to another language
HTML::link_to_language('fr', 'French version')
```

There's room for improvement so I'm waiting for your opinions on this.
