### PR TITLE
Revert to store sqlite in /storage by default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => database_path('database.sqlite'),
+            'database' => storage_path('database.sqlite'),
             'prefix'   => '',
         ],
 


### PR DESCRIPTION
Revert https://github.com/laravel/laravel/commit/879bc146504462ef273b893010edf004026aa021

Deployments with envoyer will have to use storage_path anyway (or any other linked folder that's not under source control)