### PR TITLE
Adding prefer-stable to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,6 @@
 	"config": {
 		"preferred-install": "dist"
 	},
-	"minimum-stability": "dev"
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }


### PR DESCRIPTION
Since this is the recommended way to start a new project, to me it would make sense that we explicitly prefer stable releases for all the framework dependencies. This will still respect the dev minimum stability if a dependency doesn't have a proper stable release.

http://getcomposer.org/doc/04-schema.md#prefer-stable
