### PR TITLE
fix incorrect padding with multibyte strings encryption

### DIFF
--- a/laravel/crypter.php
+++ b/laravel/crypter.php
@@ -116,7 +116,7 @@ class Crypter {
 	 */
 	protected static function pad($value)
 	{
-		$pad = static::$block - (Str::length($value) % static::$block);
+		$pad = static::$block - (strlen($value) % static::$block);
 
 		return $value .= str_repeat(chr($pad), $pad);
 	}
@@ -129,14 +129,7 @@ class Crypter {
 	 */
 	protected static function unpad($value)
 	{
-		if (MB_STRING)
-		{
-			$pad = ord(mb_substr($value, -1, 1, Config::get('application.encoding')));
-		}
-		else
-		{
-			$pad = ord(substr($value, -1));
-		}
+		$pad = ord(substr($value, -1));
 
 		if ($pad and $pad <= static::$block)
 		{
@@ -145,12 +138,7 @@ class Crypter {
 			// as the padding appears to have been changed.
 			if (preg_match('/'.chr($pad).'{'.$pad.'}$/', $value))
 			{
-				if (MB_STRING)
-				{
-					return mb_substr($value, 0, Str::length($value) - $pad, Config::get('application.encoding'));
-				}
-
-				return substr($value, 0, Str::length($value) - $pad);
+				return substr($value, 0, strlen($value) - $pad);
 			}
 
 			// If the padding characters do not match the expected padding


### PR DESCRIPTION
As far as encrypting and paddings are concerned, we are talking about **bytes** and not **characters**. So basic strlen/substr functions must be used instead of their mbstring version.
