### PR TITLE
add app commands path to class loader

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -16,6 +16,7 @@ ClassLoader::addDirectories(array(
 	app_path().'/controllers',
 	app_path().'/models',
 	app_path().'/database/seeds',
+	app_path().'/commands',
 
 ));
 


### PR DESCRIPTION
basic commands created from artisan would not register because app/commands was missing from the class loader
