### PR TITLE
Fix occasional clear-compiled failure after update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,10 @@
 			"php artisan clear-compiled",
 			"php artisan optimize"
 		],
+		"pre-update-cmd": [
+        		"php artisan clear-compiled"
+        	],
 		"post-update-cmd": [
-			"php artisan clear-compiled",
 			"php artisan optimize"
 		],
 		"post-create-project-cmd": [


### PR DESCRIPTION
Clear compiled can fail after update it should be run before update.