### PR TITLE
Added support for using non-Latin characters in URLs

### DIFF
--- a/laravel/uri.php
+++ b/laravel/uri.php
@@ -53,7 +53,7 @@ class URI {
 	 */
 	protected static function format($uri)
 	{
-		return trim($uri, '/') ?: '/';
+		return trim(urldecode($uri), '/') ?: '/';
 	}
 
 	/**


### PR DESCRIPTION
if in an example url has cyrillic (or other non-Latin) characters like this http://domain.tld/статия/заглавие routes won't work properly if they aren't decoded first.
