### PR TITLE
Allow forward slash separators in Str::classify()

### DIFF
--- a/laravel/str.php
+++ b/laravel/str.php
@@ -296,7 +296,7 @@ class Str {
 	 */
 	public static function classify($value)
 	{
-		$search = array('_', '-', '.');
+		$search = array('_', '-', '.', '/');
 
 		return str_replace(' ', '_', static::title(str_replace($search, ' ', $value)));
 	}


### PR DESCRIPTION
Currently, any strings that have a "/" in them, when Str::classify() is called the the expected class has a slash:

```
 <?php
$class = Str::classify('platform/dashboard foo bar');

// Produces:
Platform/dashboard_Foo_Bar

// Could produce
Platform_Dashboard_Foo_Bar
```
