### PR TITLE
changed google font url to be protocol relative

### DIFF
--- a/app/views/hello.php
+++ b/app/views/hello.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Laravel PHP Framework</title>
     <style>
-        @import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
+        @import url(//fonts.googleapis.com/css?family=Lato:300,400,700);
 
         body {
             margin:0;


### PR DESCRIPTION
When viewing the default landing page over SSL, the google font wasn't loading because it was flagged as insecure by the browser.
