### PR TITLE
Add missing mailgun.domain option.

### DIFF
--- a/app/config/services.php
+++ b/app/config/services.php
@@ -15,6 +15,7 @@ return array(
 	*/
 
 	'mailgun' => array(
+		'domain' => '',
 		'secret' => '',
 	),
 


### PR DESCRIPTION
Used in https://github.com/laravel/framework/blob/master/src/Illuminate/Mail/MailServiceProvider.php#L197
