### PR TITLE
.idea added to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ composer.lock
 .env.php
 .DS_Store
 Thumbs.db
-.idea
+/.idea


### PR DESCRIPTION
.idea added to .gitignore. .idea is the meta data folder used by the PHP IDE from JetBrains.

This is to avoid manually adding this every time a new project is created.
