### PR TITLE
Simplify .gitignore's .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /vendor
 composer.phar
 composer.lock
-.env.*.php
-.env.php
+.env.*
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Removes one unnecessary line to make it cleaner.
