### PR TITLE
Added path configuration for composer components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
 		]
 	},
 	"config": {
-		"preferred-install": "dist"
+		"preferred-install": "dist",
+		"component-dir": "public/components"
 	},
 	"minimum-stability": "stable"
 }


### PR DESCRIPTION
By default composer components are installed in /components, but /public/components makes more sense in Laravel.
