### PR TITLE
Improvement of validation traduction for "email" rule

### DIFF
--- a/app/lang/en/validation.php
+++ b/app/lang/en/validation.php
@@ -33,7 +33,7 @@ return array(
 	"different"            => "The :attribute and :other must be different.",
 	"digits"               => "The :attribute must be :digits digits.",
 	"digits_between"       => "The :attribute must be between :min and :max digits.",
-	"email"                => "The :attribute format is invalid.",
+	"email"                => "The :attribute must be a valid email address.",
 	"exists"               => "The selected :attribute is invalid.",
 	"image"                => "The :attribute must be an image.",
 	"in"                   => "The selected :attribute is invalid.",


### PR DESCRIPTION
Similar to : 

```
"ip" => "The :attribute must be a valid IP address."
```
