### PR TITLE
added private setting to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "devDependencies": {
     "del": "^0.1.3",
     "gulp": "^3.8.8",


### PR DESCRIPTION
so buildservers wont fail on npm install warning.

```
npm WARN package.json @ No repository field.
```
