### PR TITLE
Small Changes on the Language File (PT-PT)

### DIFF
--- a/application/language/pt/validation.php
+++ b/application/language/pt/validation.php
@@ -18,7 +18,7 @@ return array(
 	|
 	*/
 
-	"accepted"       => "O :attribute deve ser aceito.",
+	"accepted"       => "O :attribute deve ser aceite.",
 	"active_url"     => "O :attribute não é uma URL válida.",
 	"after"          => "O :attribute deve ser uma data após :date.",
 	"alpha"          => "O :attribute só pode conter letras.",


### PR DESCRIPTION
I'm a native Portuguese and i think it sounds better that way:

"accepted"       => "O :attribute deve ser aceite."
instead of
"accepted"       => "O :attribute deve ser aceito.",
