### PR TITLE
Artisan Command Registration Change

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -20,6 +20,7 @@
 - Password reminder system tweaked for greater developer freedom. Inspect stub controller by running `auth:reminders-controller` Artisan command.
 - Update `reminders.php` language file to match [this](https://github.com/laravel/laravel/blob/master/app/lang/en/reminders.php) file.
 - If you are using http hosts to set the $env variable in bootstrap/start.php, these should be changed to machine names (as returned by PHP's gethostname() function).
+- If you are registering artisan commands like: `$artisan->add(new CommandName)`, this should be changed to `Artisan::add(new CommandName)` instead.
 
 Finally,
 


### PR DESCRIPTION
We register several artisan commands for our application and we were doing so like: 

```
<?php

/* ... */

$artisan->add(new CommandOne);
$artisan->add(new CommandTwo);
```

This caused the following exception:

```
[13-Dec-2013 16:38:35 UTC] PHP Fatal error:  Call to a member function add() on a non-object in /Applications/MAMP/htdocs/maps/server/app/start/artisan.php on line 14
[13-Dec-2013 16:38:35 UTC] PHP Stack trace:
[13-Dec-2013 16:38:35 UTC] PHP   1. {main}() /Applications/MAMP/htdocs/maps/server/artisan:0
[13-Dec-2013 16:38:35 UTC] PHP   2. Illuminate\Console\Application::start() /Applications/MAMP/htdocs/maps/server/artisan:46
[13-Dec-2013 16:38:35 UTC] PHP   3. Illuminate\Console\Application->boot() /Applications/MAMP/htdocs/maps/server/vendor/laravel/framework/src/Illuminate/Console/Application.php:32
[13-Dec-2013 16:38:35 UTC] PHP   4. require() /Applications/MAMP/htdocs/maps/server/vendor/laravel/framework/src/Illuminate/Console/Application.php:62
[1
```

I changed to the documented API reference and it works fine now!

```
<?php

/* ... */

Artisan::add(new CommandOne);
Artisan::add(new CommandTwo);
```
