### PR TITLE
Add RememberToken to the default Create_Users_Table

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -17,6 +17,7 @@ class CreateUsersTable extends Migration {
 			$table->increments('id');
 			$table->string('email')->unique();
 			$table->string('password', 60);
+			$table->rememberToken();
 			$table->timestamps();
 		});
 	}


### PR DESCRIPTION
Need a remember token on the default users table - otherwise the `/logout` function gets upset.
