### PR TITLE
Delete unnecessary .gitignore file

### DIFF
--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,1 +1,0 @@
-laravel.log


### PR DESCRIPTION
The `laravel.log` already ignored in `storage/logs/.gitignore` file.