### PR TITLE
Throw exception if path don't exist

### DIFF
--- a/paths.php
+++ b/paths.php
@@ -122,13 +122,14 @@ foreach ($paths as $name => $path)
 
 /**
  * A global path helper function.
- * 
+ *
  * <code>
  *     $storage = path('storage');
  * </code>
- * 
- * @param  string  $path
- * @return string
+ *
+ * @param $path
+ * @return mixed
+ * @throws Exception
  */
 function path($path)
 {
@@ -136,7 +137,7 @@ function path($path)
     if (isset($GLOBALS['laravel_paths'][$path])) {
 	    return $GLOBALS['laravel_paths'][$path];
     } else {
-        return '';
+        throw new Exception('Path "' . $path . '" is not set in $GLOBALS');
     }
 }
 


### PR DESCRIPTION
When calling path() and the requested variable doesn't exists, throw an exception to early notify the developer
