### PR TITLE
Fix for validate_required_with

### DIFF
--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -269,8 +269,9 @@ class Validator {
 	protected function validate_required_with($attribute, $value, $parameters)
 	{
 		$other = $parameters[0];
+		$other_value = array_get($this->attributes, $other);		
 
-		if ($this->validate_required($other, $this->attributes[$other]))
+		if ($this->validate_required($other, $other_value))
 		{
 			return $this->validate_required($attribute, $value);
 		}


### PR DESCRIPTION
Hi,

If using dynamic model properties (with eloquent for example), this validation routine will throw an error if the required with field does not exist. 

I've added an array_get call to safely obtain the value from the attributes array so that it will not throw an error if the attribute does not (yet) exist
