### PR TITLE
Make trailing slash rewrite use relative path

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,7 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteRule ^(.*)/$ $1 [L,R=301]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,8 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ $1 [L,R=301]
+    RewriteCond %{REQUEST_URI} (.*)/$
+    RewriteRule ^ %1 [L,R=301]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,8 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
-    RewriteCond %{REQUEST_URI} (.*)/$
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
     # Handle Front Controller...


### PR DESCRIPTION
The "Redirect Trailing Slash" `RewriteRule` does not use a relative path. Instead, it uses an absolute path to the web root. This causes an issue if you add `RewriteBase` to `.htaccess`.

To see this problem in action, consider the following `.htaccess:

```
RewriteBase /newbase

# Redirect Trailing Slashes...
RewriteRule ^(.*)/$ /$1 [L,R=301]
```

If we make a request to  `http://some-site.com/newbase/file/`, we will be redirected to `http://some-site.com/file`, which is incorrect.

By changing the RewriteRule to `RewriteRule ^(.*)/$ $1 [L,R=301]`, you now get redirected to the correct location: `http://some-site.com/newbase/file`

Granted, you could argue that since this issue would only come up if you edit the `.htaccess` file and add the `RewriteBase` rule, you should know to change the corresponding `RewriteRule`. However, if you know little about `.htaccess` files, you might spend an hour trying to figure out why you were redirected to the web root when an extra slash was added at the end.

It's important to note that this change does not appear adversely affect anything if we still use the web root.
