### PR TITLE
Use of const instead of literal string

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
 		'sqlite' => [
 			'driver'   => 'sqlite',
-			'database' => storage_path().'/database.sqlite',
+			'database' => storage_path() . DIRECTORY_SEPARATOR . 'database.sqlite',
 			'prefix'   => '',
 		],
 


### PR DESCRIPTION
A simple change of use of the literal string for others platforms instead of *nix and mac