### PR TITLE
Updated artisan command line tool to be executable from anywhere

### DIFF
--- a/artisan
+++ b/artisan
@@ -15,26 +15,30 @@
 $artisan_dir = getcwd();
 
 if (!file_exists($artisan_dir.'/bootstrap/autoload.php')) {
-    $found_path = false;
-    $separated = explode('/', $artisan_dir);
+    if (file_exists(__DIR__.'/bootstrap/autoload.php')) {
+        $artisan_dir = __DIR__;
+    } else {
+        $found_path = false;
+        $separated = explode('/', $artisan_dir);
 
-    while (!empty($separated)) {
-        array_pop($separated);
+        while (!empty($separated)) {
+            array_pop($separated);
 
-        $artisan_dir = implode('/', $separated);
+            $artisan_dir = implode('/', $separated);
 
-        if (file_exists($artisan_dir.'/bootstrap/autoload.php')) {
-            $found_path = true;
-            break;
+            if (file_exists($artisan_dir.'/bootstrap/autoload.php')) {
+                $found_path = true;
+                break;
+            }
         }
-    }
 
-    if (!$found_path) {
-        echo "Could not find a valid laravel installation\n";
-        exit(1);
-    }
+        if (!$found_path) {
+            echo "Could not find a valid laravel installation\n";
+            exit(1);
+        }
 
-    echo "Working directory: $artisan_dir\n";
+        echo "Working directory: $artisan_dir\n";
+    }
 }
 
 /*


### PR DESCRIPTION
The script now detects from where it's run. 
the artisan tool can be somewhere in your PATH and you can manage any of your laravel 4 installs.
You just need to be somewhere inside the framework's folder.

Usage : 

``` bash
cd /path/to/laravel
cp artisan /usr/local/bin/artisan

# all these will work
artisan list

cd /path/to/laravel/app/models
artisan list

cd /path/to/laravel/vendor/laravel
artisan list
```
