### PR TITLE
Add Fanout event broadcasting

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -35,6 +35,12 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
         ],
 
+        'fanout' => [
+            'driver' => 'fanout',
+            'realm_id' => env('FANOUT_REALM_ID'),
+            'realm_key' => env('FANOUT_REALM_KEY'),
+        ],
+
         'redis' => [
             'driver' => 'redis',
             'connection' => 'default',


### PR DESCRIPTION
Fanout is a real-time, cloud based event system like Pusher. http://fanout.io . It would be nice if Laravel supported this system as well. This pull request goes with laravel/framework#8705