### PR TITLE
app.scss: corrected path for bootstrap comment

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,2 +1,2 @@
-// @import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
+// @import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
 


### PR DESCRIPTION
I assume that this used to work, but at least for me using the latest version of homestead with everything freshly installed you have to reference it relatively to load bootstrap.