### PR TITLE
new logout-method naming

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -23,7 +23,7 @@ class AuthController extends Controller {
 	{
 		$this->auth = $auth;
 
-		$this->middleware('guest', ['except' => 'logout']);
+		$this->middleware('guest', ['except' => 'getLogout']);
 	}
 
 	/**


### PR DESCRIPTION
The method-naming changed, so the old method name didn't work.
