### PR TITLE
[5.0] Handle TokenMismatchException.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -45,7 +45,7 @@ class Handler extends ExceptionHandler {
 						$this->renderHttpException($e);
 
 			case $e instanceof TokenMismatchException:
-				if ( ! \App::isLocal())
+				if ( ! app()->isLocal())
 					return $request->ajax() ?
 						response()->json('Token expired', 498) :
 						redirect()->back()->exceptInput('_token')->withErrors(['_token'=>'Session expired.']);


### PR DESCRIPTION
After a long time stay in login page without operating, click "login" button will lead to a whoops page causing the TokenMismatchException.
