### PR TITLE
Add Macros to tables

### DIFF
--- a/laravel/database/schema/table.php
+++ b/laravel/database/schema/table.php
@@ -40,6 +40,25 @@ class Table {
 	public $commands = array();
 
 	/**
+	 * The registered custom macros.
+	 *
+	 * @var array
+	 */
+	public static $macros = array();
+
+	/**
+	 * Registers a custom macro.
+	 *
+	 * @param  string   $name
+	 * @param  Closure  $macro
+	 * @return void
+	 */
+	public static function macro($name, $macro)
+	{
+		static::$macros[$name] = $macro;
+	}
+
+	/**
 	 * Create a new schema table instance.
 	 *
 	 * @param  string  $name
@@ -420,6 +439,24 @@ class Table {
 		$parameters = array_merge(compact('type'), $parameters);
 
 		return $this->columns[] = new Fluent($parameters);
+	}
+
+	/**
+	 * Dynamically handle calls to custom macros.
+	 *
+	 * @param  string  $method
+	 * @param  array   $parameters
+	 * @return mixed
+	 */
+	public function __call($method, $parameters)
+	{
+		if (isset(static::$macros[$method]))
+		{
+			array_unshift($parameters, $this);
+			return call_user_func_array(static::$macros[$method], $parameters);
+		}
+
+		throw new \Exception("Method [$method] does not exist.");
 	}
 
 }


### PR DESCRIPTION
Here's the theory behind this:

Let's say I wanted to create a bundle that allowed for adding timestamps to an eloquent model.  Yes, Laravel already does it, but pretend it didn't.  As of now, you'd need to give instructions to users to create the two new columns in their table, make sure they named them correctly and had the right column type, etc..

By allowing table macros, you can do all the hard work for them.  In the fictional Timestampable bundle's `start.php` file, you could include code like this:

``` php
Laravel\Database\Schema\Table::macro('timestampable', function($table) {
    $table->date('created_at');
    $table->date('updated_at');
});
```

Then, the user only needs to do this in their migrations:

``` php
Schema::create('foo', function($table)
{
    $table->increments('id');
    $table->string('name');
    $table->timestampable();
});
```

Of course, you would also create a `Timestampable` trait that would manage the setting and updating of those values on `save()` ... but that's not important here.

So, the main reason is to allow bundle authors the ability to do custom schema declarations, without pushing the complexity to the end user.  As a more complex example, consider:

``` php
Laravel\Database\Schema\Table::macro('uploader', function($table, $file) {
    $table->string($file.'_name');
    $table->string($file.'_original_name');
    $table->integer($file.'_size');
});

...

Schema::create('user', function($table)
{
    $table->increments('id');
    $table->string('name');
    $table->uploader('avatar');
});
```
