### PR TITLE
Removed the 'id' field from the class property declaration.

### DIFF
--- a/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
+++ b/laravel/database/eloquent/relationships/has_many_and_belongs_to.php
@@ -25,7 +25,7 @@ class Has_Many_And_Belongs_To extends Relationship {
 	 *
 	 * @var array
 	 */
-	protected $with = array('id');
+	protected $with = array();
 
 	/**
 	 * Create a new many to many relationship instance.


### PR DESCRIPTION
If a pivot table does not have an id field, then attempts to use $this->has_many_and_belongs_to() will fail. 
