### PR TITLE
[Proposal] Move the environment configuration to a dedicated file environments.php

### DIFF
--- a/bootstrap/environments.php
+++ b/bootstrap/environments.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Environments detection methods
+|--------------------------------------------------------------------------
+|
+| In the array below you can specify your settings and let Laravel detect
+| the current environment for you, or you may instead return a closure, 
+| that should be able to detect the environment and return its name.
+| 
+*/
+
+return array(
+
+	/*
+	|--------------------------------------------------------------------------
+	| Environments array
+	|--------------------------------------------------------------------------
+	|
+	| An environment is represented by a key/value pair, with its name as
+	| the key, and its corresponding machine name as the value. You may
+	| specify in an array several machine names for one environment.
+	|
+	*/
+
+	'local' => array('your-machine-name'),
+
+);

--- a/bootstrap/start.php
+++ b/bootstrap/start.php
@@ -18,17 +18,13 @@ $app = new Illuminate\Foundation\Application;
 | Detect The Application Environment
 |--------------------------------------------------------------------------
 |
-| Laravel takes a dead simple approach to your application environments
-| so you can just specify a machine name for the host that matches a
-| given environment, then we will automatically detect it for you.
+| Laravel takes a dead simple approach to your application environments.
+| In the environments.php file, just set a machine name for the host
+| that matches a given environment, we'll automatically detect it.
 |
 */
 
-$env = $app->detectEnvironment(array(
-
-	'local' => array('your-machine-name'),
-
-));
+$env = $app->detectEnvironment(require __DIR__.'/environments.php');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Extracting the environment configuration in a separate file `bootstrap/environments.php` should improve maintainability :
- it allows team members to have their own environments and machine names, while keeping intact `bootstrap/start.php` in the project repository ;
- it eases future upgrade processes, as we have a good chance that `bootstrap/start.php` was not modified.

Any feedback welcome !
