### PR TITLE
Update cipher default to align with the upgrade docs.

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -80,7 +80,7 @@ return array(
 
 	'key' => 'YourSecretKey!!!',
 
-	'cipher' => MCRYPT_RIJNDAEL_128,
+	'cipher' => MCRYPT_RIJNDAEL_256,
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
The upgrade docs state the 256 bit RIJNDAEL cipher should be used, but the default application still is set to 128.
