### PR TITLE
Fixes assumptions about dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,8 @@
 		"post-install-cmd": [
 			"php artisan optimize"
 		],
-		"pre-update-cmd": [
-			"php artisan clear-compiled"
-		],
 		"post-update-cmd": [
+			"php artisan clear-compiled",
 			"php artisan optimize"
 		],
 		"post-create-project-cmd": [


### PR DESCRIPTION
This resulted in a fatal error due to missing dependencies if someone was running composer update for the first time without having already run composer install (symfony console would not be available). Thanks to @igorw: "the real problem here is that composer does not make any assumptions about the state of vendor before updating, and therefore scripts that run before install/update, must not either"
