### PR TITLE
Add validation error message for the 'required_without' rule

### DIFF
--- a/app/lang/en/validation.php
+++ b/app/lang/en/validation.php
@@ -53,6 +53,7 @@ return array(
 	"regex"           => "The :attribute format is invalid.",
 	"required"        => "The :attribute field is required.",
 	"required_with"   => "The :attribute field is required when :values is present.",
+	"required_without" => "The :attribute field is required when :values is not present.",
 	"same"            => "The :attribute and :other must match.",
 	"size"            => array(
 		"numeric"    => "The :attribute must be :size.",


### PR DESCRIPTION
Add an error message for the 'required_without' validation rule. 

This pull request is related to https://github.com/laravel/framework/pull/824.
