### PR TITLE
Added a more dynamic method for checking dblib (response to ticket #770)

### DIFF
--- a/laravel/database/connectors/sqlserver.php
+++ b/laravel/database/connectors/sqlserver.php
@@ -30,7 +30,7 @@ class SQLServer extends Connector {
 		$port = (isset($port)) ? ','.$port : '';
 		
 		//check for dblib for mac users connecting to mssql (utilizes freetds)
-		if (!empty($dsn_type) and $dsn_type == 'dblib')
+		if (in_array('dblib',PDO::getAvailableDrivers()))
 		{
 			$dsn = "dblib:host={$host}{$port};dbname={$database}";
 		}


### PR DESCRIPTION
Added in a more dynamic method for checking whether to use dblib or
sqlsrv drivers for a mssql pdo connection. This is to make local mac
devs work well with windows prod machines.
