### PR TITLE
Missing validation sentence for timezone.

### DIFF
--- a/app/lang/en/validation.php
+++ b/app/lang/en/validation.php
@@ -71,6 +71,7 @@ return array(
 	),
 	"unique"               => "The :attribute has already been taken.",
 	"url"                  => "The :attribute format is invalid.",
+	"timezone"             => "The :attribute must be a valid zone.",
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
When using the timezone validation, it does not have a default sentence, you are greeted with: "validation.timezone" instead.
