### PR TITLE
[5.1] Updated the sample encryption key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=SomeSuperIncrediblyRandomString!
 
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeSuperIncrediblyRandomString!'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
Hi everyone,

I recently tried to initialize a new project from the develop branch but after installing all dependencies, I would get the following exception:

```
RuntimeException in EncryptionServiceProvider.php line 29:
No supported encrypter found. The cipher and / or key length are invalid.
```

After investigation and drilling down into the files, I notice the issue is that it's not possible to use Laravel straight out of the box due to the following line in Encrypter::supported

```
return ($cipher === 'AES-128-CBC' && ($length === 16)) || ($cipher === 'AES-256-CBC' && $length === 32);
```

Since the default encryption is AES-256-CBC, it's length must be 32 characters long. Therefore, I updated both the config/app.php sample string to 'SomeSuperIncrediblyRandomString!' as well as the .env.example sample string.