### PR TITLE
Prevent endless loop in .htaccess slash removal

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,9 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{THE_REQUEST} \s(.+?)/+[?\s]
+    RewriteRule ^(.+?)/$ /$1 [R=301,L]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
Pointing to a folder in the URL resulted in an endless loop. Directory names automatically redirect to the same name with a trailing slash, and the rule removed the slash. With the conditions added, it won't touch to directory names.

The rule for the front controller may also be modified to include directory names, so we could have localized resources like '/fr/images/welcome.jpg' and also access the localized content like 'mysite.com/fr', without the need to add something like 'mysite.com/fr/home'. Accessing to a directory root shouldn't be a problem, it seems virtually nobody needed to access to a folder to this date anyway, as they would face an endless loop.

### Test results:

===
Whether or not there is a route defined, when the URL to a directory is visited:

#### A. Without the solution (original framework):
The URL results in an endless loop


#### B. With the solution:

##### b1. With the directory indexing enabled:
Directory listing is displayed

##### b2. With the directory indexing disabled:
A forbidden page or an empty directory index page is displayed, depending on whether you excluded, or completely disabled the directory listing

===