### PR TITLE
Added "php artisan key:generate" to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 			"php artisan clear-compiled"
 		],
 		"post-install-cmd": [
-			"php artisan optimize"
+			"php artisan optimize",
+			"php artisan key:generate"
 		],
 		"post-update-cmd": [
 			"php artisan optimize"


### PR DESCRIPTION
I've been trying to think of a use-case where running the key generator would be detrimental, and I cannot think of one. Without this, I'm worried that tons of websites will be encrypted with 'YourSecretKey!!!'
