### PR TITLE
Fix infinite redirect when accessing a folder

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,6 +6,7 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
+    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...


### PR DESCRIPTION
Without the RewriteCond, accessing folders causes an infinite redirect instead of the relevant page to be displayed (e.g. a 403 server page).