### PR TITLE
Route update to call aliased Controller class

### DIFF
--- a/laravel/routing/route.php
+++ b/laravel/routing/route.php
@@ -1,6 +1,7 @@
 <?php namespace Laravel\Routing;
 
 use Closure;
+use \Controller;
 use Laravel\Str;
 use Laravel\URI;
 use Laravel\Bundle;


### PR DESCRIPTION
Encountered an issue recently where we needed to make some updates to Controller (so that we could namespace our controllers), meaning we needed to update call/resolve methods also. However, what we found is that Route never called the aliased Controller class. This patch fixes that by ensuring the aliased class "Controller" is always called, instead of the Controller class within its own namespace (which is the default setup in config/application.php).
