### PR TITLE
Use `mb_substr` instead of `sub_str` in order to resolve multi-language problem.

### DIFF
--- a/laravel/crypter.php
+++ b/laravel/crypter.php
@@ -129,7 +129,14 @@ class Crypter {
 	 */
 	protected static function unpad($value)
 	{
-		$pad = ord($value[($length = Str::length($value)) - 1]);
+		if (MB_STRING)
+		{
+			$pad = ord(mb_substr($value, -1, 1, Config::get('application.encoding')));
+		}
+		else
+		{
+			$pad = ord(substr($value, -1));
+		}
 
 		if ($pad and $pad < static::$block)
 		{
@@ -138,7 +145,12 @@ class Crypter {
 			// as the padding appears to have been changed.
 			if (preg_match('/'.chr($pad).'{'.$pad.'}$/', $value))
 			{
-				return substr($value, 0, $length - $pad);
+				if (MB_STRING)
+				{
+					return mb_substr($value, 0, Str::length($value) - $pad, Config::get('application.encoding'));
+				}
+
+				return substr($value, 0, Str::length($value) - $pad);
 			}
 
 			// If the padding characters do not match the expected padding


### PR DESCRIPTION
Fix some issues like http://forums.laravel.com/viewtopic.php?id=1659
