### PR TITLE
This is a -3 compatible encryption comment

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -72,9 +72,9 @@ return array(
 	| Encryption Key
 	|--------------------------------------------------------------------------
 	|
-	| This key is used by the Illuminate encrypter service and should be set
-	| to a random, 32 character string, otherwise these encrypted strings
-	| will not be safe. Please do this before deploying an application!
+	| This key is used by the Illuminate encrypter service and must be set to
+	| a non-human, random string 16, 24 or 32 characters long, since as of
+	| PHP 5.6, Mcrypt requires this before developing or deploying code.	
 	|
 	*/
 


### PR DESCRIPTION
I tried to improve the comment according to the -3 standards. According to what I have read regarding Mcrypt, the randomness and "non humaness" determines the security, not only the length. As previously discussed in similar issues, the key MUST be set to a correct length starting with PHP 5.6 and should be done before using any of Laravel's encryption features, before developing and deploying.
