### PR TITLE
[Eloquent] Allow hiding relationships

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -615,6 +615,9 @@ abstract class Model {
 
 		foreach ($this->relationships as $name => $models)
 		{
+			// Relationships can be marked as "hidden", too.
+			if (in_array($name, static::$hidden)) continue;
+
 			// If the relationship is not a "to-many" relationship, we can just
 			// to_array the related model and add it as an attribute to the
 			// array of existing regular attributes we gathered.


### PR DESCRIPTION
When generating an array (for JSON etc.) from a model with `to_array()`, hidden relationships weren't hidden.
