### PR TITLE
Change default value for queue.failed.database

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -87,7 +87,8 @@ return [
     */
 
     'failed' => [
-        'database' => 'mysql', 'table' => 'failed_jobs',
+        'database'  => env('DB_CONNECTION', 'mysql'),
+        'table'     => 'failed_jobs',
     ],
 
 ];


### PR DESCRIPTION
Use same DB_CONNECTION enviroment variable for queue.failed.database config