### PR TITLE
Update composer.json to require php version 5.5 or greater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
+        "php": ">=5.5",
         "laravel/framework": "5.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Given the recent changes on the framework. I think is better if to require 5.5 explicitly in composer.json.