### PR TITLE
[5.0] Bring workbench loaders back. Fixes laravel/framework#6164

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -33,3 +33,18 @@ if (file_exists($compiledPath))
 {
 	require $compiledPath;
 }
+
+/*
+|--------------------------------------------------------------------------
+| Register The Workbench Loaders
+|--------------------------------------------------------------------------
+|
+| The Laravel workbench provides a convenient place to develop packages
+| when working locally. However we will need to load in the Composer
+| auto-load files for the packages so that these can be used here.
+|
+*/
+if (is_dir($workbench = __DIR__.'/../workbench'))
+{
+	Illuminate\Workbench\Starter::start($workbench);
+}


### PR DESCRIPTION
Workbench is no longer auto loaded. Not sure if this was intentional but it was definitely a nice feature.
