### PR TITLE
Fix yield calls for PHP5.5

### DIFF
--- a/laravel/blade.php
+++ b/laravel/blade.php
@@ -370,7 +370,7 @@ class Blade {
 	{
 		$pattern = static::matcher('yield');
 
-		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::yield$2; ?>', $value);
+		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::yield_template$2; ?>', $value);
 	}
 
 	/**
@@ -427,7 +427,7 @@ class Blade {
 		}
 
 		return $value;
-	}	
+	}
 
 	/**
 	 * Get the regular expression for a generic Blade function.

--- a/laravel/helpers.php
+++ b/laravel/helpers.php
@@ -560,9 +560,9 @@ function render_each($partial, array $data, $iterator, $empty = 'raw|')
  * @param  string  $section
  * @return string
  */
-function yield($section)
+function yield_template($section)
 {
-	return Laravel\Section::yield($section);
+	return Laravel\Section::yield_template($section);
 }
 
 /**
@@ -584,7 +584,7 @@ function get_cli_option($option, $default = null)
 
 	return value($default);
 }
-	
+
 /**
  * Calculate the human-readable file size (with proper units).
  *

--- a/laravel/section.php
+++ b/laravel/section.php
@@ -69,7 +69,7 @@ class Section {
 	 */
 	public static function yield_section()
 	{
-		return static::yield(static::stop());
+		return static::yield_template(static::stop());
 	}
 
 	/**

--- a/laravel/tests/cases/blade.test.php
+++ b/laravel/tests/cases/blade.test.php
@@ -78,7 +78,7 @@ class BladeTest extends PHPUnit_Framework_TestCase {
 	{
 		$blade = "@yield('something')";
 
-		$this->assertEquals("<?php echo \\Laravel\\Section::yield('something'); ?>", Blade::compile_string($blade));
+		$this->assertEquals("<?php echo \\Laravel\\Section::yield_template('something'); ?>", Blade::compile_string($blade));
 	}
 
 	/**


### PR DESCRIPTION
Renames the Section::yield() method to Section::yield_template() while not changing the usage.