### PR TITLE
Prevent notice "Undefined index"

### DIFF
--- a/paths.php
+++ b/paths.php
@@ -132,7 +132,12 @@ foreach ($paths as $name => $path)
  */
 function path($path)
 {
-	return $GLOBALS['laravel_paths'][$path];
+    // Make sure the variable exists
+    if (isset($GLOBALS['laravel_paths'][$path])) {
+	    return $GLOBALS['laravel_paths'][$path];
+    } else {
+        return '';
+    }
 }
 
 /**


### PR DESCRIPTION
This will probably just appear during development, but we really should make sure the variable exists before returning it.
