### PR TITLE
Update .env.example APP_KEY to work at install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=SomeRandomStringThatMustBe32Char
 
 DB_HOST=localhost
 DB_DATABASE=homestead


### PR DESCRIPTION
On a fresh install, I got a somewhat ambiguous exception: 

```
RuntimeException in EncryptionServiceProvider.php line 29:
No supported encrypter found. The cipher and / or key length are invalid.
```

Took a bit of digging to determine the default install upgraded to AES-256-CPC, but the default ENV is still only 16 chars.

For a fresh install, a bit confounding - unless this was the intent!

Thanks,
oh4real