### PR TITLE
add other dependency manager directories to gitignore as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /bootstrap/compiled.php
 /vendor
+node_modules
+bower_components
 composer.phar
 composer.lock
 .DS_Store


### PR DESCRIPTION
To be able to work with other vendor directories from e.g. npm or bower it might make sense to add their vendor directories to gitignore as well
