### PR TITLE
Adding sass precision option of 8 as required by Bootstrap

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,5 +12,5 @@ var elixir = require('laravel-elixir');
  */
 
 elixir(function(mix) {
-    mix.sass('app.scss');
+    mix.sass('app.scss', null, {precision: 8});
 });


### PR DESCRIPTION
[Bootstrap requires a sass precision of 8](https://github.com/twbs/bootstrap-sass#sass-number-precision). The default sass file that is included with Laravel already has the line for including Bootstrap sass (although it is commented out)