### PR TITLE
Hash password in model

### DIFF
--- a/app/Services/Registrar.php
+++ b/app/Services/Registrar.php
@@ -32,7 +32,7 @@ class Registrar implements RegistrarContract {
 		return User::create([
 			'name' => $data['name'],
 			'email' => $data['email'],
-			'password' => bcrypt($data['password']),
+			'password' => $data['password'],
 		]);
 	}
 

--- a/app/User.php
+++ b/app/User.php
@@ -31,4 +31,15 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 	 */
 	protected $hidden = ['password', 'remember_token'];
 
+	/**
+	 * Hash the password attribute.
+	 *
+	 * @param  string  $password
+	 * @return void
+	 */
+	public function setPasswordAttribute($password)
+	{
+		$this->attributes['password'] = bcrypt($password);
+	}
+
 }


### PR DESCRIPTION
1. It feels safer this way. People won't accidentally store plain text passwords.
2. It's nice to introduce people to mutators out of the box.