### PR TITLE
[Proposal] More detailed logging

### DIFF
--- a/app/Providers/ErrorServiceProvider.php
+++ b/app/Providers/ErrorServiceProvider.php
@@ -1,6 +1,6 @@
 <?php namespace App\Providers;
 
-use App, Log, Exception;
+use App, Log, Exception, Request, URL;
 use Illuminate\Support\ServiceProvider;
 
 class ErrorServiceProvider extends ServiceProvider {
@@ -19,7 +19,8 @@ class ErrorServiceProvider extends ServiceProvider {
 		// shown, which includes a detailed stack trace during debug.
 		App::error(function(Exception $e)
 		{
-			Log::error($e);
+			$error = sprintf("Error %d on %s %s: %s", $code, Request::getMethod(), URL::current(), $exception);
+			Log::error($error); 
 		});
 	}
 

--- a/app/Providers/ErrorServiceProvider.php
+++ b/app/Providers/ErrorServiceProvider.php
@@ -17,10 +17,17 @@ class ErrorServiceProvider extends ServiceProvider {
 		// even register several error handlers to handle different types of
 		// exceptions. If nothing is returned, the default error view is
 		// shown, which includes a detailed stack trace during debug.
-		App::error(function(Exception $e)
+		App::error(function(Exception $e, $code)
 		{
-			$error = sprintf("Error %d on %s %s: %s", $code, Request::getMethod(), URL::current(), $exception);
-			Log::error($error); 
+			$error = sprintf("Error %d on %s %s, ", $code, Request::getMethod(), URL::current());
+
+			if ($code === 404) {
+				$error .= "referer: " . Request::header('referer', '-');
+			} else {
+				$error .= (string) $e;
+			}
+
+			Log::error($error);
 		});
 	}
 


### PR DESCRIPTION
When looking through errors it is not very clear where an error occured. For example 404 errors: from ` exception 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException' in /var/www/html/project/vendor/laravel/framework/src/Illuminate/Routing/RouteCollection.php:140` you don't know on what path that happend (and beginners don't even get that this is just a 404).
`Error 404 on GET http://mydomain.com/my-route: exception 'Symfony\...` would make much more sense imho..

(Follow-up on https://github.com/laravel/laravel/pull/2764 for 4.3 branch)