### PR TITLE
correct @return annotations in constructor doc blocks

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -26,7 +26,7 @@ class AuthController extends Controller
     /**
      * Create a new authentication controller instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -23,7 +23,7 @@ class PasswordController extends Controller
     /**
      * Create a new password controller instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -18,7 +18,7 @@ class Authenticate
      * Create a new filter instance.
      *
      * @param  Guard  $auth
-     * @return void
+     * @return self
      */
     public function __construct(Guard $auth)
     {

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
      * Create a new filter instance.
      *
      * @param  Guard  $auth
-     * @return void
+     * @return self
      */
     public function __construct(Guard $auth)
     {


### PR DESCRIPTION
"void" isn't quite accurate as the value for the @return annotation on a constructor. phpDocumentor is expecting "self" or no annotation.

This correction has the added advantage of satisfying Scrutinizer, which treats "void" as a documentation issue.