### PR TITLE
[Proposal] [5.0] Add option to enable query log and disable it by default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,6 +61,7 @@ return [
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',
+			'log'       => true,
 		],
 
 		'pgsql' => [
@@ -71,6 +72,7 @@ return [
 			'password' => '',
 			'charset'  => 'utf8',
 			'prefix'   => '',
+			'log'      => true,
 			'schema'   => 'public',
 		],
 
@@ -81,6 +83,7 @@ return [
 			'username' => 'root',
 			'password' => '',
 			'prefix'   => '',
+			'log'      => true,
 		],
 
 	],

--- a/config/local/database.php
+++ b/config/local/database.php
@@ -29,6 +29,7 @@ return [
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',
+			'log'       => true,
 		],
 
 		'pgsql' => [
@@ -39,6 +40,7 @@ return [
 			'password' => 'secret',
 			'charset'  => 'utf8',
 			'prefix'   => '',
+			'log'      => true,
 			'schema'   => 'public',
 		],
 


### PR DESCRIPTION
#### Rationale:

On production systems, especially in long-playing CLI scripts query logs grow up and takes significant resources, especially when large inserts or updates performed.
In situations when query log required it should be enabled explicitly.

The real problem why changes required and `\Illuminate\Database\Connection::disableQueryLog` can't be used is when lazy connection initialization used, so we don't know exactly when connection will be created while underlying IoC container creates connection object immediately.

When there are a lot of background scripts (e.g. queue listeners) and there are a lot of such machines that may produce significant overhead in connections number.

PR for framework is here https://github.com/laravel/framework/pull/5926
