### PR TITLE
Use Application::getBootstrapFile() to get start.php path

### DIFF
--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -54,10 +54,7 @@ $app->bindInstallPaths(require __DIR__.'/paths.php');
 |
 */
 
-$framework = $app['path.base'].
-                 '/vendor/laravel/framework/src';
-
-require $framework.'/Illuminate/Foundation/start.php';
+require Illuminate\Foundation\Application::getBootstrapFile();
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Application.php#L202-L210

The function exists, why not use it? This change will actually make it possible to require laravel/laravel in a package's `require-dev` and get access to the full default application stack.

My package which has controllers that I test using the default Laravel TestCase:

https://travis-ci.org/anlutro/laravel-4-core https://github.com/anlutro/laravel-4-core/tree/develop
