### PR TITLE
Added wildcard for directory ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/bootstrap/compiled.php
-/vendor
+*/bootstrap/compiled.php
+*/vendor
 composer.phar
 composer.lock
 .env.*.php


### PR DESCRIPTION
Laravel isn't always in the root folder
