### PR TITLE
fixed MemcachedConnector Illegal string offset 'host'

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -50,7 +50,9 @@ return [
 		'memcached' => [
 			'driver'  => 'memcached',
 			'servers' => [
-				'host' => '127.0.0.1', 'port' => 11211, 'weight' => 100
+				[
+					'host' => '127.0.0.1', 'port' => 11211, 'weight' => 100
+				],
 			],
 		],
 


### PR DESCRIPTION
ErrorException in MemcachedConnector.php Illegal string offset 'host'
