### PR TITLE
Add request method to conditions of CsrfMiddleware.php

### DIFF
--- a/app/Http/Middleware/CsrfMiddleware.php
+++ b/app/Http/Middleware/CsrfMiddleware.php
@@ -15,7 +15,7 @@ class CsrfMiddleware implements Middleware {
 	 */
 	public function handle($request, Closure $next)
 	{
-		if ($request->method() === 'POST' && $request->session()->token() != $request->input('_token'))
+		if ($request->method() !== 'GET' && $request->session()->token() != $request->input('_token'))
 		{
 			throw new TokenMismatchException;
 		}


### PR DESCRIPTION
The rationale behind this is that the CsrfMiddleware could be included in the application middleware stack to enable csrf protection on all post requests (of course for APIs, one would have to tweak the handle method to account for that too, but for "web" controllers it would work out of the box).
