### PR TITLE
[Fixes] Move PHPUnit to require-dev and fixes directory references to tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
 	"keywords": ["framework", "laravel"],
 	"license": "MIT",
 	"require": {
-		"laravel/framework": "4.3.*",
+		"laravel/framework": "4.3.*"
+	},
+	"require-dev": {
 		"phpunit/phpunit": "~4.0"
 	},
 	"autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 >
     <testsuites>
         <testsuite name="Application Test Suite">
-            <directory>./app/tests/</directory>
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase {
 
 		$testEnvironment = 'testing';
 
-		return require __DIR__.'/../../bootstrap/start.php';
+		return require __DIR__.'/../bootstrap/start.php';
 	}
 
 }


### PR DESCRIPTION
- Don't think we need to have PHPUnit as part of required, dev should be more suitable.
- Fixes paths used for running phpunit.

Signed-off-by: crynobone crynobone@gmail.com
