### PR TITLE
Remove clear-compiled from pre-install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,6 @@
             "php artisan clear-compiled",
             "php artisan optimize"
         ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
             "php artisan optimize"
         ],


### PR DESCRIPTION
If your application is somehow broken (you have a missing class, for instance), you won't be able to `composer update` because, well, your application is broken and composer is trying to call your application...

http://i.imgur.com/v2sUx5w.png