### PR TITLE
Set default charset for sqlsrv driver to utf8

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -81,6 +81,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'charset'  => 'utf8',
             'prefix'   => '',
         ],
 


### PR DESCRIPTION
In the framework database configuration, the 'mysql' and 'pgsql' connections default to charset UTF-8. The 'sqlsrv' default connection doesn't specify a default charset.

In many typical default installations of FreeTDS / dblib on Linux, the charset is inadvertently set to something other than UTF-8. As UTF-8 is the preferred default in the vast majority of use cases, it makes sense to hardcode this charset in the 'sqlsrv' connection as well. This avoids having to create a custom database configuration just to set the charset ( see #3417 )