### PR TITLE
CSS resets for the profiler bar

### DIFF
--- a/laravel/profiling/profiler.css
+++ b/laravel/profiling/profiler.css
@@ -1,3 +1,8 @@
+.anbu * {
+	color: black;
+	border: 0 !important;
+}
+
 .anbu
 {
 	font-family:Helvetica, "Helvetica Neue", Arial, sans-serif !important;


### PR DESCRIPTION
We want to reset the profiler bar so that it's still readable even if the page's font color is light or borders are added to links.
