### PR TITLE
Added ability to call Eloquent::with on a Relationship instance

### DIFF
--- a/laravel/database/eloquent/relationships/relationship.php
+++ b/laravel/database/eloquent/relationships/relationship.php
@@ -119,4 +119,17 @@ abstract class Relationship extends Query {
 		return array_unique($keys);
 	}
 
+	/**
+	 * The relationships that should be eagerly loaded by the query.
+	 *
+	 * @param  array  $includes
+	 * @return Relationship
+	 */
+	public function with($includes)
+	{
+		$this->model->includes = (array) $includes;
+
+		return $this;
+	}
+
 }


### PR DESCRIPTION
This PR allows for calling `Eloquent::with` even after a relationship query has already started.

I added this for myself a couple months ago, I'm not quite sure if this can be moved up to the `Eloquent\Query` class. That however would not have much benefits I guess, as this extension is mainly useful when you want to eager load a relationship, which isn't currently possible.
