### PR TITLE
Issue with routing via Route::resource()

### DIFF
--- a/app/Http/Controllers/ExampleController.php
+++ b/app/Http/Controllers/ExampleController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use App\Http\Requests;
+use App\Http\Controllers\Controller;
+
+class ExampleController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return Response
+     */
+    public function index()
+    {
+        return 'ExampleController@index works';
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return Response
+     */
+    public function create()
+    {
+        return 'ExampleController@create works';
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  Request  $request
+     * @return Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return Response
+     */
+    public function show($id)
+    {
+        return 'ExampleController@show works with id: ' . $id;
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return Response
+     */
+    public function edit($id)
+    {
+        return 'ExampleController@edit works with id: ' . $id;
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  Request  $request
+     * @param  int  $id
+     * @return Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,3 +14,32 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+/*
+ * Overview (with the same Controller (ExampleController) behind the routes):
+ * /folder/group --> WORKS
+ * /folder/comparison --> WORKS
+ *
+ * /folder/group/create --> FAILS
+ * /folder/comparison/create --> WORKS
+ *
+ * /folder/group/1 --> FAILS
+ * /folder/comparison/1 --> WORKS
+ *
+ * /folder/group/1/edit --> FAILS
+ * /folder/comparison/1/edit --> WORKS
+ */
+
+Route::group(['prefix' => 'folder'], function () {
+
+    Route::group(['prefix' => 'group'], function () {
+
+        // The routes to the controller which contains an issue
+        Route::resource('', 'ExampleController');
+
+    });
+
+    // The routes to the same controller without the issue
+    Route::resource('/comparison', 'ExampleController');
+
+});


### PR DESCRIPTION
Hello, 

today I found an issue with routing to a Controller via `Route::resource()` while I created a new app. To demonstrate the issue, I create some example code.

Problem: I created two nested route groups with prefixes and in the 2nd group, I wanted to reference a controller via `Route::ressource()` without a name, so that I can place aside the resource-route some other get/post-routes which has the same base uri.  

```php
Route::group(['prefix' => 'folder'], function () {
    Route::group(['prefix' => 'group'], function () {
        Route::resource('', 'ExampleController');
    });
});
```
But there's the problem. I can access the `ExampleController@index` method without problems, but the other methods/routes aren't accessible (I got an `NotFoundHttpException`).

But If I place the `Route::resource()` to the first group and add the prefix from the group it works as expected.

```php
// this works
Route::group(['prefix' => 'folder'], function () {
    Route::resource('group', 'ExampleController');
});
```

For testing purposes, I created an example with the clean laravel boilerplate and also added an working route example.

#### The routes I created for testing:

ExampleController@index:
* /folder/group --> WORKS
* /folder/comparison --> WORKS

ExampleController@create:
* /folder/group/create --> FAILS
* /folder/comparison/create --> WORKS

ExampleController@show:
* /folder/group/1 --> FAILS
* /folder/comparison/1 --> WORKS

ExampleController@edit:
* /folder/group/1/edit --> FAILS
* /folder/comparison/1/edit --> WORKS