### PR TITLE
Check if other attribute exists in required_with.

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -269,8 +269,9 @@ class Validator {
 	protected function validate_required_with($attribute, $value, $parameters)
 	{
 		$other = $parameters[0];
+		$other_value = isset($this->attributes[$other]) ? $this->attributes[$other] : null;
 
-		if ($this->validate_required($other, $this->attributes[$other]))
+		if ($this->validate_required($other, $other_value))
 		{
 			return $this->validate_required($attribute, $value);
 		}


### PR DESCRIPTION
When using checkboxes, it throws up an error saying unidentified index when it's not checked. This update fix that.
