### PR TITLE
Fixes variable export for Windows.

### DIFF
--- a/laravel/cli/tasks/test/runner.php
+++ b/laravel/cli/tasks/test/runner.php
@@ -89,7 +89,7 @@ class Runner extends Task {
 		$esc_path = escapeshellarg($path);
 
 		putenv('LARAVEL_ENV='.Request::env());
-		passthru('LARAVEL_ENV='.Request::env().' phpunit --configuration '.$esc_path, $status);
+		passthru('phpunit --configuration '.$esc_path, $status);
 
 		@unlink($path);
 


### PR DESCRIPTION
The solution presented in #1870 has been implemented only partially.

The fix in commit https://github.com/laravel/laravel/commit/678b92ef85ce0258eb9a6ac57bb26fca9480e430 will not work.

This Pull Request makes an additional correction so that `LARAVEL_ENV` can be used in Windows. 

Signed-off-by: aeberhardo aeberhard@gmx.ch
