### PR TITLE
 Inspiring class with a contract example

### DIFF
--- a/app/Console/Commands/InspireCommand.php
+++ b/app/Console/Commands/InspireCommand.php
@@ -1,7 +1,7 @@
 <?php namespace App\Console\Commands;
 
+use App\Contracts\Inspiring as InspiringContract;
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Inspiring;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -22,12 +22,22 @@ class InspireCommand extends Command {
 	protected $description = 'Display an inspiring quote';
 
 	/**
+	 * The inspiring class
+	 *
+	 * @var InspiringContract
+	 */
+	protected $inspiring;
+
+	/**
 	 * Create a new command instance.
 	 *
+	 * @param InspiringContract $inspiring
 	 * @return void
 	 */
-	public function __construct()
+	public function __construct(InspiringContract $inspiring)
 	{
+		$this->inspiring = $inspiring;
+
 		parent::__construct();
 	}
 
@@ -38,7 +48,7 @@ class InspireCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->comment(PHP_EOL.Inspiring::quote().PHP_EOL);
+		$this->comment(PHP_EOL.$this->inspiring->quote().PHP_EOL);
 	}
 
 }

--- a/app/Contracts/Inspiring.php
+++ b/app/Contracts/Inspiring.php
@@ -1,0 +1,12 @@
+<?php namespace App\Contracts;
+
+interface Inspiring {
+
+	/**
+	 * Get an inspiring quote.
+	 *
+	 * @return string
+	 */
+	public function quote();
+
+}

--- a/app/Inspiring.php
+++ b/app/Inspiring.php
@@ -1,0 +1,28 @@
+<?php namespace App;
+
+use App\Contracts\Inspiring as InspiringContract;
+use Illuminate\Support\Collection;
+
+class Inspiring implements InspiringContract {
+
+	/**
+	 * Get an inspiring quote.
+	 *
+	 * Taylor & Dayle made this commit from Jungfraujoch. (11,333 ft.)
+	 *
+	 * @return string
+	 */
+	public function quote()
+	{
+		return Collection::make([
+
+			'When there is no desire, all things are at peace. - Laozi',
+			'Simplicity is the ultimate sophistication. - Leonardo da Vinci',
+			'Simplicity is the essence of happiness. - Cedric Bledsoe',
+			'Smile, breathe, and go slowly. - Thich Nhat Hanh',
+			'Simplicity is an acquired taste. - Katharine Gerould',
+
+		])->random();
+	}
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		//
+		$this->app->bind('App\Contracts\Inspiring','App\Inspiring');
 	}
 
 }


### PR DESCRIPTION
Moved the inspiring class to the laravel app.

This makes it an example of how to use/integrate your own contracts within your app and use the interface binding and loading the inspire class by its contract.
