### PR TITLE
Hardening the serialization that is part of caching to database

### DIFF
--- a/laravel/cache/drivers/database.php
+++ b/laravel/cache/drivers/database.php
@@ -49,7 +49,7 @@ class Database extends Driver {
 		{
 			if (time() >= $cache->expiration) return $this->forget($key);
 
-			return unserialize(base64_decode($cache->value));
+			return json_decode($cache->value);
 		}
 	}
 
@@ -70,7 +70,7 @@ class Database extends Driver {
 	{
 		$key = $this->key.$key;
 
-		$value = base64_encode(serialize($value));
+		$value = json_encode($value);
 
 		$expiration = $this->expiration($minutes);
 


### PR DESCRIPTION
I get "Serialize error at offset xxxx" errors when reading back caches made from the response of web APIs like Twitter or Facebook.  I did some poking around and found blog posts that describe a fix:
- http://davidwalsh.name/php-serialize-unserialize-issues
- http://lampbear.wordpress.com/2010/06/29/serialize-error-at-offset-how-to-fix/

This patch adds the solution from these blogs and has fixed my errors.
