### PR TITLE
Allows redis queue to use user-defined connection

### DIFF
--- a/app/config/queue.php
+++ b/app/config/queue.php
@@ -60,6 +60,7 @@ return array(
 
 		'redis' => array(
 			'driver' => 'redis',
+			'connection' => 'default',
 			'queue'  => 'default',
 		),
 


### PR DESCRIPTION
This pull request updates the `queue.php` config file to allow Redis queue to use user-defined connection and not just the 'default' connection. This pull-request is the part of [https://github.com/laravel/framework/pull/6035](https://github.com/laravel/framework/pull/6035).