### PR TITLE
default APP_KEY to a 32 characters length string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=SomeRandomStringSomeRandomString
 
 DB_HOST=localhost
 DB_DATABASE=homestead

--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeRandomStringSomeRandomString'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
So  fresh installation of laravel won't throw the cipher related exception anymore.