### PR TITLE
Automatic assignment of the command fields

### DIFF
--- a/app/Commands/Command.php
+++ b/app/Commands/Command.php
@@ -2,6 +2,44 @@
 
 abstract class Command {
 
-	//
 
+    /**
+     * list of the command data fields.
+     *
+     * @var array
+     */
+    protected $_fields=[];
+
+    /**
+     * an associative array of the command data fields and their values,
+     * that is filled by the constructor from its $input.
+     *
+     * @var array
+     */
+    protected $_data=[];
+
+    /**
+     * Populate $this->_data from $input
+     *
+     * @param array|ArrayAccess $input
+     * @return Command
+     */
+    public function __construct($input)
+    {
+        foreach($this->_fields as $field)
+        {
+            $this->_data[$field]=isset($input[$field])?$input[$field]:null;
+        }
+    }
+
+    /**
+     * Retrieve data fields.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->_data[$key];
+    }
 }

--- a/app/Commands/TestCommand.php
+++ b/app/Commands/TestCommand.php
@@ -1,0 +1,18 @@
+<?php namespace App\Commands;
+
+use App\Commands\Command;
+
+use Illuminate\Contracts\Bus\SelfHandling;
+
+class TestCommand extends Command implements SelfHandling {
+
+    protected $_fields=['name', 'email'];
+
+	public function handle()
+	{
+        var_dump($this->_data);
+
+		die($this->email);
+	}
+
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -19,3 +19,7 @@ Route::controllers([
 	'auth' => 'Auth\AuthController',
 	'password' => 'Auth\PasswordController',
 ]);
+
+get('test-command', function (Illuminate\Bus\Dispatcher $bus) {
+    $bus->dispatch(new \App\Commands\TestCommand(['email'=>'mtvs.dev@gmial.com']));
+});


### PR DESCRIPTION
# Automatic assignment of the command fields #

Currently in order to set the fields of a command object you need to write down the fields at least 4 times.

1. Attributes on the object
2. Constructor parameters
3. Passing the arguments for the constructor 
4. Actual assignment in the constructor

It is tedious especially when you need to make changes (adding or removing the fields).

I think if there was a way to declare them once it would be better.