### PR TITLE
Start Workbench in TestCase

### DIFF
--- a/app/tests/TestCase.php
+++ b/app/tests/TestCase.php
@@ -18,6 +18,11 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase {
         return require __DIR__.'/../../start.php';
     }
 
+    /**
+     * Starts the workbench.
+     *
+     * @return void
+     */
     public function startWorkbench()
     {
         if (is_dir($workbench = __DIR__.'/../../workbench'))


### PR DESCRIPTION
Adding a workbench class to the providers array causes tests to fail with a class not found exception. "Starting" the workbench from `TestCase::createApplication()` ensures that the workbench autoloads are loaded.
