### PR TITLE
Changed Laravel\ namespace prefix in some classes calls in helpers to global.

### DIFF
--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -574,7 +574,7 @@ function yield($section)
  */
 function get_cli_option($option, $default = null)
 {
-	foreach (Request::foundation()->server->get('argv') as $argument)
+	foreach (Laravel\Request::foundation()->server->get('argv') as $argument)
 	{
 		if (starts_with($argument, "--{$option}="))
 		{


### PR DESCRIPTION
Changed Laravel\ namespace prefix in some classes calls in helpers to global, to allow aliases to work, and allow class extending.
