### PR TITLE
Change key length to 32 characters to prevent exception

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=SomeRandomStringWith32Characters
 
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeRandomStringWith32Characters'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
Some minutes ago, I created a new project with Laravel 5.1 LTS via the Laravel installer. But with the change of the encryption cipher to `AES-256-CBC` in 5.1, we need now a key which is 32 characters long.

It was also discussed in the [Laravel.io-forum](http://laravel.io/forum/06-09-2015-no-supported-encrypter-found-the-cipher-and-or-key-length-are-invalid).

So we should update the keys to match 32 characters.

I got following error after creating a new Laravel project before my patch: 
```
[2015-06-20 17:47:42] local.ERROR: exception 'RuntimeException' with message 'No supported encrypter found. The cipher and / or key length are invalid.' in /bootstrap/cache/compiled.php:6911
Stack trace:
#0 /bootstrap/cache/compiled.php(1057): Illuminate\Encryption\EncryptionServiceProvider->Illuminate\Encryption\{closure}(Object(Illuminate\Foundation\Application), Array)
#1 /bootstrap/cache/compiled.php(1010): Illuminate\Container\Container->build(Object(Closure), Array)
#2 /bootstrap/cache/compiled.php(1537): Illuminate\Container\Container->make('encrypter', Array)
#3 /bootstrap/cache/compiled.php(1102): Illuminate\Foundation\Application->make('Illuminate\\Cont...')
#4 /bootstrap/cache/compiled.php(1086): Illuminate\Container\Container->resolveClass(Object(ReflectionParameter))
#5 /bootstrap/cache/compiled.php(1072): Illuminate\Container\Container->getDependencies(Array, Array)
#6 /bootstrap/cache/compiled.php(1010): Illuminate\Container\Container->build('App\\Http\\Middle...', Array)
#7 /bootstrap/cache/compiled.php(1537): Illuminate\Container\Container->make('App\\Http\\Middle...', Array)
#8 /bootstrap/cache/compiled.php(2006): Illuminate\Foundation\Application->make('App\\Http\\Middle...')
#9 /public/index.php(58): Illuminate\Foundation\Http\Kernel->terminate(Object(Illuminate\Http\Request), Object(Illuminate\Http\Response))
#10 {main} 
``` 