### PR TITLE
Don't overwrite an existing jQuery library when outputting the profiler

### DIFF
--- a/laravel/profiling/template.blade.php
+++ b/laravel/profiling/template.blade.php
@@ -119,6 +119,6 @@
 	</ul>
 </div>
 
-<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+<script>window.jQuery || document.write(unescape("%3Cscript src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'%3E%3C/script%3E"))</script>
 <script>{{ file_get_contents(path('sys').'profiling/profiler.js') }}</script>
 <!-- /ANBU - LARAVEL PROFILER -->


### PR DESCRIPTION
It's nice to have the profiler up, but I noticed that it started changing my jQuery's behavior when I upgraded to jQuery 1.9. So I figured we should only write the fallback if no other jQuery library was loaded.
