### PR TITLE
Remove none existing files being referred in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /bootstrap/compiled.php
-/app/routing/cache.php
 /vendor
 composer.phar
 composer.lock

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,1 +1,0 @@
-services.manifest


### PR DESCRIPTION
- `/app/routing/cache.php` is now `/storage/meta/routes.php`
- `/storage/services.manifest` is now `/storage/meta/services.json` (a long lost file from pre-4.0).

Signed-off-by: crynobone crynobone@gmail.com
