### PR TITLE
Add composer.lock to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /bootstrap/compiled.php
 /vendor
 composer.phar
-composer.lock
 .env.*.php
 .env.php
 .DS_Store


### PR DESCRIPTION
You should never ‘composer update’ a production server. This will ensure only dependancies which have passed tests will be pulled in on production servers.