### PR TITLE
Added a settings flag to allow secure cookies

### DIFF
--- a/app/config/session.php
+++ b/app/config/session.php
@@ -122,4 +122,17 @@ return array(
 
 	'domain' => null,
 
+	/*
+	|--------------------------------------------------------------------------
+	| Session Cookie Security
+	|--------------------------------------------------------------------------
+	|
+	| Indicates that the cookie should only be transmitted over a secure HTTPS 
+	| connection from the client. When set to TRUE, the cookie will only be
+	| set if a secure connection exists.
+	|
+	*/
+
+	'secure' => false,
+
 );


### PR DESCRIPTION
Relates to the framework pull request here: https://github.com/laravel/framework/pull/1979

This setting allows the user to define SSL-only session cookies in the session config.
