### PR TITLE
Minor comment block fix

### DIFF
--- a/app/lang/en/validation.php
+++ b/app/lang/en/validation.php
@@ -7,9 +7,9 @@ return array(
 	| Validation Language Lines
 	|--------------------------------------------------------------------------
 	|
-	| The following language lines contain the default error messages used by
+	| The following language lines contains the default error messages used by
 	| the validator class. Some of these rules have multiple versions such
-	| such as the size rules. Feel free to tweak each of these messages.
+	| as the size rules. Feel free to tweak each of these messages.
 	|
 	*/
 


### PR DESCRIPTION
Minor fixes in `app\lang\en\validation.php` "Validation Language Lines" comment block:
- Changed `contain` to `contains`
- Removed duplicated word `such`
