### PR TITLE
[5.0] Add "node_modules" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
+/node_modules
 .env


### PR DESCRIPTION
Seems sensible if Laravel's going to push Elixir.

A person unfamiliar with the node ecosystem should be able to use Elixir with ease, however I don't feel they should necessarily know up-front that they should add node_modules to their global `.gitignore` file.