### PR TITLE
Update "docs/views/html.md", parse error in example code.

### DIFF
--- a/laravel/documentation/views/html.md
+++ b/laravel/documentation/views/html.md
@@ -21,11 +21,11 @@ For example, the < symbol should be converted to its entity representation. Conv
 
 #### Converting a string to its entity representation:
 
-	echo HTML::entities('<script>alert('hi');</script>');
+	echo HTML::entities('<script>alert(\'hi\');</script>');
 
 #### Using the "e" global helper:
 
-	echo e('<script>alert('hi');</script>');
+	echo e('<script>alert(\'hi\');</script>');
 
 <a name="scripts-and-style-sheets"></a>
 ## Scripts And Style Sheets


### PR DESCRIPTION
The example code for the `HTML::entities()` method in the documentation had unescaped apostrophes (single quotes) in the string passed as the first parameter.
A parse error would have resulted should someone try to use that code.

Plus it is really bugging me every time I view that page in the documentation.
