### PR TITLE
application URI and protocol

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application URI
+    |--------------------------------------------------------------------------
+    |
+    | This URI can be used for more dynamic subdomain routing and is used
+    | to form the application URL.
+    |
+    */
+
+    'uri' => env('APP_URI', 'localhost'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Protocol
+    |--------------------------------------------------------------------------
+    |
+    | The protocol is used to set the application url to your desired protcol,
+    | such as http or https. This will not enforce redirects or the protocol
+    | used while browsing.
+    |
+    */
+
+    'protocol' => env('APP_PROTOCOL', 'http'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application URL
     |--------------------------------------------------------------------------
     |
@@ -26,7 +51,7 @@ return [
     |
     */
 
-    'url' => 'http://localhost',
+    'url' => env('APP_PROTOCOL', 'http').'://'.env('APP_URI', 'localhost'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Added an application URI and application protocol to allow for greater flexibility for devs.

This allows for things like

```php
Route::group(['domain' => 'api.' . config('app.uri')], function() {
    // routes
});
```

It's obviously no necessity, but I see little reason not to separate it. It also allows future integrations related to protocol to easily check the protocol the user wants to use, which could be http in dev and https in production.