### PR TITLE
'base_url' config option for S3 driver

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -49,10 +49,11 @@ return [
 		],
 
 		's3' => [
-			'driver' => 's3',
-			'key'    => 'your-key',
-			'secret' => 'your-secret',
-			'bucket' => 'your-bucket',
+			'driver'   => 's3',
+			'key'      => 'your-key',
+			'secret'   => 'your-secret',
+			'bucket'   => 'your-bucket',
+			'base_url' => 'http://s3.amazonaws.com',
 		],
 
 		'rackspace' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -53,7 +53,7 @@ return [
 			'key'      => 'your-key',
 			'secret'   => 'your-secret',
 			'bucket'   => 'your-bucket',
-			'base_url' => 'http://s3.amazonaws.com',
+			'base_url' => 'https://s3.amazonaws.com',
 		],
 
 		'rackspace' => [


### PR DESCRIPTION
By adding a base_url config option to the S3 driver, other cloud storage platforms that use the S3 API can be utilized. Google Cloud Storage and DreamHosts' DreamObjects are two examples of cloud storage platforms that use the S3 API. Flysystem and the AWS SDK support custom `base_url` endpoints when creating the S3Client.