### PR TITLE
Add PHPSpec config file and dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
 		"laravel/framework": "~5.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.0"
+		"phpunit/phpunit": "~4.0",
+		"phpspec/phpspec": "~2.1"
 	},
 	"autoload": {
 		"classmap": [

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,5 @@
+suites:
+    main:
+        namespace: App
+        psr4_prefix: App
+        src_path: app


### PR DESCRIPTION
This adds a default PHPSpec config file which should be enough to create PHPSpec specifications and run them. Works great with `phpspec describe` and `phpspec run`.

We might want to change the namespace in here when you run `php artisan app:name` command.
