### PR TITLE
Adds a parameter to Query::insert() to allow INSERT IGNOREs

### DIFF
--- a/laravel/database/query.php
+++ b/laravel/database/query.php
@@ -787,7 +787,7 @@ class Query {
 	 * @param  array  $values
 	 * @return bool
 	 */
-	public function insert($values)
+	public function insert($values, $ignore = false)
 	{
 		// Force every insert to be treated like a batch insert to make creating
 		// the binding array simpler since we can just spin through the inserted
@@ -804,7 +804,7 @@ class Query {
 			$bindings = array_merge($bindings, array_values($value));
 		}
 
-		$sql = $this->grammar->insert($this, $values);
+		$sql = $this->grammar->insert($this, $values, $ignore);
 
 		return $this->connection->query($sql, $bindings);
 	}

--- a/laravel/database/query/grammars/grammar.php
+++ b/laravel/database/query/grammars/grammar.php
@@ -378,7 +378,7 @@ class Grammar extends \Laravel\Database\Grammar {
 	 * @param  array   $values
 	 * @return string
 	 */
-	public function insert(Query $query, $values)
+	public function insert(Query $query, $values, $ignore = false)
 	{
 		$table = $this->wrap_table($query->from);
 
@@ -399,7 +399,9 @@ class Grammar extends \Laravel\Database\Grammar {
 
 		$parameters = implode(', ', array_fill(0, count($values), "($parameters)"));
 
-		return "INSERT INTO {$table} ({$columns}) VALUES {$parameters}";
+		$ignore = ($ignore) ? 'IGNORE ' : null;
+
+		return "INSERT {$ignore}INTO {$table} ({$columns}) VALUES {$parameters}";
 	}
 
 	/**


### PR DESCRIPTION
adds a second parameter to Query::insert() to allow ignores. e.g:

``` php
$data = array(
  array('email' => 'example@gmail.com'),
  array('email' => 'example@yahoo.com')
);
DB::table('users')->insert($data, true);
```

will yield:

``` sql
INSERT IGNORE INTO `posts` (`email`) VALUES (?), (?)
Bindings: array (
  0 => 'example@gmail.com',
  1 => 'example@yahoo.com'
)
```

Without the 2nd parameter, insert behavior remains intact.
