### PR TITLE
Enable filename-based cache busting on dev server

### DIFF
--- a/server.php
+++ b/server.php
@@ -16,4 +16,30 @@ if ($uri !== '/' and file_exists($requested))
 	return false;
 }
 
+// The following code enables filename-based cache busting. Requests
+// such as "/css/style.1234567.css" are automatically converted to
+// "/css/style.css". This approach was made popular by the HTML5
+// Boilerplate project, see html5boilerplate.com for more info.
+if (preg_match('/^(.+)\.(\d+)\.(css|gif|jpeg|jpg|js|png|svg)$/', $uri, $matches))
+{
+	$requested = $paths['public'].$matches[1].'.'.$matches[3];
+
+	if (file_exists($requested))
+	{
+		$types = array(
+			'css' => 'text/css',
+			'gif' => 'image/gif',
+			'jpeg' => 'image/jpeg',
+			'jpg' => 'image/jpeg',
+			'js' => 'application/javascript',
+			'png' => 'image/png',
+			'svg' => 'image/svg+xml'
+		);
+
+		header('Content-type: '.$types[$matches[3]]);
+		readfile($requested);
+		exit;
+	}
+}
+
 require_once $paths['public'].'/index.php';


### PR DESCRIPTION
Filename-based cache busting is a popular approach to versioning public assets. Put simply, it allows the injection of a version number into an asset's filename without actually having to renaming the file itself. This allows for far-future expires headers on public assets with an easy way to break this cache. This is done using URL rewriting, currently only possible when using Apache or Nginx, not the built-in PHP server.

The following addition to `server.php` adds this functionality to the local development server. This shouldn't have any backwards breaking side effects, since it first checks to see if the file already exists.

I debated using [fileinfo](http://www.php.net/manual/en/function.finfo-file.php) to determine the mime type, but this seemed like overkill considering how few asset types this is required for. Further, I've noticed issues with fileinfo in certain environments where the definition (magic) file is out of date.

As noted in the comments, this approach was made popular by the HTML5 Boilerplate project. See their [.htaccess](https://github.com/h5bp/html5-boilerplate/blob/master/.htaccess#L624) file for more information.

I believe this should be part of the default Laravel install because:
1. Filename-based cache busting is used by many Laravel developers
2. Without it developers have to "duck tape" a solution together for their dev environment
3. Without it developers may be less likely to use this very smart approach to cache busting
4. Not having this creates a barrier to using the built-in PHP server for those familiar with using `.htaccess` files
5. I don't see any backwards compatibility issues
6. The work is done :)

Thanks!
