### PR TITLE
Adding possibility to delete rows with join clauses

### DIFF
--- a/laravel/database/query/grammars/grammar.php
+++ b/laravel/database/query/grammars/grammar.php
@@ -425,7 +425,7 @@ class Grammar extends \Laravel\Database\Grammar {
 	{
 		$table = $this->wrap_table($query->from);
 
-		return trim("DELETE FROM {$table} ".$this->wheres($query));
+		return trim("DELETE {$table} FROM {$table} ".$this->joins($query).' '.$this->wheres($query)));
 	}
 
 	/**


### PR DESCRIPTION
Either on fluent or eloquent, it's impossible to delete rows when using join statements.
I'm not 100% sure this works with all SQL variations. Still, I'm submitting it to others approves.
