### PR TITLE
Prevent TokenMismatchException for HTTP OPTIONS requests

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -17,7 +17,7 @@ class VerifyCsrfToken implements Middleware {
 	 */
 	public function handle($request, Closure $next)
 	{
-		if ($request->method() == 'GET' || $this->tokensMatch($request))
+		if ($this->isReadOnly($request) || $this->tokensMatch($request))
 		{
 			return $next($request);
 		}
@@ -34,6 +34,17 @@ class VerifyCsrfToken implements Middleware {
 	protected function tokensMatch($request)
 	{
 		return $request->session()->token() == $request->input('_token');
+	}
+
+	/**
+	 * Determine if the HTTP request uses a ‘read’ verb.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return bool
+	 */
+	protected function isReadOnly($request)
+	{
+		return in_array($request->method(), ['GET', 'OPTIONS']);
 	}
 
 }


### PR DESCRIPTION
`OPTIONS` HTTP requests should be treated in the same way than `GET` requests by the `VerifyCsrfToken` middleware. Otherwise, an exception is thrown, thus preventing any `OPTIONS` route to work.
