### PR TITLE
View service provider

### DIFF
--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -5,24 +5,24 @@ use Illuminate\Support\ServiceProvider;
 
 class ViewServiceProvider extends ServiceProvider {
 
-    /**
-     * Bootstrap any necessary services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        // Here you may bind composers, creators, etc, to your views.
-    }
+	/**
+	 * Bootstrap any necessary services.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		// Here you may bind composers, creators, etc, to your views.
+	}
 
-    /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        //
-    }
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		//
+	}
 
 }

--- a/config/app.php
+++ b/config/app.php
@@ -104,7 +104,7 @@ return [
 		'App\Providers\FilterServiceProvider',
 		'App\Providers\LogServiceProvider',
 		'App\Providers\RouteServiceProvider',
-        'App\Providers\ViewServiceProvider',
+		'App\Providers\ViewServiceProvider',
 
 		/*
 		 * Laravel Framework Service Providers...

--- a/config/compile.php
+++ b/config/compile.php
@@ -21,7 +21,7 @@ return [
 		__DIR__.'/../app/Providers/FilterServiceProvider.php',
 		__DIR__.'/../app/Providers/LogServiceProvider.php',
 		__DIR__.'/../app/Providers/RouteServiceProvider.php',
-        __DIR__.'/../app/Providers/ViewServiceProvider.php',
+		__DIR__.'/../app/Providers/ViewServiceProvider.php',
 
 	],
 


### PR DESCRIPTION
Since 4.3 is emphasizing the use of service providers over bootstrap files I think it makes sense to have a **ViewServiceProvider** under app\Providers that can be used to bind any shared data, view composers, creators, etc. However, I'm not sure if this functionality has enough widespread use to actually warrant a new SP, nor am I sure about the naming (there already is an Illuminate ViewServiceProvider for that component so it could be confusing). It's also empty by default, though this may not be an issue as the AppServiceProvider is also empty.
