### PR TITLE
Fix typo on config namespaces.controller to namespace.controllers

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -15,7 +15,7 @@ class RouteServiceProvider extends ServiceProvider {
 	public function before()
 	{
 		URL::setRootControllerNamespace(
-			trim(config('namespaces.controller'), '\\')
+			trim(config('namespaces.controllers'), '\\')
 		);
 	}
 


### PR DESCRIPTION
This line

``` php
trim(config('namespaces.controller'), '\\')
```

should be

``` php
trim(config('namespaces.controllers'), '\\')
```
