### PR TITLE
move Trailing Slashes after Handle Front

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,11 +5,12 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
-
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
+
+    # Redirect Trailing Slashes...
+    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    
     RewriteRule ^ index.php [L]
 </IfModule>


### PR DESCRIPTION
We have redirect loop because Apache add slash for directories (DirectorySlash On by default in apache)
