### PR TITLE
Fix Infinite Redirect Loop

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -31,8 +31,8 @@ return [
 
 	'stripe' => [
 		'model'  => 'App\User',
+		'key' => '',
 		'secret' => '',
-		'public' => '',
 	],
 
 ];

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,11 +5,12 @@
 
     RewriteEngine On
 
+    # Handle Directory Request...
+    RewriteCond %{REQUEST_FILENAME} !-d
     # Redirect Trailing Slashes...
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...
-    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 
 ## Security Vulnerabilities
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell at taylorotwell@gmail.com. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell at taylor@laravel.com. All security vulnerabilities will be promptly addressed.
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ Documentation for the framework can be found on the [Laravel website](http://lar
 
 Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](http://laravel.com/docs/contributions).
 
+## Security Vulnerabilities
+
+If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell at taylorotwell@gmail.com. All security vulnerabilities will be promptly addressed.
+
 ### License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Bug
In the previous `.htaccess` file, if you tried accessing an asset folder such as `css/` you would be infinitely redirected because of the trailing hash redirect on line 9.

It would redirect, then on the next load Apache would rewrite it with a slash since it is a existing directory.

## Solution
To fix this problem, I've put the directory rewrite condition before the trailing hash redirect so if you try to access an asset folder you aren't put into a redirect loop.

I've also gotten rid of the directory condition before the index.php rewrite since you don't want people to be able to access the folder index in an assets directory.

## Replicate bug
To replicate the redirect bug try to access an assets folder in your `public/` directory such as 'css/`.