### PR TITLE
Include FailConsoleServiceProvider by default

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -112,6 +112,7 @@ return array(
 		'Illuminate\Database\MigrationServiceProvider',
 		'Illuminate\Pagination\PaginationServiceProvider',
 		'Illuminate\Queue\QueueServiceProvider',
+		'Illuminate\Queue\FailConsoleServiceProvider',
 		'Illuminate\Redis\RedisServiceProvider',
 		'Illuminate\Remote\RemoteServiceProvider',
 		'Illuminate\Auth\Reminders\ReminderServiceProvider',


### PR DESCRIPTION
If this service provider isn't included then artisan queue fail commands like queue:failed or queue:failed-table aren't available.

Otherwise documentation http://laravel.com/docs/queues#failed-jobs should be updated to make clear that this provider is necessary.
