### PR TITLE
Use artisan dump-autoload instead of artisan optimize in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
 			"php artisan clear-compiled"
 		],
 		"post-install-cmd": [
-			"php artisan optimize"
+			"php artisan dump-autoload"
 		],
 		"post-update-cmd": [
-			"php artisan optimize"
+			"php artisan dump-autoload"
 		]
 	},
 	"config": {


### PR DESCRIPTION
This change is in reference to the laravel/framework#1303 discussion, and the actual pull request for laravel/framework#1312.
