### PR TITLE
Eloquent Facade Suggestion

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -170,7 +170,6 @@ return [
 		'Cookie'    => 'Illuminate\Support\Facades\Cookie',
 		'Crypt'     => 'Illuminate\Support\Facades\Crypt',
 		'DB'        => 'Illuminate\Support\Facades\DB',
-		'Eloquent'  => 'Illuminate\Database\Eloquent\Model',
 		'Event'     => 'Illuminate\Support\Facades\Event',
 		'File'      => 'Illuminate\Support\Facades\File',
 		'Hash'      => 'Illuminate\Support\Facades\Hash',


### PR DESCRIPTION
Since we use "php artisan make:model ModelName" every time we create a model, and it always includes the:
use Illuminate\Database\Eloquent\Model;
I think the facade is only useful for those who migrating models from L4. 
I suggest we either use Model or Eloquent for the standard.
Just suggestion. Thanks.