### PR TITLE
Remove inline styling, add class to link

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -47,11 +47,9 @@
 
 						<div class="form-group">
 							<div class="col-md-6 col-md-offset-4">
-								<button type="submit" class="btn btn-primary" style="margin-right: 15px;">
-									Login
-								</button>
+								<button type="submit" class="btn btn-primary">Login</button>
 
-								<a href="/password/email">Forgot Your Password?</a>
+								<a class="btn btn-link" href="/password/email">Forgot Your Password?</a>
 							</div>
 						</div>
 					</form>


### PR DESCRIPTION
Doing so negates the need inline styling, as Bootstrap has a `btn-link` class which works with grouped buttons.