### PR TITLE
Add "@var" comment to fix IDE auto-complete of "$router" variable in "routes.php"

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,4 +11,6 @@
 |
 */
 
+/** @var \Illuminate\Routing\Router $router */
+
 $router->get('/', 'HomeController@index');


### PR DESCRIPTION
Without proper `@var` comment the IDE auto-complete on new `$router` variable doesn't work at all, which makes it very hard to add new routers, because you need to type router method names by hand.

Related to laravel/framework#5971
