### PR TITLE
Disable CSRF protection for auth/*

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,7 @@ class VerifyCsrfToken extends BaseVerifier
      * @var array
      */
     protected $except = [
+        'auth/*',
         //
     ];
 }


### PR DESCRIPTION
# TL;DR

You don't really need CSRF protection on authentication endpoint. It only breaks user experience sometimes and provides no real security.

## Why?

Obviously, upon logging in your request is already authorized using login-password pair, so any extra parameters are redundant. In fact CSRF protection here is even a little harmful. My client, while beta-testing a new project, has been bitten by it multiple times. Consider the following scenario:

1. User logs in into an app, uses it for a while and logs off.
2. Then the work day ends and he goes home, leaving PC on and browser tab with authorization page open.
3. While he's away his session expires and CSRF token becomes invalid.
4. He comes back in the morning, unlocks PC and enters his credentials on auth page.
5. He gets a "Whoops" and calls to tell me that "the login page is buggy" and I need to fix it.

You'd think it would happen so rarely it doesn't need to be fixed, well actually it happened almost every morning back then. It was really annoying.

## Ideas and questions

Obviously, we don't need a CSRF check here. What we actually need is to throttle login attempts to prevent bruteforcing a password. I doubt whether throttling needs to be in a project boilerplate, although maybe it does. Maybe one could use some ``RouteThrottleMiddleware`` available out-of-the-box in the framework.

Another question is whether only login endpoint should skip token checks or if registration and email confirmation endpoints should behave the same way. I think they should but I'm not sure yet.

Suggestions?