### PR TITLE
Change URIs to routes (URIs is a bit misleading)

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;
 class VerifyCsrfToken extends BaseVerifier
 {
     /**
-     * The URIs that should be excluded from CSRF verification.
+     * The routes that should be excluded from CSRF verification.
      *
      * @var array
      */


### PR DESCRIPTION
`App\Http\Middleware\VerifyCsrfToken::shouldPassThrough()` is checking routes rather than URIs - had the misfortune of trying to match a URI when I should have been trying to match a route - so amended the note/comment.