### PR TITLE
Optionally load .env environment file if it exist.

### DIFF
--- a/bootstrap/environment.php
+++ b/bootstrap/environment.php
@@ -11,10 +11,13 @@
 |
 */
 
+if (is_file(__DIR__.'/../.env'))
+{
+	Dotenv::load(__DIR__.'/../', '.env');
+}
+
 try
 {
-	Dotenv::load(__DIR__.'/../');
-
 	Dotenv::required('APP_ENV');
 }
 catch (RuntimeException $e)


### PR DESCRIPTION
Avoid causing exception to occur during installation or production setup where you could choose to opt for configuring environment values through nginx or apache.

Solved laravel/framework#6032

Signed-off-by: crynobone crynobone@gmail.com
