### PR TITLE
Allow developers to set the Content-Disposition header in Response::download()

### DIFF
--- a/laravel/response.php
+++ b/laravel/response.php
@@ -202,9 +202,14 @@ class Response {
 		// off to the HttpFoundation and let it create the header text.
 		$response = new static(File::get($path), 200, $headers);
 
-		$d = $response->disposition($name);
+		// If the Content-Disposition header has already been set by the
+		// merge above, then do not override it with out generated one.
+		if (!isset($headers['Content-Disposition'])) {
+			$d = $response->disposition($name);
+			$response = $response->header('Content-Disposition', $d);
+		}
 
-		return $response->header('Content-Disposition', $d);
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
This change allows developers to set the Content-Disposition header in Response::download() without it getting overwritten. This was a necessary change for me because I want to be able to suggest to the browser whether or not to display a PDF or to download it with:

Content-Disposition: inline; filename=file.pdf;

or 

Content-Disposition: attachment; filename=file.pdf;

This change allows me to do that.
