### PR TITLE
Removed dev minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,5 @@
     },
     "config": {
         "preferred-install": "dist"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }


### PR DESCRIPTION
I am assuming this is no longer required or desired for a LTS release.