### PR TITLE
Check application.ssl when setting a secure cookie

### DIFF
--- a/laravel/cookie.php
+++ b/laravel/cookie.php
@@ -82,6 +82,10 @@ class Cookie {
 
 		$value = static::hash($value).'+'.$value;
 
+		// If the developer has explicitly disabled SLL, then we shouldn't force
+		// this cookie over SSL.
+		$secure = $secure && Config::get('application.ssl');
+
 		// If the secure option is set to true, yet the request is not over HTTPS
 		// we'll throw an exception to let the developer know that they are
 		// attempting to send a secure cookie over the insecure HTTP.


### PR DESCRIPTION
Most SLL-related code in Laravel checks to see if `application.ssl`
is true before doing an action requiring it. `Cookie::put()` is the
only exception that I've found, to date, that doesn't test for SSL.

This checks to see that the SSL is enabled when attempting to set a
secure cookie.

To verify, set `application.ssl` to false (without this patch) then
run:

```
Cookie::put('foo', 'bar', 0, '/', null, true);
```

You will get an exception because of line 90 in `cookie.php`:

```
    if ($secure and ! Request::secure())
    {
        throw new \Exception("Attempting to set secure cookie over HTTP.");
    }
```

With this patch you will not get this error unless both `application.ssl`
is true, and the cookie `$secure` flag is set.

P.S. I've set the base branch of the pull request to `master` because the `develop` branch is L4. Where will L3 be maintained when the master branch switches to L4?
