### PR TITLE
[Proposal] Allow workbench stability to be set

### DIFF
--- a/config/workbench.php
+++ b/config/workbench.php
@@ -27,5 +27,18 @@ return [
 	*/
 
 	'email' => '',
+	
+	/*
+	|--------------------------------------------------------------------------
+	| Workbench Stability
+	|--------------------------------------------------------------------------
+	|
+	| Like the option above, your e-mail address is used when generating new
+	| workbench packages. The stability is placed in your composer.json file
+	| automatically after the package is created by the workbench tool.
+	|
+	*/
+
+	'stability' => 'stable',
 
 ];


### PR DESCRIPTION
As a Developer
When working on a dev version of Laravel and making a Laravel Package using workbench I would like to still use php artisan workbench without getting the error that matching stability level not found
So I can continue making Laravel packages for a project even when using a dev version of Laravel

-----
This way Workbench allows the stability option and more importantly continues to work when 
in transitions like L4 to L5.

this is related to this proposal https://github.com/laravel/framework/pull/6052


Thanks