### PR TITLE
Fixed connector options merge bug.

### DIFF
--- a/laravel/database/connectors/connector.php
+++ b/laravel/database/connectors/connector.php
@@ -35,7 +35,7 @@ abstract class Connector {
 	{
 		$options = (isset($config['options'])) ? $config['options'] : array();
 
-		return $this->options + $options;
+		return $options + $this->options;
 	}
 
 }


### PR DESCRIPTION
Fixed issue with options ordering when merging the default and user values into one array.

Currently any user specified options do not override the default values provided, due to PHP's array operator implementation of + taking precedents of elements from the left-hand array.
