### PR TITLE
Fixed typo in global.php

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -60,7 +60,7 @@ App::error(function(Exception $exception, $code)
 |
 | The "down" Artisan command gives you the ability to put an application
 | into maintenance mode. Here, you will define what is displayed back
-| to the user if maintenace mode is in effect for this application.
+| to the user if maintenance mode is in effect for this application.
 |
 */
 


### PR DESCRIPTION
Changed 'maintenace' to 'maintenance'.
