### PR TITLE
Normalize controller detection

### DIFF
--- a/laravel/routing/controller.php
+++ b/laravel/routing/controller.php
@@ -111,6 +111,10 @@ abstract class Controller {
 			}
 		}
 
+		// This will normalize the results of the controllers between different
+		// filesystems, while retaining the expected behaviour.
+		rsort($controllers, SORT_STRING | SORT_FLAG_CASE);
+
 		return $controllers;
 	}
 


### PR DESCRIPTION
Nested controller directories that are named similar to controller files (i.e., foo/ and foo.php) will be detected differently between the HFS+ and Ext4 (possibly others).

This patch will normalize the controllers by reverse sorting them so that regardless of the filesystem, the results will be the same across different filesystems in a way that does not break backward compatibility.
