### PR TITLE
Make Trailing Slashes work with subdirectory.

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,8 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [L,R=301]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
If you are working in a subdirectory like `http://localhost/projects/laravelhere/route` and put a Trailing Slashes, it redirect to `http://localhost/laravelhere/route`, excluding the subdirectory.

This PR solve this, allowing you work inside subdirectory, if you want.