### PR TITLE
[bug] Auth redirect should match default routes

### DIFF
--- a/app/Http/Filters/AuthFilter.php
+++ b/app/Http/Filters/AuthFilter.php
@@ -23,7 +23,7 @@ class AuthFilter {
 			}
 			else
 			{
-				return Redirect::guest('login');
+				return Redirect::guest('auth\login');
 			}
 		}
 	}


### PR DESCRIPTION
that php artisan auth:make outputs

```

Route: Route::controller('auth', 'Auth\AuthController');
Controller created successfully.
Route: Route::controller('password', 'Auth\RemindersController');
Authentication requests created successfully.
Migration created successfully.
Generating optimized class loader
Compiling common classes
Compiling views
```
