### PR TITLE
[Liferaft] HttpNotFoundException in Tests when hitting the same route twice.

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -10,8 +10,4 @@
 | and give it the Closure to execute when that URI is requested.
 |
 */
-
-Route::get('/', function()
-{
-	return View::make('hello');
-});
+require_once __DIR__ . '/../src/routes.php';

--- a/app/tests/ExampleTest.php
+++ b/app/tests/ExampleTest.php
@@ -9,9 +9,17 @@ class ExampleTest extends TestCase {
 	 */
 	public function testBasicExample()
 	{
-		$crawler = $this->client->request('GET', '/');
+		$this->call('GET', '/search');
+	}
 
-		$this->assertTrue($this->client->getResponse()->isOk());
+	/**
+	* A basic functional test example.
+	*
+	* @return void
+	*/
+	public function testBasicExample2()
+	{
+		$this->call('GET', '/search');
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
 			"app/database/migrations",
 			"app/database/seeds",
 			"app/tests/TestCase.php"
-		]
+		],
+		"psr-4": {
+			"Acme\\": "src"
+		}
 	},
 	"scripts": {
 		"post-install-cmd": [

--- a/liferaft.md
+++ b/liferaft.md
@@ -1,0 +1,11 @@
+HttpNotFoundException in Tests when hitting the same route twice.
+
+There's no way to define two tests in the same test class which will hit the
+same route. It's happening when I got psr-4 mapping to src/ directory.
+
+Just execute phpunit.
+All I did in this Liferaft's repository is:
+psr-4 mapping to src folder. (Acme namespace)
+require once route file from src in route.php in app.
+created one simple controller
+defined two simple tests.

--- a/src/Controllers/SearchController.php
+++ b/src/Controllers/SearchController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Acme\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class SearchController extends Controller
+{
+  public function index()
+  {
+    return "OK";
+  }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,0 +1,3 @@
+<?php
+
+Route::get('/search', 'Acme\\Controllers\\SearchController@index');


### PR DESCRIPTION
There's no way to define two tests in the same test class which will hit the
same route. It's happening when I got psr-4 mapping to src/ directory.

Just execute phpunit.
All I did in this Liferaft's repository is:
psr-4 mapping to src folder. (Acme namespace)
require once route file from src in route.php in app.
created one simple controller
defined two simple tests.
