### PR TITLE
[5.0] Proposal - Install bower components in vendor dir

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "vendor/bower_components"
+}


### PR DESCRIPTION
Laravel Elixir's `publish` command expects bower components to be installed in `vendor/bower_components`