### PR TITLE
Set minimum stability to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,6 @@
     "config": {
         "preferred-install": "dist"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Prevent people from using unstable package by default. Also affects what composer chooses.

Example: `composer require symfony/dom-crawler` will get:
> Using version ^3.0@dev for symfony/dom-crawler

With `stable`, they get the correct version (`^2.7`)

As far as I know, previous versions of Laravel always shipped with `stable` as default, don't know why that has changed?


Fixes #3419 and #3414