### PR TITLE
Update PasswordController.php

### DIFF
--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -50,7 +50,9 @@ class PasswordController {
 	 */
 	public function sendResetLink(Request $request)
 	{
-		switch ($response = $this->passwords->sendResetLink($request->only('email')))
+		switch ($response = $this->passwords->sendResetLink($request->only('email'), function ($message) {
+			$message->subject('Password Reset');
+		}))
 		{
 			case PasswordBroker::INVALID_USER:
 				return redirect()->back()->with('error', trans($response));


### PR DESCRIPTION
Provide a sensible default subject heading when sending a Password Reset link email. 

As discussed here there is no default password subject: https://github.com/laravel/framework/pull/6062
