### PR TITLE
Automatically apply entities to output using Blade

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -197,6 +197,8 @@ class Blade {
 	 */
 	protected static function compile_echos($value)
 	{
+		$value = preg_replace('/\{\{\{(.+?)\}\}\}/', '<?php echo HTML::entities($1); ?>', $value);
+
 		return preg_replace('/\{\{(.+?)\}\}/', '<?php echo $1; ?>', $value);
 	}
 

--- a/laravel/tests/cases/blade.test.php
+++ b/laravel/tests/cases/blade.test.php
@@ -13,9 +13,13 @@ class BladeTest extends PHPUnit_Framework_TestCase {
 	{
 		$blade1 = '{{$a}}';
 		$blade2 = '{{e($a)}}';
+		$blade3 = '{{{$a}}}';
+		$blade4 = '{{{e($a)}}}';
 
 		$this->assertEquals('<?php echo $a; ?>', Blade::compile_string($blade1));
 		$this->assertEquals('<?php echo e($a); ?>', Blade::compile_string($blade2));
+		$this->assertEquals('<?php echo HTML::entities($a); ?>', Blade::compile_string($blade3));
+		$this->assertEquals('<?php echo HTML::entities(e($a)); ?>', Blade::compile_string($blade4));
 	}
 
 	/**


### PR DESCRIPTION
By using 3 braces instead of 2, you can now automatically apply
HTML::entities() to any output
