### PR TITLE
Adding PHP Coding Standards Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /node_modules
 .env
+php-cs-fixer

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude(['vendor'])
+    ->in(__DIR__);
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([
+        'align_double_arrow',
+        '-psr0'
+        ])
+    ->finder($finder);

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -41,8 +41,8 @@ class AuthController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|max:255',
-            'email' => 'required|email|max:255|unique:users',
+            'name'     => 'required|max:255',
+            'email'    => 'required|email|max:255|unique:users',
             'password' => 'required|confirmed|min:6',
         ]);
     }
@@ -56,8 +56,8 @@ class AuthController extends Controller
     protected function create(array $data)
     {
         return User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
+            'name'     => $data['name'],
+            'email'    => $data['email'],
             'password' => bcrypt($data['password']),
         ]);
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -26,8 +26,8 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \App\Http\Middleware\Authenticate::class,
+        'auth'       => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'guest'      => \App\Http\Middleware\RedirectIfAuthenticated::class,
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "laravel/framework": "5.1.*"
     },
     "require-dev": {
+        "fabpot/php-cs-fixer": "^1.9",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
@@ -30,13 +31,15 @@
     "scripts": {
         "post-install-cmd": [
             "php artisan clear-compiled",
-            "php artisan optimize"
+            "php artisan optimize",
+            "php -r \"copy('vendor/fabpot/php-cs-fixer/php-cs-fixer', 'php-cs-fixer');\""
         ],
         "pre-update-cmd": [
             "php artisan clear-compiled"
         ],
         "post-update-cmd": [
-            "php artisan optimize"
+            "php artisan optimize",
+            "php -r \"copy('vendor/fabpot/php-cs-fixer/php-cs-fixer', 'php-cs-fixer');\""
         ],
         "post-root-package-install": [
             "php -r \"copy('.env.example', '.env');\""

--- a/config/auth.php
+++ b/config/auth.php
@@ -59,8 +59,8 @@ return [
     */
 
     'password' => [
-        'email' => 'emails.password',
-        'table' => 'password_resets',
+        'email'  => 'emails.password',
+        'table'  => 'password_resets',
         'expire' => 60,
     ],
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -30,13 +30,13 @@ return [
 
         'pusher' => [
             'driver' => 'pusher',
-            'key' => env('PUSHER_KEY'),
+            'key'    => env('PUSHER_KEY'),
             'secret' => env('PUSHER_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
         ],
 
         'redis' => [
-            'driver' => 'redis',
+            'driver'     => 'redis',
             'connection' => 'default',
         ],
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -37,8 +37,8 @@ return [
         ],
 
         'database' => [
-            'driver' => 'database',
-            'table'  => 'cache',
+            'driver'     => 'database',
+            'table'      => 'cache',
             'connection' => null,
         ],
 
@@ -57,7 +57,7 @@ return [
         ],
 
         'redis' => [
-            'driver' => 'redis',
+            'driver'     => 'redis',
             'connection' => 'default',
         ],
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -37,8 +37,8 @@ return [
 
         'database' => [
             'driver' => 'database',
-            'table' => 'jobs',
-            'queue' => 'default',
+            'table'  => 'jobs',
+            'queue'  => 'default',
             'expire' => 60,
         ],
 
@@ -67,10 +67,10 @@ return [
         ],
 
         'redis' => [
-            'driver' => 'redis',
+            'driver'     => 'redis',
             'connection' => 'default',
-            'queue'  => 'default',
-            'expire' => 60,
+            'queue'      => 'default',
+            'expire'     => 60,
         ],
 
     ],

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -13,9 +13,9 @@
 
 $factory->define(App\User::class, function ($faker) {
     return [
-        'name' => $faker->name,
-        'email' => $faker->email,
-        'password' => str_random(10),
+        'name'           => $faker->name,
+        'email'          => $faker->email,
+        'password'       => str_random(10),
         'remember_token' => str_random(10),
     ];
 });

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -14,9 +14,9 @@ return [
     */
 
     'password' => 'Passwords must be at least six characters and match the confirmation.',
-    'user' => "We can't find a user with that e-mail address.",
-    'token' => 'This password reset token is invalid.',
-    'sent' => 'We have e-mailed your password reset link!',
-    'reset' => 'Your password has been reset!',
+    'user'     => "We can't find a user with that e-mail address.",
+    'token'    => 'This password reset token is invalid.',
+    'sent'     => 'We have e-mailed your password reset link!',
+    'reset'    => 'Your password has been reset!',
 
 ];


### PR DESCRIPTION
I am suggesting we add [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer). It would allow us to add CS rules and enforce them (Tracis CI can check it).

By running ```$ php-cs-fixer fix .``` we would fix everything that isn't following included rules.

For now I enabled ```PSR2_LEVEL``` with disabled ```psr0``` which was changing namespace ```App``` to ```app``` and enabled ```align_double_arrow``` which aligns arrows in array, example: https://github.com/laravel/laravel/compare/master...PSmolic:implementing-php-cs-fixer#diff-b3af398d5ac2670049a1f17f4683c03eR29
