### PR TITLE
Fix wrong path to compiled.php file

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -27,7 +27,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 */
 
-$compiledPath = __DIR__.'/../vendor/compiled.php';
+$compiledPath = __DIR__.'/../storage/framework/compiled.php';
 
 if (file_exists($compiledPath))
 {


### PR DESCRIPTION
The compiled.php file generated by the Artisan "optimize" command is located in storage/framework directory and not under vendor directory