### PR TITLE
Adding .htaccess to app folder

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,0 +1,1 @@
+deny from all


### PR DESCRIPTION
Some people will inevitably deploy app to publicly accessible folder. This file will prevent web access to files in the app folder on Apache.
