### PR TITLE
Isset should return true if the key exists.

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -711,7 +711,7 @@ abstract class Model {
 	{
 		foreach (array('attributes', 'relationships') as $source)
 		{
-			return array_key_exists($key, $this->{$source}) && $this->{$source}[$key] !== null;
+			if (array_key_exists($key, $this->{$source}) && $this->{$source}[$key] !== null) return true;
 		}
 
 		return false;


### PR DESCRIPTION
Shouldn't __isset() only check if the key "is set"?  Not whether it's `empty`?  The developer can then further test for empty() if they want, but Laravel shouldn't make that assumption in my opinion.
