### PR TITLE
Remove the composer.lock file (.gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /vendor
 composer.phar
-composer.lock
 .env.*
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
This composer.lock would be useful to keep (for faster composer install).

I don't know why you set phpunit as a dev dependency. I have 5 minutes composer update because of this bad guy now :(