### PR TITLE
[develop] Fix indent format.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,26 +2,25 @@
 
 use Illuminate\Support\ServiceProvider;
 
-class AppServiceProvider extends ServiceProvider {
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
 
-	/**
-	 * Bootstrap any application services.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		//
-	}
-
-	/**
-	 * Register any application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		//
-	}
-
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -49,7 +49,7 @@ $app = require_once __DIR__.'/../bootstrap/app.php';
 $kernel = $app->make('Illuminate\Contracts\Http\Kernel');
 
 $response = $kernel->handle(
-	$request = Illuminate\Http\Request::capture()
+    $request = Illuminate\Http\Request::capture()
 );
 
 $response->send();

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,7 +2,6 @@
 
 class ExampleTest extends TestCase
 {
-
     /**
      * A basic functional test example.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
-
     /**
      * Creates the application.
      *


### PR DESCRIPTION
This converts AppServiceProvider to spaces since it wasn't and removes a few empty lines after class declarations.

This is a re-PR of #3314 due to it being locked.

@GrahamCampbell #3314 was for the develop branch, so is this one.  Sorry I didn't put it in the title to make it more clear.

Ping @OzanKurt, @pespantelis.  Yes, you're correct, the master branch is not PSR-2 but the develop branch is.