### PR TITLE
Added node_modules directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/node_modules
 /vendor
 .env


### PR DESCRIPTION
Elixir requires Node.js modules so that after installing them, they appear in `git status`. This Pull Request adds the **node_modules** directory to the Git ignore list so that Node.js dependencies are accidentally checked into source control.
