### PR TITLE
32 Character key that won't throw a cipher error

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'DonotForgetYour32CharacterString'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
When deploying from Forge on an initial deployment it breaks because there is not a valid key from the sample .env or in the app.php. It also causes general deployment issues and isn't very clear on what is happening.