### PR TITLE
[Liferaft] HTML Provider escaping bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .env.*
 .DS_Store
 Thumbs.db
+.idea

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,4 +11,6 @@
 |
 */
 
-Route::get('/', 'HomeController@index');
+Route::get('/', function(){
+	return view('test.test');
+});

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,9 @@
 	"license": "MIT",
 	"type": "project",
 	"require": {
-		"laravel/framework": "~5.0"
-	},
+		"laravel/framework": "~5.0",
+        "illuminate/html": "5.0.*"
+    },
 	"require-dev": {
 		"phpunit/phpunit": "~4.0"
 	},

--- a/config/app.php
+++ b/config/app.php
@@ -128,7 +128,7 @@ return [
 		'Illuminate\Translation\TranslationServiceProvider',
 		'Illuminate\Validation\ValidationServiceProvider',
 		'Illuminate\View\ViewServiceProvider',
-
+		'Illuminate\Html\HtmlServiceProvider',
 	],
 
 	/*
@@ -187,6 +187,8 @@ return [
 		'Validator' => 'Illuminate\Support\Facades\Validator',
 		'View'      => 'Illuminate\Support\Facades\View',
 
+		'HTML' => 'Illuminate\Html\HtmlFacade',
+		'Form' => 'Illuminate\Html\FormFacade',
 	],
 
 ];

--- a/liferaft.md
+++ b/liferaft.md
@@ -1,0 +1,19 @@
+HTML Provider escaping bug
+
+When using illuminate/html, the html generated is enclosed in double quotes and not parsed by the browser. The e() helper seems to be involved, but I can't tell in what way.
+
+* No seeds/database required
+
+### Tested with
+- Browsers
+	- Chrome
+	- Firefox
+
+- Stack
+	- Homestead 0.1.9 (PHP)
+	- artisan serve (with host PHP 5.5.9-1ubuntu4.4)
+
+
+### Steps to reproduce
+
+* Access the "/" route

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bug Report</title>
+</head>
+<body>
+<div class="container">
+    @yield('content')
+</div>
+</body>
+</html>

--- a/resources/views/test/test.blade.php
+++ b/resources/views/test/test.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.master')
+
+@section('content')
+<div>
+This content is Ok
+<input type="text" name="testInput">
+</div>
+
+<div>
+This Content not parsed by the browser
+  <div class="pull-right">
+        {{ Form::open(['url' => 'auth/login', 'class' => 'form-inline', 'role' => 'form']) }}
+            <!-- Email Form Input -->
+            <div class="form-group">
+                {{ Form::text('email', null, ['class' => 'form-control input-sm', 'placeholder' => trans('generics.email')]) }}
+            </div>
+            <!-- Password Form Input -->
+            <div class="form-group">
+                {{ Form::password('password', ['class' => 'form-control input-sm', 'placeholder' => trans('generics.password')]) }}
+            </div>
+            <div class="checkbox">
+                <label class="radio-inline">
+                    {{Form::checkbox('remember_me')}} {{ trans('auth.remember_me') }}
+                </label>
+            </div>
+            {{ Form::submit(trans('auth.login'), ['class' => 'btn btn-primary btn-xs']) }}
+            {{ HTML::link('auth/register', trans('auth.register'),['class' => 'btn btn-default btn-xs']) }}
+        {{ Form::close() }}
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
When using illuminate/html, the html generated is enclosed in double quotes and not parsed by the browser. The e() helper seems to be involved, but I can't tell in what way.
- No seeds/database required
### Tested with
- Browsers
  - Chrome
  - Firefox
- Stack
  - Homestead 0.1.9 (PHP)
  - artisan serve (with host PHP 5.5.9-1ubuntu4.4)
### Steps to reproduce
- Access the "/" route
