### PR TITLE
added $attributes to sync() like attach()

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -116,9 +116,10 @@ class Has_Many_And_Belongs_To extends Relationship {
 	 * Sync the joining table with the array of given IDs.
 	 *
 	 * @param  array  $ids
+	 * @param  array  $attributes
 	 * @return bool
 	 */
-	public function sync($ids)
+	public function sync($ids, $attributes)
 	{
 		$current = $this->pivot()->lists($this->other_key());
 		$ids = (array) $ids;
@@ -130,7 +131,7 @@ class Has_Many_And_Belongs_To extends Relationship {
 		{
 			if ( ! in_array($id, $current))
 			{
-				$this->attach($id);
+				$this->attach($id, $attributes);
 			}
 		}
 


### PR DESCRIPTION
sync is basically a shortcut to a foreach loop using attach.  Now you can pass attributes you want synced as well since it's just using attach() anyways.

I use this in my own application clouddueling all the time to manage a business has employees relationship and give me access when I want to do special things like tracking activity.  (e.g. "This person added this to this.  Would you like to fire them?")
