### PR TITLE
Fix for double escaping of queries in the profiler

### DIFF
--- a/laravel/profiling/profiler.php
+++ b/laravel/profiling/profiler.php
@@ -146,9 +146,9 @@ class Profiler {
 		foreach ($bindings as $binding)
 		{
 			$binding = Database::escape($binding);
-
+			
 			$sql = preg_replace('/\?/', $binding, $sql, 1);
-			$sql = htmlspecialchars($sql);
+			$sql = htmlspecialchars($sql, ENT_QUOTES, 'UTF-8', false);
 		}
 
 		static::$data['queries'][] = array($sql, $time);


### PR DESCRIPTION
Sometimes the logged queries would be rendered with visible
HTML entities in the profiler, due to double encoding (You know,
&amp;gt; stuff). I could not find out why it was being escaped
twice, but I found an easy fix: since PHP 5.2.3 the htmlspecialchars
function had a double_encoding parameter that could be set
to false. Voilà!
