### PR TITLE
fix php artisan serve functionality with hardcoded values

### DIFF
--- a/server.php
+++ b/server.php
@@ -4,9 +4,9 @@ $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
 $uri = urldecode($uri);
 
-$paths = require __DIR__.'/bootstrap/paths.php';
+$public = __DIR__ . '/public';
 
-$requested = $paths['public'].$uri;
+$requested = $public . $uri;
 
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
@@ -16,4 +16,4 @@ if ($uri !== '/' and file_exists($requested))
 	return false;
 }
 
-require_once $paths['public'].'/index.php';
+require_once $public . '/index.php';


### PR DESCRIPTION
Because `bootstrap/paths.php` got removed. Can't find a decent way to source paths now.
