### PR TITLE
php artisan serve now allows CORS requests

### DIFF
--- a/server.php
+++ b/server.php
@@ -18,4 +18,7 @@ if ($uri !== '/' && file_exists(__DIR__.'/public'.$uri)) {
     return false;
 }
 
+// Allowing CORS Requests
+header("Access-Control-Allow-Origin: *");
+
 require_once __DIR__.'/public/index.php';


### PR DESCRIPTION
This is important because we can now use `php artisan serve` to create SPA's and use Laravel as a remote endpoint.

e.g.: Your front-end application runs on `http://localhost:3000` and Laravel at `http://localhost:8000`, now Laravel can be requested by our front-end app.