### PR TITLE
Incremented version from 3.2.13 to 3.2.14

### DIFF
--- a/artisan
+++ b/artisan
@@ -3,7 +3,7 @@
  * Laravel - A PHP Framework For Web Artisans
  *
  * @package  Laravel
- * @version  3.2.13
+ * @version  3.2.14
  * @author   Taylor Otwell <taylorotwell@gmail.com>
  * @link     http://laravel.com
  */

--- a/paths.php
+++ b/paths.php
@@ -3,7 +3,7 @@
  * Laravel - A PHP Framework For Web Artisans
  *
  * @package  Laravel
- * @version  3.2.13
+ * @version  3.2.14
  * @author   Taylor Otwell <taylorotwell@gmail.com>
  * @link     http://laravel.com
  */

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
  * Laravel - A PHP Framework For Web Artisans
  *
  * @package  Laravel
- * @version  3.2.13
+ * @version  3.2.14
  * @author   Taylor Otwell <taylorotwell@gmail.com>
  * @link     http://laravel.com
  */


### PR DESCRIPTION
Incremented Laravel's version to 3.2.14 in three files that still contained 3.2.13 as version number.

Signed-off-by: aeberhardo aeberhard@gmx.ch
