### PR TITLE
Custom auth password throwing undefined array key

### DIFF
--- a/laravel/auth/drivers/eloquent.php
+++ b/laravel/auth/drivers/eloquent.php
@@ -46,9 +46,9 @@ class Eloquent extends Driver {
 
 		// If the credentials match what is in the database we will just
 		// log the user into the application and remember them if asked.
-		$password = $arguments['password'];
-
 		$password_field = Config::get('auth.password', 'password');
+
+		$password = $arguments[$password_field];		
 
 		if ( ! is_null($user) and Hash::check($password, $user->{$password_field}))
 		{

--- a/laravel/auth/drivers/fluent.php
+++ b/laravel/auth/drivers/fluent.php
@@ -34,9 +34,9 @@ class Fluent extends Driver {
 
 		// If the credentials match what is in the database we will just
 		// log the user into the application and remember them if asked.
-		$password = $arguments['password'];
-
 		$password_field = Config::get('auth.password', 'password');
+
+		$password = $arguments[$password_field];
 
 		if ( ! is_null($user) and Hash::check($password, $user->{$password_field}))
 		{


### PR DESCRIPTION
Fixed bug where a custom password key in Auth would throw an undefined array key 'password' in all instances.
