### PR TITLE
resolve phpmd static access warning

### DIFF
--- a/app/Providers/BusServiceProvider.php
+++ b/app/Providers/BusServiceProvider.php
@@ -13,9 +13,9 @@ class BusServiceProvider extends ServiceProvider {
 	 */
 	public function boot(Dispatcher $dispatcher)
 	{
-		$dispatcher->mapUsing(function($command)
+		$dispatcher->mapUsing(function($command) use ($dispatcher)
 		{
-			return Dispatcher::simpleMapping(
+			return $dispatcher::simpleMapping(
 				$command, 'App\Commands', 'App\Handlers\Commands'
 			);
 		});


### PR DESCRIPTION
PHPMD raises a [Static Access warning](https://github.com/phpmd/phpmd/blob/5d06695148d2203f56b27a5205ab87ce6a594a22/src/main/resources/rulesets/cleancode.xml#L69) for this line. It's only a problem for people using PHPMD, so appreciate the change could be made individually.

That said, if this is the only use case for the simpleMapping method then it could be changed to a non-static call within the framework.