### PR TITLE
[5.0] Fixed artisan optimize crash

### DIFF
--- a/resources/config/compile.php
+++ b/resources/config/compile.php
@@ -15,9 +15,9 @@ return [
 
 	'files' => [
 
-		__DIR__.'/../app/Providers/AppServiceProvider.php',
-		__DIR__.'/../app/Providers/EventServiceProvider.php',
-		__DIR__.'/../app/Providers/RouteServiceProvider.php',
+		__DIR__.'/../../app/Providers/AppServiceProvider.php',
+		__DIR__.'/../../app/Providers/EventServiceProvider.php',
+		__DIR__.'/../../app/Providers/RouteServiceProvider.php',
 
 	],
 


### PR DESCRIPTION
`php artisan optimize` throws an exception `RuntimeException` with the message `Cannot open /home/slik/Projects/Web/laravel-dev/resources/config/../app/Providers/AppServiceProvider.php for reading'` because the config folder was moved to the resources directory, and the paths in the `resources/config/compile.php` are not valid anymore.

This patch fixes the problem.
