### PR TITLE
Remove underscore from default cookie name

### DIFF
--- a/application/config/session.php
+++ b/application/config/session.php
@@ -76,10 +76,12 @@ return array(
 	|--------------------------------------------------------------------------
 	|
 	| The name that should be given to the session cookie.
+	| Avoid using an underscore "_" in the cookie name, as some browesers (i.e. IE)
+	| dont always accept cookies with an underscore
 	|
 	*/
 
-	'cookie' => 'laravel_session',
+	'cookie' => 'laravelSession',
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Internet explorer can sometimes reject a cookie with an underscore. This caused numerous issues on CI - there are lots of CI forums posts about the issue, because the default CI cookie contained an underscore (apart from other issues which I wont go into).

So I thought it makes sense to remove it from Laravel to prevent any similar issues from popping up in the future.
