### PR TITLE
minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,5 @@
     },
     "config": {
         "preferred-install": "dist"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
minimum stability wasn't "dev" in the previous releases
was it left on purpose this time?