### PR TITLE
Replace storage_path with database_path helper

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => storage_path('database.sqlite'),
+            'database' => database_path('database.sqlite'),
             'prefix'   => '',
         ],
 


### PR DESCRIPTION
According to the docs, the sqlite database should be located within the "database" folder.