### PR TITLE
Switch detectEnvironment to Closure

### DIFF
--- a/bootstrap/environment.php
+++ b/bootstrap/environment.php
@@ -11,8 +11,7 @@
 |
 */
 
-$env = $app->detectEnvironment([
-
-	'local' => ['homestead'],
-
-]);
+$env = $app->detectEnvironment(function()
+{
+    return getenv('APP_ENV') ?: 'local';
+});


### PR DESCRIPTION
I'm not sure people's opinion on this, but it would seem that this is one of the first things I change for all of my installations of Laravel.

Also, seeing as Homestead has support for environment variables, it would be a perfect opportunity to utilise it, and encourage more people to use environment variables instead of hardcoding environment names + host names.

Thoughts?
