### PR TITLE
Add MIT license info to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,6 @@
 	"config": {
 		"preferred-install": "dist"
 	},
-	"minimum-stability": "dev"
+	"minimum-stability": "dev",
+	"license": "MIT"
 }


### PR DESCRIPTION
By Composer convention, the license information should be included in the composer.json file. This will allow the license to show up when pulling things from composer as well as showing info on the packagist page.
