### PR TITLE
Patch for ->push();

### DIFF
--- a/laravel/database/eloquent/model.php
+++ b/laravel/database/eloquent/model.php
@@ -335,7 +335,7 @@ abstract class Model {
 	 */
 	public function push()
 	{
-		$this->save();
+		if (!$this->save()) return false;
 
 		// To sync all of the relationships to the database, we will simply spin through
 		// the relationships, calling the "push" method on each of the models in that
@@ -349,9 +349,11 @@ abstract class Model {
 
 			foreach ($models as $model)
 			{
-				$model->push();
+				if (!$model->push()) return false;
 			}
 		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Just like $model->save(), $model->push() needs to return success / fail. I ran into this issue because my app was rolling back the transaction when if (!$model->push()) {} occurred, which of course was returning Null.

With this pull request, if the model's ->save() method or any of the child relationship's ->push() method's fail, it'll return false. This of course may leave the DB in a mixed state, so it is up the the user to encapsulate ->push() in a pDO transaction and roll back if ->push() fails.

L3 Example:

DB::connection()->pdo->beginTransaction();
if (!$model->push())
    DB::connection()->pdo->rollBack();
else
    DB::connection()->pdo->commit();

Does $model->push() exist in L4? If not, it is really nifty to have. Hint Hint.
