### PR TITLE
Update migrator.php

### DIFF
--- a/laravel/cli/tasks/migrate/migrator.php
+++ b/laravel/cli/tasks/migrate/migrator.php
@@ -200,7 +200,7 @@ class Migrator extends Task {
 			$table->primary(array('bundle', 'name'));
 		});
 
-		echo "Migration table created successfully.";
+		echo "Migration table created successfully.".PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
when used in a setup task. The output created didn't add a line ending.
