### PR TITLE
[5.0] Set database.prefix based on env config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -60,7 +60,7 @@ return [
 			'password'  => env('DB_PASSWORD', ''),
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
-			'prefix'    => '',
+			'prefix'    => env('DB_PREFIX', ''),
 			'strict'    => false,
 		],
 
@@ -71,7 +71,7 @@ return [
 			'username' => env('DB_USERNAME', 'forge'),
 			'password' => env('DB_PASSWORD', ''),
 			'charset'  => 'utf8',
-			'prefix'   => '',
+			'prefix'   => env('DB_PREFIX', ''),
 			'schema'   => 'public',
 		],
 
@@ -81,7 +81,7 @@ return [
 			'database' => env('DB_DATABASE', 'forge'),
 			'username' => env('DB_USERNAME', 'forge'),
 			'password' => env('DB_PASSWORD', ''),
-			'prefix'   => '',
+			'prefix'   => env('DB_PREFIX', ''),
 		],
 
 	],


### PR DESCRIPTION
DB tables prefix should be an environment variable.

For example, consider you have a shared host with max 1 database limitation that you used for hosting your projects, so you need to set DB prefix while on your local development environment you don't need it. 