### PR TITLE
Add calling class and function information in logs

### DIFF
--- a/laravel/log.php
+++ b/laravel/log.php
@@ -60,7 +60,7 @@ class Log {
 
 		foreach($trace as $item)
 		{
-			if ($item['class'] == __CLASS__)
+			if (isset($item['class']) AND $item['class'] == __CLASS__)
 			{
 				continue;
 			}


### PR DESCRIPTION
Issue #1634 
Add the name of the class and function where a Log::write is called into log messages.

Old log message format:
2013-01-22 23:03:34 ERROR - Error message

New log message format:
2013-01-22 23:03:34 ERROR - ClassName::function_name - Error message
