### PR TITLE
Update comment for clarity

### DIFF
--- a/app/config/session.php
+++ b/app/config/session.php
@@ -24,7 +24,7 @@ return array(
 	|--------------------------------------------------------------------------
 	|
 	| Here you may specify the number of minutes that you wish the session
-	| to be allowed to remain idle before it is expired. If you want them
+	| to be allowed to remain idle before it expires. If you want them
 	| to immediately expire when the browser closes, set it to zero.
 	|
 	*/


### PR DESCRIPTION
Comment used the word "for" where the word "before" was meant
