### PR TITLE
Environment calls in config use lowercase and dot notation.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 APP_ENV=local
-APP_DEBUG=true
-APP_KEY=SomeRandomString
+app.debug=true
+app.key=SomeRandomString
 
-DB_HOST=localhost
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+db.host=localhost
+db.database=homestead
+db.username=homestead
+db.password=secret
 
-CACHE_DRIVER=file
-SESSION_DRIVER=file
+cache.driver=file
+session.driver=file

--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
 	|
 	*/
 
-	'debug' => env('APP_DEBUG'),
+	'debug' => env('app.debug'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -78,7 +78,7 @@ return [
 	|
 	*/
 
-	'key' => env('APP_KEY', 'YourSecretKey!!!'),
+	'key' => env('app.key', 'YourSecretKey!!!'),
 
 	'cipher' => MCRYPT_RIJNDAEL_128,
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -13,7 +13,7 @@ return [
 	|
 	*/
 
-	'default' => env('CACHE_DRIVER', 'file'),
+	'default' => env('cache.driver', 'file'),
 
 	/*
 	|--------------------------------------------------------------------------

--- a/config/database.php
+++ b/config/database.php
@@ -54,10 +54,10 @@ return [
 
 		'mysql' => [
 			'driver'    => 'mysql',
-			'host'      => env('DB_HOST', 'localhost'),
-			'database'  => env('DB_DATABASE', 'forge'),
-			'username'  => env('DB_USERNAME', 'forge'),
-			'password'  => env('DB_PASSWORD', ''),
+			'host'      => env('db.host', 'localhost'),
+			'database'  => env('db.database', 'forge'),
+			'username'  => env('db.username', 'forge'),
+			'password'  => env('db.password', ''),
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',
@@ -66,10 +66,10 @@ return [
 
 		'pgsql' => [
 			'driver'   => 'pgsql',
-			'host'     => env('DB_HOST', 'localhost'),
-			'database' => env('DB_DATABASE', 'forge'),
-			'username' => env('DB_USERNAME', 'forge'),
-			'password' => env('DB_PASSWORD', ''),
+			'host'     => env('db.host', 'localhost'),
+			'database' => env('db.database', 'forge'),
+			'username' => env('db.username', 'forge'),
+			'password' => env('db.password', ''),
 			'charset'  => 'utf8',
 			'prefix'   => '',
 			'schema'   => 'public',
@@ -77,10 +77,10 @@ return [
 
 		'sqlsrv' => [
 			'driver'   => 'sqlsrv',
-			'host'     => env('DB_HOST', 'localhost'),
-			'database' => env('DB_DATABASE', 'forge'),
-			'username' => env('DB_USERNAME', 'forge'),
-			'password' => env('DB_PASSWORD', ''),
+			'host'     => env('db.host', 'localhost'),
+			'database' => env('db.database', 'forge'),
+			'username' => env('db.username', 'forge'),
+			'password' => env('db.password', ''),
 			'prefix'   => '',
 		],
 

--- a/config/session.php
+++ b/config/session.php
@@ -16,7 +16,7 @@ return [
 	|
 	*/
 
-	'driver' => env('SESSION_DRIVER', 'file'),
+	'driver' => env('session.driver', 'file'),
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Stemming from [issue 6733](https://github.com/laravel/framework/issues/6733) on the framework repo, this pull attempts to keep consistency between env naming and how config::get() pulls things. 