### PR TITLE
Ignore Vagrantfile in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /node_modules
 Homestead.yaml
 Vagrantfile
+.vagrant
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 /node_modules
 Homestead.yaml
+Vagrantfile
 .env


### PR DESCRIPTION
I was using Homestead in per project setup when I noticed that Vagrantfile is not ignored. It might be accidentally committed.
