### PR TITLE
avoid logical operators - replaced 'and' by '&&'

### DIFF
--- a/server.php
+++ b/server.php
@@ -11,7 +11,7 @@ $requested = $paths['public'].$uri;
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' and file_exists($requested))
+if ($uri !== '/' && file_exists($requested))
 {
 	return false;
 }


### PR DESCRIPTION
"The and operator does not have the same precedence as &&. This could lead to unexpected behavior, use && instead."
see : https://insight.sensiolabs.com/projects/eedbee2c-cfb3-4642-a8e3-eb319b909987/analyses/1?status=violations#168231877
