### PR TITLE
Defining global patterns before parent boot function call

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -22,9 +22,9 @@ class RouteServiceProvider extends ServiceProvider {
 	 */
 	public function boot(Router $router)
 	{
-		parent::boot($router);
-
 		//
+		
+		parent::boot($router);
 	}
 
 	/**


### PR DESCRIPTION
Kindly check if my assumption is correct? In relation to this issue, http://stackoverflow.com/questions/28251154/laravel-5-0-dev-defining-global-patterns-is-not-working/29567578#29567578 and https://laracasts.com/discuss/channels/general-discussion/route-global-pattern-in-routeserviceprovider-not-working-in-laravel-5?page=1

Not really an issue, it's just probably creating some confusions for others

or this could be a different issue/bug

thanks!