### PR TITLE
added default mysql port config as well as environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ DB_HOST=localhost
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
+DB_PORT=33060
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/config/database.php
+++ b/config/database.php
@@ -58,7 +58,7 @@ return [
 			'database'  => env('DB_DATABASE', 'forge'),
 			'username'  => env('DB_USERNAME', 'forge'),
 			'password'  => env('DB_PASSWORD', ''),
-			'port'  	=> env('DB_PORT', 3306),
+			'port'      => env('DB_PORT', 3306),
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',

--- a/config/database.php
+++ b/config/database.php
@@ -58,6 +58,7 @@ return [
 			'database'  => env('DB_DATABASE', 'forge'),
 			'username'  => env('DB_USERNAME', 'forge'),
 			'password'  => env('DB_PASSWORD', ''),
+			'port'  	=> env('DB_PORT', 3306),
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',


### PR DESCRIPTION
When I was first using migrate command, it gives a port error and I need an extra step for it to work with my local homestead environment.
Homestead by default uses port 33060 and forwards it to 3306. So I thought it might be good to just add a default config for MySQL port for local environments to enable it to work out of the box.