### PR TITLE
Updates to .htaccess formatting, fix trailing slash redirects

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,15 +1,16 @@
 <IfModule mod_rewrite.c>
 	<IfModule mod_negotiation.c>
-    	Options -MultiViews
-    </IfModule>
+		Options -MultiViews
+	</IfModule>
 
-    RewriteEngine On
+	RewriteEngine On
 
-    # Redirect Trailing Slashes...
+	# Redirect Trailing Slashes...
+	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule ^(.*)/$ /$1 [L,R=301]
 
 	# Handle Front Controller...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^ index.php [L]
+	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteRule ^ index.php [L]
 </IfModule>


### PR DESCRIPTION
This update to `public/.htaccess` prevents redirecting trailing slashes for URLs of directories to non-trailing slashes. This was causing an infinite loop when trying to view directory contents.

This update also corrects the mixed spaces and tabs in the file.
