### PR TITLE
Warn that cache key prefix is ignored on cache flush

### DIFF
--- a/app/config/cache.php
+++ b/app/config/cache.php
@@ -82,6 +82,9 @@ return array(
 	| be other applications utilizing the same cache. So, we'll specify a
 	| value to get prefixed to all our keys so we can avoid collisions.
 	|
+	| Note that when flushing the cache, this cache key prefix will be ignored
+	| and the entire cache flushed.
+	|
 	*/
 
 	'prefix' => 'laravel',


### PR DESCRIPTION
As discussed in https://github.com/laravel/framework/issues/5034

If you would prefer this to be against a different branch I can rebase.