### PR TITLE
Added comments to indicate the exclusive nature of the two options for session timeouts

### DIFF
--- a/app/config/session.php
+++ b/app/config/session.php
@@ -26,7 +26,7 @@ return array(
 	| Here you may specify either the number of minutes that you wish the 
 	| session to be allowed to remain idle before it expires or that the
 	| session only expires immediately on the browser closing. If you set
-        | 'expire_on_close' to true, 'lifetime' will be ignored. 
+	| 'expire_on_close' to true, 'lifetime' will be ignored. 
 	|
 	*/
 

--- a/app/config/session.php
+++ b/app/config/session.php
@@ -23,9 +23,10 @@ return array(
 	| Session Lifetime
 	|--------------------------------------------------------------------------
 	|
-	| Here you may specify the number of minutes that you wish the session
-	| to be allowed to remain idle before it expires. If you want them
-	| to immediately expire on the browser closing, set that option.
+	| Here you may specify either the number of minutes that you wish the 
+	| session to be allowed to remain idle before it expires or that the
+	| session only expires immediately on the browser closing. If you set
+        | 'expire_on_close' to true, 'lifetime' will be ignored. 
 	|
 	*/
 


### PR DESCRIPTION
Expiration can be one or the other: lifetime or expire_on_close. See
http://stackoverflow.com/questions/26167047/authentication-in-laravel-4-persisting-beyond-session-timeout-is-this-localho?noredirect=1#comment41025042_26167047