### PR TITLE
Fix slash redirect, dealing with non-ASCII chars

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -7,7 +7,7 @@
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteRule ^(.*)/$ /$1 [L,R=301,NE]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
Some Apache servers, like the one where I keep the Laravel application I'm working, apply double url encoding when dealing with strings containing national characters, so a query string like:

/myurl/?q=cana-de-a%C3%A7%C3%BAcar
(cana-de-açúcar)

becomes:

/myurl?=cana-de-a%25C3%25A7%25C3%25BAcar
(cana-de-a%ç%úcar)

This PR solves this issue, while keep the same behavior when dealing with A-Z characters.
