### PR TITLE
Have logical default for Queue Driver when testing

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,5 +18,6 @@
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
     </php>
 </phpunit>


### PR DESCRIPTION
We should set the queue driver to be `sync` when testing by default. Makes sense along side the other testing defaults like cache and session etc