### PR TITLE
Fixed middleware except option

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -23,7 +23,7 @@ class AuthController extends Controller {
 	{
 		$this->auth = $auth;
 
-		$this->middleware('guest', ['except' => 'logout']);
+		$this->middleware('guest', ['except' => 'getLogout']);
 	}
 
 	/**


### PR DESCRIPTION
Since the logout() method was renamed to getLogout(), this needs to change too.
