### PR TITLE
Ignore the temp file created when in maintenance mode

### DIFF
--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -4,3 +4,4 @@ compiled.php
 services.json
 events.scanned.php
 routes.scanned.php
+down


### PR DESCRIPTION
I've noticed that when I set a Laravel 5 site in maintenance mode. The file `storage/framework/down` gets created. Seems like this should be ignored.