### PR TITLE
Added @throws TokenMismatchException

### DIFF
--- a/app/Http/Middleware/CsrfMiddleware.php
+++ b/app/Http/Middleware/CsrfMiddleware.php
@@ -11,7 +11,6 @@ class CsrfMiddleware implements Middleware {
 	 *
 	 * @param  \Illuminate\Http\Request  $request
 	 * @param  \Closure  $next
-	 * 
 	 * @return mixed
 	 * 
 	 * @throws TokenMismatchException


### PR DESCRIPTION
Since modern IDE's will expect you to define the @throws attribute, added this to the Docblock.
