### PR TITLE
Add comment to cache.php describing how to use a Memcached UNIX socket

### DIFF
--- a/app/config/cache.php
+++ b/app/config/cache.php
@@ -64,6 +64,8 @@ return array(
 	| Now you may specify an array of your Memcached servers that should be
 	| used when utilizing the Memcached cache driver. All of the servers
 	| should contain a value for "host", "port", and "weight" options.
+	| For Unix sockets, set "host" to a socket path, like
+	| '/yourpath/to/memcached.sock' and set "port" to 0.
 	|
 	*/
 


### PR DESCRIPTION
### Change

Updated app/config/cache.php to reflect that memcached 'host' and 'port' will accept values besides TCP/IP host and port.
### Backstory

As of PECL memcached driver 2.0.0b1 (release date 2011-03-13), UNIX sockets are supported by the addServer method
http://pecl.php.net/package-changelog.php?package=memcached&release=2.0.0b1

The http://php.net/manual/en/memcached.addserver.php docs were missing these socket details too, but PHP.net accepted my edits and published them this week.
### Working Example

I simply specified the socket path in the host and 0 for the port and have confirmed socket cache hits with no other changes to Laravel.

```
-               array('host' => '127.0.0.1', 'port' => 11211, 'weight' => 100),
+                array('host' => '/var/run/memcached/memcached.sock', 'port' => 0, 'weight' => 100),
```

The only real trick was making sure the web server user had write access to the socket file, which has nothing to do with Laravel config.
