### PR TITLE
Added guidance for where to put dependency service providers

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -129,6 +129,10 @@ return [
 		'Illuminate\Validation\ValidationServiceProvider',
 		'Illuminate\View\ViewServiceProvider',
 
+		/*
+		 * Dependency Service Providers...
+		 */
+
 	],
 
 	/*


### PR DESCRIPTION
With application service providers going into the AppServiceProvider, it would be nice to have a common location for dependency service providers that other packages can reference in installation instructions.
