### PR TITLE
Fix for white-on-white profiler text when using dark site theme

### DIFF
--- a/laravel/profiling/profiler.css
+++ b/laravel/profiling/profiler.css
@@ -8,6 +8,7 @@
 	right:0 !important;
 	width:100%;
 	z-index: 9999 !important;
+	color: #000;
 }
 
 .anbu-tabs


### PR DESCRIPTION
![7yvh](https://f.cloud.github.com/assets/283772/32003/7935e958-4fd6-11e2-8cbf-9c0fadc96259.png)
