### PR TITLE
get_dirty() comparison is not type safe

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -517,7 +517,7 @@ abstract class Model {
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! array_key_exists($key, $this->original) or $value != $this->original[$key])
+			if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])
 			{
 				$dirty[$key] = $value;
 			}


### PR DESCRIPTION
get_dirty() must compare using Not Identical (!==) in place of Not Equal (!=).
For example, changing null to false don't make the model dirty.
