### PR TITLE
Use timing safe string comparison in CSRF filter

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Security\Core\Util\StringUtils;
+
 /*
 |--------------------------------------------------------------------------
 | Application & Route Filters
@@ -83,7 +85,7 @@ Route::filter('guest', function()
 
 Route::filter('csrf', function()
 {
-	if (Session::token() !== Input::get('_token'))
+	if ( ! StringUtils::equals(Session::token(), Input::get('_token')))
 	{
 		throw new Illuminate\Session\TokenMismatchException;
 	}


### PR DESCRIPTION
Use a timing safe comparison, as provided by the Symfony Security Component.

As proposed by by @lasselehtinen and @ircmaxell in https://github.com/laravel/laravel/commit/ba0cf2a1c9280e99d39aad5d4d686d554941eea1

(I'm not a security expert, so they more knowledge about this)