### PR TITLE
Fix redirect loop .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,7 +5,8 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes...
+    # Redirect Trailing Slashes but not for folders...
+    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...


### PR DESCRIPTION
Folders that exist have a redirect loop when visiting them. This is because Apache redirects to trailing slash for folders and the current rule is removing it, Apache then adds a trailing slash again.