### PR TITLE
Changed robots.txt to use disallow instead of allow

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-User-agent: * Allow: /
+User-agent: *
+Disallow: 


### PR DESCRIPTION
While it works with major crawlers like Google, the `Allow:` field isn't a standard that's supported by all bots. For a generic `robots.txt` file like this, the "standard" empty `Disallow:` should probably be used to be compatible with the most bots. Additionally, the existing `robots.txt` file fails validators as it doesn't contain a `Disallow:` field.
