### PR TITLE
Fire log event with class & function name

### DIFF
--- a/laravel/log.php
+++ b/laravel/log.php
@@ -48,14 +48,6 @@ class Log {
 	{
 		$message = ($pretty_print) ? print_r($message, true) : $message;
 
-		// If there is a listener for the log event, we'll delegate the logging
-		// to the event and not write to the log files. This allows for quick
-		// swapping of log implementations for debugging.
-		if (Event::listeners('laravel.log'))
-		{
-			Event::fire('laravel.log', array($type, $message));
-		}
-
 		$trace=debug_backtrace();
 
 		foreach($trace as $item)
@@ -78,6 +70,14 @@ class Log {
 		else
 		{
 			$class = '';
+		}
+
+		// If there is a listener for the log event, we'll delegate the logging
+		// to the event and not write to the log files. This allows for quick
+		// swapping of log implementations for debugging.
+		if (Event::listeners('laravel.log'))
+		{
+			Event::fire('laravel.log', array($type, $class . $function . " - " . $message));
 		}
 
 		$message = static::format($type, $class . $function . ' - ' . $message);


### PR DESCRIPTION
In Profiler, the class & function name are not shown in log. In many cases, this would make debugging a lot easier. With this patch, the class and function name are also shown in Profiler. timestamp is less usefull in Profiler.

This is a very simple patch, but a better approach would be to add the class and function as parameters when firing, so you can decide somewhere else whether or not to show class & function in Profiler log, I suggest an optional extra config setting for this.

But that's a change "to big for me at the moment" :-)
