### PR TITLE
Fix boundary error in validation messages

### DIFF
--- a/app/lang/en/validation.php
+++ b/app/lang/en/validation.php
@@ -38,9 +38,9 @@ return array(
 	"integer"         => "The :attribute must be an integer.",
 	"ip"              => "The :attribute must be a valid IP address.",
 	"max"             => array(
-		"numeric"     => "The :attribute must be less than :max.",
-		"file"        => "The :attribute must be less than :max kilobytes.",
-		"string"      => "The :attribute must be less than :max characters.",
+		"numeric"     => "The :attribute must be at most :max.",
+		"file"        => "The :attribute must be at most :max kilobytes.",
+		"string"      => "The :attribute must be at most :max characters.",
 	),
 	"mimes"           => "The :attribute must be a file of type: :values.",
 	"min"             => array(


### PR DESCRIPTION
The code checks for less than or equal to, and the error message said "less than". I changed it to "at most".

Sorry for the duplicate pull request--I did the old one in the develop branch, and I wanted to resubmit it in a patch branch.
