### PR TITLE
Remove redundant Closure namespace import in VerifyCsrfToken

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,6 +1,5 @@
 <?php namespace App\Http\Middleware;
 
-use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;
 
 class VerifyCsrfToken extends BaseVerifier


### PR DESCRIPTION
Commit https://github.com/laravel/laravel/commit/89f568156f59e374d98523f18493672ab380c42e made the Closure namespace import redundant in VerifyCsrfToken