### PR TITLE
The default sendmail path must contain '-bs' or '-t' flags.

### DIFF
--- a/app/config/mail.php
+++ b/app/config/mail.php
@@ -106,6 +106,6 @@ return array(
 	|
 	*/
 
-	'sendmail' => '/usr/sbin/sendmail',
+	'sendmail' => '/usr/sbin/sendmail -bs',
 
 );


### PR DESCRIPTION
This is required, if not Swiftmailer will throw the next exception:

```
 [Swift_TransportException]                                                                                               
  Unsupported sendmail command flags [/usr/sbin/sendmail]. Must be one
of "-bs" or "-t" but can include additional flags.
```
