### PR TITLE
Make pretty URLs and default views work when using an Apache alias

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,8 +5,8 @@
 
     RewriteEngine On
 
-	# Uncomment and set your actual path if you run your application using an alias
-	# RewriteBase /your_aliased_path
+    # Uncomment and set your actual path if you run your application using an alias
+    # RewriteBase /your_aliased_path
 
     # Redirect Trailing Slashes...
     RewriteRule ^(.*)/$ /$1 [L,R=301]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,9 @@
 
     RewriteEngine On
 
+	# Uncomment and set your actual path if you run your application using an alias
+	# RewriteBase /your_aliased_path
+
     # Redirect Trailing Slashes...
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Laravel</title>
 
-	<link href="/css/app.css" rel="stylesheet">
+	<link href="{{ URL::asset('css/app.css') }}" rel="stylesheet">
 
 	<!-- Fonts -->
 	<link href='//fonts.googleapis.com/css?family=Roboto:400,300' rel='stylesheet' type='text/css'>
@@ -33,18 +33,18 @@
 
 			<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 				<ul class="nav navbar-nav">
-					<li><a href="/">Home</a></li>
+					<li><a href="{{ url('/') }}">Home</a></li>
 				</ul>
 
 				<ul class="nav navbar-nav navbar-right">
 					@if (Auth::guest())
-						<li><a href="/auth/login">Login</a></li>
-						<li><a href="/auth/register">Register</a></li>
+						<li><a href="{{ url('auth/login') }}">Login</a></li>
+						<li><a href="{{ url('auth/register') }}">Register</a></li>
 					@else
 						<li class="dropdown">
 							<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ Auth::user()->name }} <span class="caret"></span></a>
 							<ul class="dropdown-menu" role="menu">
-								<li><a href="/auth/logout">Logout</a></li>
+								<li><a href="{{ url('auth/logout') }}">Logout</a></li>
 							</ul>
 						</li>
 					@endif

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -18,7 +18,7 @@
 						</div>
 					@endif
 
-					<form class="form-horizontal" role="form" method="POST" action="/auth/login">
+					<form class="form-horizontal" role="form" method="POST" action="{{ url('auth/login') }}">
 						<input type="hidden" name="_token" value="{{ csrf_token() }}">
 
 						<div class="form-group">
@@ -51,7 +51,7 @@
 									Login
 								</button>
 
-								<a href="/password/email">Forgot Your Password?</a>
+								<a href="{{ url('password/email') }}">Forgot Your Password?</a>
 							</div>
 						</div>
 					</form>

--- a/resources/views/auth/password.blade.php
+++ b/resources/views/auth/password.blade.php
@@ -24,7 +24,7 @@
 						</div>
 					@endif
 
-					<form class="form-horizontal" role="form" method="POST" action="/password/email">
+					<form class="form-horizontal" role="form" method="POST" action="{{ url('password/email') }}">
 						<input type="hidden" name="_token" value="{{ csrf_token() }}">
 
 						<div class="form-group">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -18,7 +18,7 @@
 						</div>
 					@endif
 
-					<form class="form-horizontal" role="form" method="POST" action="/auth/register">
+					<form class="form-horizontal" role="form" method="POST" action="{{ url('auth/register') }}">
 						<input type="hidden" name="_token" value="{{ csrf_token() }}">
 
 						<div class="form-group">

--- a/resources/views/auth/reset.blade.php
+++ b/resources/views/auth/reset.blade.php
@@ -18,7 +18,7 @@
 						</div>
 					@endif
 
-					<form class="form-horizontal" role="form" method="POST" action="/password/reset">
+					<form class="form-horizontal" role="form" method="POST" action="{{ url('password/reset') }}">
 						<input type="hidden" name="_token" value="{{ csrf_token() }}">
 						<input type="hidden" name="token" value="{{ $token }}">
 


### PR DESCRIPTION
To make pretty URLS work when using an Apache alias:
 - Added a `RewriteBase` directive to `public/.htaccess` (commented out by default)

To make links and forms in the default views work:
- Changed hardcoded absolute URLs for their relative counterparts, using `url()`.
