### PR TITLE
Force HTTPS for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,14 @@
 	"config": {
 		"preferred-install": "dist"
 	},
-	"minimum-stability": "dev"
+	"minimum-stability": "dev",
+	"repositories": [
+		{
+			"packagist": false
+		},
+		{
+			"type": "composer",
+			"url": "https://packagist.org/"
+		}
+	]
 }


### PR DESCRIPTION
A persistent problem when using composer is that it will silently switch to non-SSL when downloading JSON files from packagist.org resulting in a failure to open the stream. This request is after finding a fix here:

https://github.com/composer/composer/issues/1992#issuecomment-20869636
