### PR TITLE
[Proposal] CsrfFilter if request is ajax read from X-CSRF-Token header

### DIFF
--- a/app/Http/Filters/CsrfFilter.php
+++ b/app/Http/Filters/CsrfFilter.php
@@ -18,7 +18,16 @@ class CsrfFilter {
 	 */
 	public function filter(Route $route, Request $request)
 	{
-		if (Session::token() != $request->input('_token'))
+		if ($request->ajax())
+		{
+			$token = $request->header('X-CSRF-Token');
+		}
+		else
+		{
+			$token = $request->input('_token');
+		}
+		
+		if (Session::token() != $token)
 		{
 			throw new TokenMismatchException;
 		}


### PR DESCRIPTION
When making single page apps or ajax driven sites, you may be sending the token via X-CSRF-Token header. I think we can make this validation by default, like the one in AuthFilter. What do you think?

Cheers :)