### PR TITLE
renamed yield function names to yield_content

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -361,7 +361,7 @@ class Blade {
 	/**
 	 * Rewrites Blade @yield statements into Section statements.
 	 *
-	 * The Blade @yield statement is a shortcut to the Section::yield method.
+	 * The Blade @yield statement is a shortcut to the Section::yield_content method.
 	 *
 	 * @param  string  $value
 	 * @return string
@@ -370,7 +370,7 @@ class Blade {
 	{
 		$pattern = static::matcher('yield');
 
-		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::yield$2; ?>', $value);
+		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::yield_content$2; ?>', $value);
 	}
 
 	/**

--- a/laravel/documentation/views/templating.md
+++ b/laravel/documentation/views/templating.md
@@ -44,7 +44,7 @@ View sections provide a simple way to inject content into layouts from nested vi
 #### Rendering the contents of a section:
 
 	<head>
-		<?php echo Section::yield('scripts'); ?>
+		<?php echo Section::yield_content('scripts'); ?>
 	</head>
 
 #### Using Blade short-cuts to work with sections:

--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -560,9 +560,9 @@ function render_each($partial, array $data, $iterator, $empty = 'raw|')
  * @param  string  $section
  * @return string
  */
-function yield($section)
+function yield_content($section)
 {
-	return Section::yield($section);
+	return Section::yield_content($section);
 }
 
 /**

--- a/laravel/section.php
+++ b/laravel/section.php
@@ -69,7 +69,7 @@ class Section {
 	 */
 	public static function yield_section()
 	{
-		return static::yield(static::stop());
+		return static::yield_content(static::stop());
 	}
 
 	/**
@@ -128,7 +128,7 @@ class Section {
 	 * @param  string  $section
 	 * @return string
 	 */
-	public static function yield($section)
+	public static function yield_content($section)
 	{
 		return (isset(static::$sections[$section])) ? static::$sections[$section] : '';
 	}

--- a/laravel/tests/cases/blade.test.php
+++ b/laravel/tests/cases/blade.test.php
@@ -78,7 +78,7 @@ class BladeTest extends PHPUnit_Framework_TestCase {
 	{
 		$blade = "@yield('something')";
 
-		$this->assertEquals("<?php echo \\Laravel\\Section::yield('something'); ?>", Blade::compile_string($blade));
+		$this->assertEquals("<?php echo \\Laravel\\Section::yield_content('something'); ?>", Blade::compile_string($blade));
 	}
 
 	/**


### PR DESCRIPTION
This is required for 5.4+ compatibility, as in PHP 5.4+ yield is a reserved word and cannot be used as identifier.
