### PR TITLE
[5.0] Fixed Exception Handler instance

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -38,7 +38,7 @@ $app->singleton(
 
 $app->singleton(
 	'Illuminate\Contracts\Debug\ExceptionHandler',
-	'App\Exceptions\ExceptionHandler'
+	'App\Exceptions\Handler'
 );
 
 /*


### PR DESCRIPTION
Called wrong class name for the new Exception Handler:
https://github.com/laravel/laravel/blob/develop/app/Exceptions/Handler.php
