### PR TITLE
Enable .env as default - app.php relies on this for csrf

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=YourSecretKey!!!
 
 DB_HOST=localhost
 DB_DATABASE=homestead


### PR DESCRIPTION
Token mismatch occurs if .env isn't enabled. Allows laravel to be used out of the box.