### PR TITLE
Fix VerifyCsrfToken name

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -24,7 +24,7 @@ class RouteServiceProvider extends ServiceProvider {
 	protected $middleware = [
 		'auth' => 'App\Http\Middleware\Authenticated',
 		'auth.basic' => 'App\Http\Middleware\AuthenticatedWithBasicAuth',
-		'csrf' => 'App\Http\Middleware\CsrfTokenIsValid',
+		'csrf' => 'App\Http\Middleware\VerifyCsrfToken',
 		'guest' => 'App\Http\Middleware\IsGuest',
 	];
 


### PR DESCRIPTION
Apparently that class was renamed. It was referenced wrongly in the RouteServiceProvider, which you only notice when you remove VerifyCsrfToken from the Kernel and including the middleware manually in a route (['middleware'=>'csrf']).
