### PR TITLE
Use the base.path when loading the illuminate application.

### DIFF
--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -54,7 +54,7 @@ $app->bindInstallPaths(require __DIR__.'/paths.php');
 |
 */
 
-$framework = __DIR__.'/../vendor/laravel/framework/src';
+$framework = $app['path.base'].'/vendor/laravel/framework/src';
 
 require $framework.'/Illuminate/Foundation/start.php';
 


### PR DESCRIPTION
To me this makes more sense since (as far as I know), then `vendor` directory should (will?) always be in the base of the application. When shifting directories around for an application this will mean one less file that needs changing.
