### PR TITLE
[Proposal] Remove google fonts

### DIFF
--- a/resources/views/hello.php
+++ b/resources/views/hello.php
@@ -4,11 +4,10 @@
 	<meta charset="UTF-8">
 	<title>Laravel PHP Framework</title>
 	<style>
-		@import url(//fonts.googleapis.com/css?family=Lato:700);
 
 		body {
 			margin:0;
-			font-family:'Lato', sans-serif;
+			font-family: Arial, Helvetica, sans-serif;
 			text-align:center;
 			color: #999;
 		}
@@ -29,6 +28,7 @@
 
 		h1 {
 			font-size: 32px;
+			font-weight:normal;
 			margin: 16px 0 0 0;
 		}
 	</style>


### PR DESCRIPTION
With laravel popular in China, more and more developers to join the laravel arms, but now there is a problem, most developers when installing Laravel half-day untapped home, and later found because Home Use the google font, it is proposed to remove this dependence, leaving the majority of Laravel fans a good impression. Thank you!

In fact, this looks good:

![image](https://cloud.githubusercontent.com/assets/1472352/4605509/942cebb2-51e6-11e4-8e9b-bf1c8800a894.png)
