### PR TITLE
Use https rather than // for google fonts in default views.

### DIFF
--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
 
 		<style>
 			body {

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 	<head>
 		<title>Laravel</title>
 		
-		<link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
 
 		<style>
 			body {


### PR DESCRIPTION
Ensure the default views always use HTTPS for the loading of fonts.

https://github.com/konklone/cdns-to-https#background

This change, due to its size and what it does - breaks nothing as far as compatibility goes. It just enforces a slightly better/newer practice. As such, I'm merging it to the 5.0 branch.

Sorry about the previous PR, I accidentally added the commits of `master` on top. I was expecting git to only merge my commit, not everyone elses.