### PR TITLE
[Proposal] More detailed logging

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -46,7 +46,7 @@ Log::useFiles(storage_path().'/logs/laravel.log');
 |
 */
 
-App::pushError(function(Exception $exception, $code)
+App::error(function(Exception $exception, $code)
 {
 	$error = sprintf("Error %d on %s %s: %s", $code, Request::getMethod(), URL::current(), $exception);
 	Log::error($error);


### PR DESCRIPTION
1. Push the most common exception to the end, to catch after all other handlers
2. Include the code/method/path, so it is more clear where the error occured.

When looking through errors it is not very clear where an error occured. For example 404 errors: from `exception 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException' in /var/www/html/project/vendor/laravel/framework/src/Illuminate/Routing/RouteCollection.php:140` you don't know on what path that happend (and beginners don't even get that this is just a 404).
`Error 404 on GET /my-route: exception 'Symfony\...` would make much more sense imho

The pushError instead of error would also allow serviceproviders/package to extend default logging (because otherwise the function here is always on top)
