### PR TITLE
[Bug] Composer create-project key:generate currently broken

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
 	|
 	*/
 
-	'key' => env('APP_KEY', 'YourSecretKey!!!'),
+	'key' => env('APP_KEY', 'SomeRandomString'),
 
 	'cipher' => MCRYPT_RIJNDAEL_128,
 


### PR DESCRIPTION
The default `key` in `app.php` config *must* match the `.env.example` app key on a new project - otherwise `artisan key:generate` is actually silently failing.

This is because `key:generate` is searching `.env.example` for `YourSecretKey!!!` when it doesnt exist (because `.env.example` currently has `SomeRandomString` as the default).

As a side note - the current `key:generate` command still leaves the default key in `app.php` unchanged. Is that also a bug - or a design intention to force people to use manually change it? Might be worth running a one-off command to set another random key there as well (separate from the `.env.example` key)?