### PR TITLE
Use no protocol to fetch Lato font

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link href='http://fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
 
 		<style>
 			body {


### PR DESCRIPTION
When using https://example.com, the welcome page design looks off due to fetching the Lato font on http://.

Ref: https://github.com/laravel/framework/issues/7159

**Update:** Using no protocol i.e `//`