### PR TITLE
Remove "artisan" reference from index.php due to (what I'm guessing is) copy + paste

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -55,9 +55,9 @@ $app->run();
 | Shutdown The Application
 |--------------------------------------------------------------------------
 |
-| Once Artisan has finished running. We will fire off the shutdown events
-| so that any final work may be done by the application before we shut
-| down the process. This is the last thing to happen to the request.
+| Once the web request has finished running. We will fire off the shutdown
+| events so that any final work may be done by the application before we
+| shut down the process. This is the last thing to happen to the request.
 |
 */
 


### PR DESCRIPTION
In 2a14998be997329ebb86cff5b64df76d00446241 I'm guessing @taylorotwell copied / pasted code from the artisan script to `index.php`. Fixed.
