### PR TITLE
Enable model guarding after doing seeds

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -15,5 +15,7 @@ class DatabaseSeeder extends Seeder
         Model::unguard();
 
         // $this->call('UserTableSeeder');
+        
+        Model::reguard();
     }
 }


### PR DESCRIPTION
Leaving models unguarded can cause all kinds of havoc if someone uses seeds in their tests.
Best to default to reguard after doing the seeds.