### PR TITLE
[Liferaft] Laravel doesn't properly handle DateTime objects in different timezones

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -23,4 +23,11 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
 	 */
 	protected $hidden = array('password', 'remember_token');
 
+	/**
+	 * The 'born' attribute is a date
+	 */
+	public function getDates() {
+		return ['born'];
+	}
+
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -13,5 +13,26 @@
 
 Route::get('/', function()
 {
-	return View::make('hello');
+	ob_start();
+
+	$user = new User;
+	echo "At start, \$user->born is: "; var_dump($user->born);
+
+	$born = \Carbon\Carbon::parse('1983-01-01 12:00:00 UTC');
+	echo "New UTC Carbon date: {$born->toRssString()}\n";
+
+	echo "Change its timezone to America/Vancouver\n";
+	$born->timezone('America/Vancouver');
+	echo "Vancouver Carbon date: {$born->toRssString()}\n";
+
+	echo "Now set \$user->born to this\n";
+	$user->born = $born;
+
+	echo "Now retrieve \$user->born: {$user->born->toRssString()}\n";
+
+	echo "We should see 12 noon +0000, but we see 4am +0000\n";
+
+	$response = Response::make(ob_get_clean(), 200);
+	$response->header('Content-Type', 'text/plain');
+	return $response;
 });

--- a/liferaft.md
+++ b/liferaft.md
@@ -1,0 +1,8 @@
+Laravel doesn't properly handle DateTime objects in different timezones
+
+When a datetime property on a model is set to a Carbon or DateTime object with a 
+different timezone than Laravel's configured timezone, it is stored incorrectly.
+
+In the User model, the attribute 'born' is described as a date.
+
+Hit the / route for a plain text demonstration of the issue.


### PR DESCRIPTION
When a datetime property on a model is set to a Carbon or DateTime object with a 
different timezone than Laravel's configured timezone, it is stored incorrectly.

In the User model, the attribute 'born' is described as a date.

Hit the / route for a plain text demonstration of the issue.