### PR TITLE
Use arrows instead of guillemets in pagination

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -13,8 +13,8 @@ return [
 	|
 	*/
 
-	'previous' => '&laquo; Previous',
+	'previous' => '&larr; Previous',
 
-	'next'     => 'Next &raquo;',
+	'next'     => 'Next &rarr;',
 
 ];


### PR DESCRIPTION
Currently, "Previous" and "Next" pagination links use guillemets « (`&laquo;`) and » (`&raquo;`) as navigational signs, but it seems semantically correct to use arrows ← (`&larr;`) and → (`&rarr;`) since guillemets are quotation marks.
