### PR TITLE
Check type in get_dirty()

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -517,7 +517,7 @@ abstract class Model {
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! array_key_exists($key, $this->original) or $value != $this->original[$key])
+			if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])
 			{
 				$dirty[$key] = $value;
 			}


### PR DESCRIPTION
Hello,
If you have an attribute something like this:
03332 (german zip) and the original value in the database is per example 3332,
you have trouble with this compare (in models/base/ get_dirty() :

if ( ! array_key_exists($key, $this->original) or $value != $this->original[$key])

Because this if doesn't compare the type of the $value and $this->original[$key]
for PHP is 03332 = 3332 so nothing will get in the dirty array which is definitely wrong.
So my proposal for solution is to compare also the type:

if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])

Greetings,
Leif
