### PR TITLE
Make logging more configurable

### DIFF
--- a/app/config/log.php
+++ b/app/config/log.php
@@ -1,0 +1,58 @@
+<?php
+
+return array(
+
+	/*
+	|--------------------------------------------------------------------------
+	| Application Log Location
+	|--------------------------------------------------------------------------
+	|
+	| We need a location where the application logs can be stored. A sensible
+	| default has been specified, but you are free to change it to any other
+	| place on disk that you desire.
+	|
+	*/
+
+	'path' => storage_path().'/logs',
+
+	/*
+	|--------------------------------------------------------------------------
+	| Log File
+	|--------------------------------------------------------------------------
+	|
+	| The filename for the application logs.  Again, a sensible default has
+	| been provided, but feel free to change it.  If you are using daily logs
+	| (see below), then the date will be added to the file name (before the
+	| file extension).
+	*/
+
+	'file' => 'laravel.log',
+
+	/*
+	|--------------------------------------------------------------------------
+	| Use Daily Files
+	|--------------------------------------------------------------------------
+	|
+	| By default, Laravel uses the same log file continuously, and you are
+	| responsible for rotating it to keep it from getting too big.
+	| Alternatively, by setting this value to "true", we will create a new log
+	| file each day and name it appropriately (eg. "laravel-2014-02-01.log").
+	|
+	*/
+
+	'daily' => true,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Maximum Number of Days to Keep Logs
+	|--------------------------------------------------------------------------
+	|
+	| If you are using daily log files (above), then set this to specify how
+	| many days worth of logs to keep.  Set it to zero to keep the daily logs
+	| indefinitely.
+	|
+	*/
+
+	'keep' => 30,
+
+);

--- a/app/start/global.php
+++ b/app/start/global.php
@@ -31,7 +31,14 @@ ClassLoader::addDirectories(array(
 |
 */
 
-Log::useFiles(storage_path().'/logs/laravel.log');
+if (Config::get('log.daily'))
+{
+	Log::useDailyFiles(Config::get('log.path').Config::get('log.file'), Config::get('log.keep',0));
+}
+else
+{
+	Log::useFiles(Config::get('log.path').Config::get('log.file'));
+}
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows users to configure the path and file name for the application log, as well as whether to create one big log (like L4 currently does), or to use daily logs (like L3 used to do).  And, if you choose to use daily logs, you can specify how many days worth of logs to keep.

Inspired by [this issue](https://github.com/laravel/framework/issues/1585).
