### PR TITLE
Event firing of 500s now passes along the $exception object

### DIFF
--- a/application/routes.php
+++ b/application/routes.php
@@ -48,7 +48,8 @@ Route::get('/', function()
 |
 | Similarly, we use an event to handle the display of 500 level errors
 | within the application. These errors are fired when there is an
-| uncaught exception thrown in the application.
+| uncaught exception thrown in the application. The exception object
+| that is captured during execution is then passed to the 500 listener.
 |
 */
 
@@ -57,7 +58,7 @@ Event::listen('404', function()
 	return Response::error('404');
 });
 
-Event::listen('500', function()
+Event::listen('500', function($exception)
 {
 	return Response::error('500');
 });

--- a/laravel/error.php
+++ b/laravel/error.php
@@ -54,7 +54,7 @@ class Error {
 		// Using events gives the developer more freedom.
 		else
 		{
-			$response = Event::first('500');
+			$response = Event::first('500', $exception);
 
 			$response = Response::prepare($response);
 		}


### PR DESCRIPTION
Have also updated the commentary / documentation on the Event::listen section of routes.php.
