### PR TITLE
Use dashes instead of underscores when generating URLs to controller routes

### DIFF
--- a/laravel/routing/controller.php
+++ b/laravel/routing/controller.php
@@ -183,7 +183,7 @@ abstract class Controller {
 
 			$search = '(:'.($key + 1).')';
 
-			$destination = str_replace($search, $value, $destination, $count);
+			$destination = str_replace($search, str_replace('-', '_', $value), $destination, $count);
 
 			if ($count > 0) unset($parameters[$key]);
 		}

--- a/laravel/routing/router.php
+++ b/laravel/routing/router.php
@@ -212,7 +212,7 @@ class Router {
 
 			$uri = ltrim(str_replace('(:bundle)', static::$bundle, $uri), '/');
 			
-			if($uri == '')
+			if ($uri == '')
 			{
 				$uri = '/';
 			}

--- a/laravel/tests/application/controllers/auth.php
+++ b/laravel/tests/application/controllers/auth.php
@@ -12,6 +12,11 @@ class Auth_Controller extends Controller {
 		return __FUNCTION__;
 	}
 
+	public function action_dashes_in_the_name()
+	{
+		return __FUNCTION__;
+	}
+
 	public function action_profile($name)
 	{
 		return $name;

--- a/laravel/tests/cases/controller.test.php
+++ b/laravel/tests/cases/controller.test.php
@@ -184,18 +184,12 @@ class ControllerTest extends PHPUnit_Framework_TestCase {
 	public function testRestfulControllersRespondWithRestfulMethods()
 	{
 		Request::$foundation->setMethod('GET');
-		//$_SERVER['REQUEST_METHOD'] = 'GET';
-
 		$this->assertEquals('get_index', Controller::call('restful@index')->content);
 
-		//$_SERVER['REQUEST_METHOD'] = 'PUT';
 		Request::$foundation->setMethod('PUT');
-
 		$this->assertEquals(404, Controller::call('restful@index')->status());
 
-		//$_SERVER['REQUEST_METHOD'] = 'POST';
 		Request::$foundation->setMethod('POST');
-
 		$this->assertEquals('post_index', Controller::call('restful@index')->content);
 	}
 

--- a/laravel/tests/cases/routing.test.php
+++ b/laravel/tests/cases/routing.test.php
@@ -5,7 +5,7 @@ use Laravel\Routing\Router;
 class RoutingTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Destroy the testing environment.
+	 * Initialize the test environment.
 	 */
 	public function setUp()
 	{
@@ -115,6 +115,8 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('home@(:1)', Router::route('GET', 'home/profile')->action['uses']);
 		$this->assertEquals('admin.panel@(:1)', Router::route('GET', 'admin/panel')->action['uses']);
 		$this->assertEquals('admin.panel@(:1)', Router::route('GET', 'admin/panel/show')->action['uses']);
+
+		$this->assertEquals('action_dashes_in_the_name', Router::route('GET', 'auth/dashes-in-the-name')->call());
 	}
 
 	/**

--- a/laravel/tests/cases/url.test.php
+++ b/laravel/tests/cases/url.test.php
@@ -65,6 +65,10 @@ class URLTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://localhost/index.php/x/y/Taylor', URL::to_action('x@y', array('Taylor')));
 		$this->assertEquals('http://localhost/index.php/foo/bar', URL::to_action('foo@baz'));
 		$this->assertEquals('http://localhost/index.php/foo/bar/Taylor', URL::to_action('foo@baz', array('Taylor')));
+
+		Route::controller('foo.bar');
+		$this->assertEquals('http://localhost/index.php/foo/bar/index', URL::to_action('foo.bar@index'));
+		$this->assertEquals('http://localhost/index.php/foo/bar/some-long-action-name', URL::to_action('foo.bar@some_long_action_name'));
 	}
 
 	/**

--- a/laravel/url.php
+++ b/laravel/url.php
@@ -223,7 +223,8 @@ class URL {
 		// We'll replace both dots and @ signs in the URI since both are used
 		// to specify the controller and action, and by convention should be
 		// translated into URI slashes for the URL.
-		$uri = $root.'/'.str_replace(array('.', '@'), '/', $action);
+		// We'll also replace underscores with dashes
+		$uri = $root.'/'.str_replace(array('.', '@'), '/', str_replace('_', '-', $action));
 
 		$uri = static::to(str_finish($uri, '/').$parameters);
 


### PR DESCRIPTION
As mentioned [here](http://forums.laravel.io/viewtopic.php?id=539), it is better to replace underscores with dashes in automatically generated URLs. Tests included.
