### PR TITLE
Fix the support of multiple schemes for PostgreSQL

### DIFF
--- a/laravel/database/connectors/postgres.php
+++ b/laravel/database/connectors/postgres.php
@@ -48,7 +48,7 @@ class Postgres extends Connector {
 		// the database to set the search path.
 		if (isset($config['schema']))
 		{
-			$connection->prepare("SET search_path TO '{$config['schema']}'")->execute();
+			$connection->prepare("SET search_path TO {$config['schema']})->execute();
 		}
 
 		return $connection;


### PR DESCRIPTION
This will fix support of multiple schemes for PostgreSQL.
For example, you may need to use PostgreSQL DB with several schemes.
Each of them may have partial tables (tables in DB may be split into several schemes).
In this case you will need to provide scheme name before each table or field request within SQL code.
Laravel uses native PostgreSQL feature that will look through all schemes declared in search_path variable untill first met desired object.

But this cool feature in case of multiple schemes doesn't work in Laravel due to those unnecessary single quotes.
To test multiple schemes, create two new schemes i.e. myscheme1 and myscheme2 and try to write into you database configuration:

``` php
'schema' => 'myscheme1, myscheme2'
```

after that split some tables through those schemes (i.e. move table users to myscheme2).
When you will run your appliaction you will met smth. like following error:

```
SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "users" doesn't exists.
```

Try to remove those single quotes and you will see that it will fix this issue.
