### PR TITLE
Removing length requirement for email validation

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -42,7 +42,7 @@ class AuthController extends Controller
     {
         return Validator::make($data, [
             'name' => 'required|max:255',
-            'email' => 'required|email|max:255|unique:users',
+            'email' => 'required|email|unique:users',
             'password' => 'required|confirmed|min:6',
         ]);
     }


### PR DESCRIPTION
PHP's ```FILTER_VALIDATE_EMAIL``` already checks for email lengths, and enforces a limit of 254 characters on emails, per the [RFC 2821](https://www.ietf.org/rfc/rfc2821.txt) standard. Therefore, enforcing a length here is redundant.

PHP 5.5's source code for the ```FILTER_VALIDATE_EMAIL``` constant can be found [here](http://lxr.php.net/xref/PHP_5_5/ext/filter/logical_filters.c#503).