### PR TITLE
add `subscribe` property

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -16,6 +16,15 @@ class EventServiceProvider extends ServiceProvider {
 		],
 	];
 
+    /**
+     * The subscriber classes to register.
+     *
+     * @var array
+     */
+    protected $subscribe = [
+        'Subscriber',
+    ];
+
 	/**
 	 * Register any other events for your application.
 	 *


### PR DESCRIPTION
the `subscribe` property is yet another way to register subscribers,
but it is not apparent to most users unless they dig through the source
code a little bit. this update to the default `EventServiceProvider`
will help make this option more apparent to the user