### PR TITLE
Add validation message for string rule

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -70,6 +70,7 @@ return [
 		"string"  => "The :attribute must be :size characters.",
 		"array"   => "The :attribute must contain :size items.",
 	],
+	"string"               => "The :attribute must be a string.",
 	"unique"               => "The :attribute has already been taken.",
 	"url"                  => "The :attribute format is invalid.",
 	"timezone"             => "The :attribute must be a valid zone.",


### PR DESCRIPTION
Turns out there is no validation message for the `string` rule.

Now there is :)