### PR TITLE
PHPSpec produces PSR-2 classes, modify template to produce Laravel-style Classes

### DIFF
--- a/.phpspec/class.tpl
+++ b/.phpspec/class.tpl
@@ -1,0 +1,5 @@
+<?php namespace %namespace%;
+
+ class %name% {
+ 
+}


### PR DESCRIPTION
I would like to add in a template for the class file which is used by PHPSpec to generate the classes.  This formatting will make the class look like Laravel-style classes.   

PHPSpec produces:


```php
<?php

namespace MyCompany;

class Foo 
{
}
```


but to match the rest of the Laravel classes, it should be formatted like this:

```php
<?php namespace MyCompany;

 class Foo {
 }
```


N.B. *not* PSR-2 compatible