### PR TITLE
Untrack node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 .env
+/node_modules


### PR DESCRIPTION
I don't want node_modules to be there when I deploy. node_modules should only exist in my local environment and thanks to package.json, doesn't need to be tracked through git.
