### PR TITLE
Mixed case bundle config variables

### DIFF
--- a/laravel/bundle.php
+++ b/laravel/bundle.php
@@ -397,14 +397,14 @@ class Bundle {
 
 		if (strpos($identifier, '::') !== false)
 		{
-			$element = explode('::', strtolower($identifier));
+			$element = explode('::', $identifier);
 		}
 		// If no bundle is in the identifier, we will insert the default bundle
 		// since classes like Config and Lang organize their items by bundle.
 		// The application folder essentially behaves as a default bundle.
 		else
 		{
-			$element = array(DEFAULT_BUNDLE, strtolower($identifier));
+			$element = array(DEFAULT_BUNDLE, $identifier);
 		}
 
 		return static::$elements[$identifier] = $element;


### PR DESCRIPTION
This commit corrects an issue where you couldn't define config variables with uppercase letters in them.  The variables would be returned as `null` when you attempted to retrieve them.

For example in a bundle named "test"

If you had a config file `config/test.php`:

``` php
return array("sampleOne" => "this is sample one", "sampleTwo" => "this is sample two");
```

`var_dump(Config::get('test::test.sampleOne')));` will return `null`.

However `var_dump(Config::get('test::test.sampleone')));` will give you the correct value of "this is a sample one".

Passes the core unit tests.

This should also close issue #1638 which describes the identical issue.
