### PR TITLE
[bug] Auth filter still redirects to /login not auth/login

### DIFF
--- a/app/Http/Filters/AuthFilter.php
+++ b/app/Http/Filters/AuthFilter.php
@@ -23,7 +23,7 @@ class AuthFilter {
 			}
 			else
 			{
-				return Redirect::guest('login');
+				return Redirect::guest('auth/login');
 			}
 		}
 	}


### PR DESCRIPTION
 if you use make:auth it defaults to auth/login for a path. But if you look at the Auth filter it defaults to /login as a path.
