### PR TITLE
Use the attributes array to set a value as in the documentation

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -57,7 +57,7 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
 	 */
 	public function setRememberToken($value)
 	{
-		$this->remember_token = $value;
+		$this->attributes['remember_token'] = $value;
 	}
 
 	/**


### PR DESCRIPTION
Noticed that the `setRememberToken()` method doesn't use the attributes array to set a value, as is recommended in the Eloquent docs. If this change is accepted, the 4.1.26 upgrade docs should perhaps be updated also to reflect this change.
