### PR TITLE
fix AuthFilter params error

### DIFF
--- a/app/Http/Filters/AuthFilter.php
+++ b/app/Http/Filters/AuthFilter.php
@@ -11,7 +11,7 @@ class AuthFilter {
 	 * @param  \Illuminate\Http\Request  $request
 	 * @return mixed
 	 */
-	public function filter(Request $request)
+	public function filter(Route $route, Request $request)
 	{
 		if (Auth::guest())
 		{


### PR DESCRIPTION
The first param of filter method must be an instance of Illuminate\Routing\Route
