### PR TITLE
Fix bug in ANBU that cause wrong total time showing on SQL tab

### DIFF
--- a/laravel/database/connection.php
+++ b/laravel/database/connection.php
@@ -308,7 +308,7 @@ class Connection {
 	 */
 	protected function log($sql, $bindings, $start)
 	{
-		$time = number_format((microtime(true) - $start) * 1000, 2);
+		$time = (microtime(true) - $start) * 1000;
 
 		Event::fire('laravel.query', array($sql, $bindings, $time));
 

--- a/laravel/profiling/template.blade.php
+++ b/laravel/profiling/template.blade.php
@@ -36,7 +36,7 @@
 						@foreach ($queries as $query)
 							<tr>
 								<td class="anbu-table-first">
-									{{ $query[1] }}ms
+									{{ number_format($query[1], 2) }}ms
 								</td>
 								<td>
 									<pre>{{ $query[0] }}</pre>
@@ -103,7 +103,7 @@
 			<a data-anbu-tab="anbu-sql" class="anbu-tab" href="#">SQL 
 				<span class="anbu-count">{{ count($queries) }}</span>
 				@if (count($queries))
-				<span class="anbu-count">{{ array_sum(array_map(function($q) { return $q[1]; }, $queries)) }}ms</span>
+				<span class="anbu-count">{{ number_format(array_sum(array_pluck($queries, '1')), 2) }}ms</span>
 				@endif
 			</a>
 		</li>


### PR DESCRIPTION
When query time is larger than one second 'array_sum' cannot convert it
to float right. Also, it is better to fire 'laravel.query' event with
raw time as an argument rather than its string representation
