### PR TITLE
Use $.noConflict in profiler to prevent conflicts in multiple versions of jQuery.

### DIFF
--- a/laravel/profiling/profiler.js
+++ b/laravel/profiling/profiler.js
@@ -1,4 +1,9 @@
 var anbu = {
+	// Sandbox a jQuery instance for the profiler.
+	jq: jQuery.noConflict(true)
+};
+
+anbu.jq.extend(anbu, {
 
 	// BOUND ELEMENTS
 	// -------------------------------------------------------------
@@ -6,20 +11,20 @@ var anbu = {
 	// the DOM every time they are used.
 
 	el: {
-		main: jQuery('.anbu'),
-		close: jQuery('#anbu-close'),
-		zoom: jQuery('#anbu-zoom'),
-		hide: jQuery('#anbu-hide'),
-		show: jQuery('#anbu-show'),
-		tab_pane: jQuery('.anbu-tab-pane'),
-		hidden_tab_pane: jQuery('.anbu-tab-pane:visible'),
-		tab: jQuery('.anbu-tab'),
-		tabs: jQuery('.anbu-tabs'),
-		tab_links: jQuery('.anbu-tabs a'),
-		window: jQuery('.anbu-window'),
-		closed_tabs: jQuery('#anbu-closed-tabs'),
-		open_tabs: jQuery('#anbu-open-tabs'),
-		content_area: jQuery('.anbu-content-area')
+		main: anbu.jq('.anbu'),
+		close: anbu.jq('#anbu-close'),
+		zoom: anbu.jq('#anbu-zoom'),
+		hide: anbu.jq('#anbu-hide'),
+		show: anbu.jq('#anbu-show'),
+		tab_pane: anbu.jq('.anbu-tab-pane'),
+		hidden_tab_pane: anbu.jq('.anbu-tab-pane:visible'),
+		tab: anbu.jq('.anbu-tab'),
+		tabs: anbu.jq('.anbu-tabs'),
+		tab_links: anbu.jq('.anbu-tabs a'),
+		window: anbu.jq('.anbu-window'),
+		closed_tabs: anbu.jq('#anbu-closed-tabs'),
+		open_tabs: anbu.jq('#anbu-open-tabs'),
+		content_area: anbu.jq('.anbu-content-area')
 	},
 
 	// CLASS ATTRIBUTES
@@ -30,7 +35,7 @@ var anbu = {
 	is_zoomed: false,
 
 	// initial height of content area
-	small_height: jQuery('.anbu-content-area').height(),
+	small_height: anbu.jq('.anbu-content-area').height(),
 
 	// the name of the active tab css
 	active_tab: 'anbu-active-tab',
@@ -76,7 +81,7 @@ var anbu = {
 			event.preventDefault();
 		});
 		anbu.el.tab.click(function(event) {
-			anbu.clicked_tab(jQuery(this));
+			anbu.clicked_tab(anbu.jq(this));
 			event.preventDefault();
 		});
 
@@ -104,8 +109,8 @@ var anbu = {
 	open_window: function(tab) {
 
 		// can't directly assign this line, but it works
-		jQuery('.anbu-tab-pane:visible').fadeOut(200);
-		jQuery('.' + tab.attr(anbu.tab_data)).delay(220).fadeIn(300);
+		anbu.jq('.anbu-tab-pane:visible').fadeOut(200);
+		anbu.jq('.' + tab.attr(anbu.tab_data)).delay(220).fadeIn(300);
 		anbu.el.tab_links.removeClass(anbu.active_tab);
 		tab.addClass(anbu.active_tab);
 		anbu.el.window.slideDown(300);
@@ -172,13 +177,13 @@ var anbu = {
 	// Toggle the zoomed mode of the top window.
 
 	zoom: function() {
-
+		var height;
 		if (anbu.is_zoomed) {
 			height = anbu.small_height;
 			anbu.is_zoomed = false;
 		} else {
 			// the 6px is padding on the top of the window
-			height = (jQuery(window).height() - anbu.el.tabs.height() - 6) + 'px';
+			height = (anbu.jq(window).height() - anbu.el.tabs.height() - 6) + 'px';
 			anbu.is_zoomed = true;
 		}
 
@@ -186,9 +191,7 @@ var anbu = {
 
 	}
 
-};
+});
 
 // launch anbu on jquery dom ready
-jQuery(document).ready(function() {
-	anbu.start();
-});
+anbu.jq(anbu.start);

--- a/laravel/profiling/template.blade.php
+++ b/laravel/profiling/template.blade.php
@@ -119,10 +119,6 @@
 	</ul>
 </div>
 
-@if (Config::get('application.profiler_js_src'))
-	<script>{{ file_get_contents(Config::get('application.profiler_js_src')) }}</script>
-@else
-	<script>window.jQuery || document.write("<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'>\x3C/script>")</script>
-	<script>{{ file_get_contents(path('sys').'profiling/profiler.js') }}</script>
-@endif
+<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+<script>{{ file_get_contents(path('sys').'profiling/profiler.js') }}</script>
 <!-- /ANBU - LARAVEL PROFILER -->


### PR DESCRIPTION
EDIT: this pull request has been modified to simply run the Laravel profiler jQuery in "sandboxed" noConflict mode.
