### PR TITLE
add `subscribe` property

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -17,6 +17,15 @@ class EventServiceProvider extends ServiceProvider
     ];
 
     /**
+     * The subscriber classes to register.
+     *
+     * @var array
+     */
+    protected $subscribe = [
+        'Subscriber',
+    ];
+
+    /**
      * Register any other events for your application.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events


### PR DESCRIPTION
the `subscribe` property is yet another way to register subscribers,
but it is not apparent to most users unless they dig through the source
code a little bit. this update to the default `EventServiceProvider`
will help make this option more apparent to the user

this PR was originally incorrectly sent to `master`. now sending to `develop`