### PR TITLE
gitignore windows thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 composer.lock
 .DS_Store
+Thumbs.db


### PR DESCRIPTION
In addition to `.DS_Store`, we should also ignore `Thumbs.db`.
