### PR TITLE
Add missing license information in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "laravel/laravel",
 	"description": "The Laravel Framework.",
 	"keywords": ["framework", "laravel"],
+	"license": "MIT",
 	"require": {
 		"laravel/framework": "4.0.*"
 	},


### PR DESCRIPTION
The license information was missing from the composer.json file. This information is quite important as it is displayed on Packagist and used by automated tools (like http://insight.sensiolabs.com/ for instance) to check compatibility of your project dependencies.
