### PR TITLE
I don't find Solution

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,6 @@
 
 namespace App\Exceptions;
 
-use Exception;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
@@ -22,10 +21,10 @@ class Handler extends ExceptionHandler
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
      *
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      */
-    public function report(Exception $e)
+    public function report($e)
     {
         return parent::report($e);
     }
@@ -34,10 +33,10 @@ class Handler extends ExceptionHandler
      * Render an exception into an HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return \Illuminate\Http\Response
      */
-    public function render($request, Exception $e)
+    public function render($request, $e)
     {
         return parent::render($request, $e);
     }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=5.5.9",
-        "laravel/framework": "5.1.*"
+        "laravel/framework": "5.2.*"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
@@ -47,5 +47,7 @@
     },
     "config": {
         "preferred-install": "dist"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
 i set two primary key and then migrate (By mistake),i get this error
 SQLSTATE[42000]: Syntax error or access violation: 1068 Multiple primary key defined
then is i run this:
php artisan migrate:reset
and i get this :
Table 'users' already exists

i know this table is hidden and i did not set database engine type 
have any Solution in php artisan or
Always i should remove (recreate) database Handy ?

or some questions and answer
http://stackoverflow.com/questions/26077458/laravel-migration-table-already-exists-but-i-want-to-add-new-not-the-older
{The reason this happens is that you ran a rollback previously and it had some error in the code or did not drop the table. This still however messes up the laravel migration table and as far as it's concerned you now have no record of pushing the user table up. The user table does already exist however and this error is throw.}