### PR TITLE
Move app providers after illuminate providers, thus avoid error when registering/booting process is depending on illuminate register/boot is being executed too late.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -96,16 +96,6 @@ return [
 	'providers' => [
 
 		/*
-		 * Application Service Providers...
-		 */
-		'App\Providers\AppServiceProvider',
-		'App\Providers\ArtisanServiceProvider',
-		'App\Providers\ErrorServiceProvider',
-		'App\Providers\FilterServiceProvider',
-		'App\Providers\LogServiceProvider',
-		'App\Providers\RouteServiceProvider',
-
-		/*
 		 * Laravel Framework Service Providers...
 		 */
 		'Illuminate\Foundation\Providers\ArtisanServiceProvider',
@@ -128,6 +118,16 @@ return [
 		'Illuminate\Translation\TranslationServiceProvider',
 		'Illuminate\Validation\ValidationServiceProvider',
 		'Illuminate\View\ViewServiceProvider',
+
+		/*
+		 * Application Service Providers...
+		 */
+		'App\Providers\AppServiceProvider',
+		'App\Providers\ArtisanServiceProvider',
+		'App\Providers\ErrorServiceProvider',
+		'App\Providers\FilterServiceProvider',
+		'App\Providers\LogServiceProvider',
+		'App\Providers\RouteServiceProvider',
 
 	],
 


### PR DESCRIPTION
Solve issues such as laravel/framework#5576

In 5576, `AppServiceProvider::boot()` executed first before `Illuminate\Database\DatabaseServiceProvider::boot()` which would set the connection resolver for Eloquent.

Signed-off-by: crynobone crynobone@gmail.com
