### PR TITLE
validate_between() does not support negative numbers

### DIFF
--- a/laravel/tests/cases/validator.test.php
+++ b/laravel/tests/cases/validator.test.php
@@ -189,6 +189,11 @@ class ValidatorTest extends PHPUnit_Framework_TestCase {
 		$rules = array('amount' => 'numeric|between:2,3');
 		$this->assertFalse(Validator::make($input, $rules)->valid());
 
+		// Negative numbers
+		$input = array('amount' => '-33.84');
+		$rules = array('amount' => 'numeric|between:-22,-34');
+		$this->assertTrue(Validator::make($input, $rules)->valid());
+
 		// If no numeric rule is on the field, it is treated as a string
 		$input = array('amount' => '111');
 		$rules = array('amount' => 'between:1,3');

--- a/laravel/validator.php
+++ b/laravel/validator.php
@@ -382,9 +382,9 @@ class Validator {
 	 */
 	protected function validate_between($attribute, $value, $parameters)
 	{
-		$size = $this->size($attribute, $value);
+		$size = abs($this->size($attribute, $value));
 
-		return $size >= $parameters[0] and $size <= $parameters[1];
+		return $size >= abs($parameters[0]) and $size <= abs($parameters[1]);
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Rudolf Vavruch rudolf@antler.co.za

I am making a pull request onto L3, as recommended here: http://forums.laravel.io/viewtopic.php?id=5665

Contains fix and updated unit test.
