### PR TITLE
Allow Profiler to display logged arrays

### DIFF
--- a/laravel/profiling/template.blade.php
+++ b/laravel/profiling/template.blade.php
@@ -16,7 +16,7 @@
 									{{ $log[0] }}
 								</td>
 								<td>
-									{{ $log[1] }}
+									{{ var_dump($log[1]) }}
 								</td>
 						@endforeach
 						</tr>


### PR DESCRIPTION
This allows a developer to log $array variables, and get the full
output. Currently only the word "array" appears if you try to log an
array. But by changing to var_dump() you can view the full contents of
the array
