### PR TITLE
Add calling class and function information in logs. #1634

### DIFF
--- a/laravel/log.php
+++ b/laravel/log.php
@@ -56,7 +56,31 @@ class Log {
 			Event::fire('laravel.log', array($type, $message));
 		}
 
-		$message = static::format($type, $message);
+		$trace=debug_backtrace();
+
+		foreach($trace as $item)
+		{
+			if ($item['class'] == __CLASS__)
+			{
+				continue;
+			}
+
+			$caller = $item;
+
+			break;
+		}
+
+		$function = $caller['function'];
+		if (isset($caller['class']))
+		{
+			$class = $caller['class'] . '::';
+		}
+		else
+		{
+			$class = '';
+		}
+
+		$message = static::format($type, $class . $function . ' - ' . $message);
 
 		File::append(path('storage').'logs/'.date('Y-m-d').'.log', $message);
 	}


### PR DESCRIPTION
Issue #1634 
Add the name of the class and function where a Log::write is called into log messages.

Old log message format:
2013-01-22 23:03:34 ERROR - Space name, backstages, generated non-object

New log message format:
2013-01-22 23:03:34 ERROR - Podioconnect::get_space_id - Space name, backstages, generated non-object
