### PR TITLE
minor bug, remove un necessary return

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,7 +24,7 @@ class Handler extends ExceptionHandler {
 	 */
 	public function report(Exception $e)
 	{
-		return parent::report($e);
+		parent::report($e);
 	}
 
 	/**


### PR DESCRIPTION
Since parent is a void return.