### PR TITLE
Respect LARAVEL_ENV variable

### DIFF
--- a/laravel/core.php
+++ b/laravel/core.php
@@ -171,9 +171,9 @@ Request::$foundation = RequestFoundation::createFromGlobals();
 
 if (Request::cli())
 {
-	$environment = get_cli_option('env');
+	$environment = get_cli_option('env', getenv('LARAVEL_ENV'));
 
-	if ( ! isset($environment))
+	if (empty($environment))
 	{
 		$environment = Request::detect_env($environments, gethostname());
 	}


### PR DESCRIPTION
Laravel **should** respect `LARAVEL_ENV` variable when running through CLI
