### PR TITLE
Updated upgrade guide for laravel 4.1.9

### DIFF
--- a/upgrade.md
+++ b/upgrade.md
@@ -16,7 +16,6 @@
   - in `providers` add `'Illuminate\Remote\RemoteServiceProvider',`.
   - in `aliases` add `'SSH' => 'Illuminate\Support\Facades\SSH',`.
 - If `app/controllers/BaseController.php` has a use statement at the top, change `use Illuminate\Routing\Controllers\Controller;` to `use Illuminate\Routing\Controller;`. You may also remove this use statament, for you have registered a class alias for this.
-- If you are overriding `missingMethod` in your controllers, add $method as the first parameter.
 - Password reminder system tweaked for greater developer freedom. Inspect stub controller by running `auth:reminders-controller` Artisan command.
 - Update `reminders.php` language file to match [this](https://github.com/laravel/laravel/blob/master/app/lang/en/reminders.php) file.
 - If you are using http hosts to set the $env variable in bootstrap/start.php, these should be changed to machine names (as returned by PHP's gethostname() function).


### PR DESCRIPTION
Fixes the upgrade guide for https://github.com/laravel/framework/commit/d6e9c601054595ac5c1b40e426f22c97d50bd508.
