### PR TITLE
Move terminate process before sending the response

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -53,6 +53,6 @@ $response = $kernel->handle(
     $request = Illuminate\Http\Request::capture()
 );
 
-$response->send();
-
 $kernel->terminate($request, $response);
+
+$response->send();


### PR DESCRIPTION
Moving terminate process before sending the response back to the browser.

Within the `send()` method from `Symfony\Component\HttpFoundation\Response`, it checks if the 'fastcgi_finish_request()` function exists if it is will directly flush all response data to the browser. There will be no more code executed.

I guess it will only appear for fastcgi users and when using terminable middleware.

Using PHP 5.5.9