### PR TITLE
Move pre-update-cmd to post-update-cmd, solves inconveniences.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,8 @@
 		"post-install-cmd": [
 			"php artisan optimize"
 		],
-		"pre-update-cmd": [
-			"php artisan clear-compiled"
-		],
 		"post-update-cmd": [
+			"php artisan clear-compiled"
 			"php artisan optimize"
 		],
 		"post-create-project-cmd": [


### PR DESCRIPTION
Why do we have the following in composer.json?

``` js
"pre-update-cmd": [
    "php artisan clear-compiled"
]
```

Since this piece of code prevent composer from updating sometimes (e.g. when a `ServiceProvide` has been added to `config/app.php` before getting the dependancy).

Does it serve a specific purpose? Or solve certain issues?
I began to move these lines from all projects form the start to save the headache of not being able to run `composer update`.

I know `composer update --no-scripts` does the job, but why should we pass the additional argument in the first place?
