### PR TITLE
Get rid of npm warning: "npm WARN package.json @ No repository field."

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "devDependencies": {
     "gulp": "^3.8.8",
     "laravel-elixir": "*"


### PR DESCRIPTION
Was merged already some time ago  in https://github.com/laravel/laravel/commit/75393db929a43a6b56a85bdc65a4f607f77efcd8 but was lost a merge after.