### PR TITLE
[5.1] Move copying .env.example to post-root-package-install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,10 @@
             "php artisan clear-compiled",
             "php artisan optimize"
         ],
+        "post-root-package-install": [
+            "php -r \"copy('.env.example', '.env');\""
+        ],
         "post-create-project-cmd": [
-            "php -r \"copy('.env.example', '.env');\"",
             "php artisan key:generate"
         ]
     },


### PR DESCRIPTION
post-create-project-cmd is executed only after post-install-cmd and this
could cause issue on the first installation (via composer
create-project) where environment is not prepared hence `php artisan
optimize` would generate `compiled.php`.

### Current Behaviour

1. `post-install-cmd` execute `php artisan optimize` while `.env` doesn't exist (env=production & debug=false).
2. `post-create-project-cmd` execute copying `.env.example` and generate key.

### Expected Behaviour

1. `post-root-package-cmd` copy `.env.example` to `.env` so we can have (env=local & debug=true).
2. `post-install-cmd` execute `php artisan optimize` with correct `.env`.
3. `post-create-project-cmd` generate key.

Refer to <https://getcomposer.org/doc/articles/scripts.md#command-events>

Signed-off-by: crynobone <crynobone@gmail.com>