### PR TITLE
Adds the disabled attribute to an empty-valued option form

### DIFF
--- a/laravel/form.php
+++ b/laravel/form.php
@@ -451,6 +451,8 @@ class Form {
 
 		$attributes = array('value' => HTML::entities($value), 'selected' => $selected);
 
+		if(!$value) $attributes['disabled'] = 'disabled';
+
 		return '<option'.HTML::attributes($attributes).'>'.HTML::entities($display).'</option>';
 	}
 


### PR DESCRIPTION
Adds a disabled attribute to an empty valued <option> form.
e.g:

``` php
$items = array('' => 'Select a color', '0' => 'Blue', '1' => 'Green');
echo Form::select('color', $items, '');
```

Should output something like:

``` php
<select id="color" name="color">
 <option disabled="disabled" selected="selected" value="">Select a color</option>
 <option value="0">Blue</option>
 <option value="1">Green</option>
</select>
```
