### PR TITLE
Added the account config option and updated queue hint so it implies tha...

### DIFF
--- a/app/config/queue.php
+++ b/app/config/queue.php
@@ -43,9 +43,10 @@ return array(
 
 		'sqs' => array(
 			'driver' => 'sqs',
+			'account'=> 'your-account-id',
 			'key'    => 'your-public-key',
 			'secret' => 'your-secret-key',
-			'queue'  => 'your-queue-url',
+			'queue'  => 'default',
 			'region' => 'us-east-1',
 		),
 


### PR DESCRIPTION
...t it's just a queue name and not a queue url.

This goes along with PR #3864 for laravel/framework (https://github.com/laravel/framework/pull/3864).
