### PR TITLE
Avoid 301 on directories

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,6 +6,7 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
+    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...


### PR DESCRIPTION
Adds `RewriteCond %{REQUEST_FILENAME} !-d` before the "redirect trailing slash" rule in case of querying a directory (in `/public`) because it caused infinite 301 redirections.
