### PR TITLE
Fix unnecessary return in App\Exceptions\Handler#report()

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,7 +24,7 @@ class Handler extends ExceptionHandler {
 	 */
 	public function report(Exception $e)
 	{
-		return parent::report($e);
+		parent::report($e);
 	}
 
 	/**


### PR DESCRIPTION
Doc comment in App\Exceptions\Handler#report() said return type is void.
This method seems to me that return no value.
This PR removed return statement.