### PR TITLE
Fix fonts directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,6 @@ elixir(function(mix) {
         )
        .publish(
             'font-awesome/fonts',
-            'public/css/fonts'
+            'public/fonts'
         );
 });


### PR DESCRIPTION
Without changing bootstrap directories default fonts folder should be near css folder, not in css folder
