### PR TITLE
Swap order of boot() and register() in service providers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,16 +5,6 @@ use Illuminate\Support\ServiceProvider;
 class AppServiceProvider extends ServiceProvider {
 
 	/**
-	 * Bootstrap any application services.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		//
-	}
-
-	/**
 	 * Register any application services.
 	 *
 	 * This service provider is a great spot to register your various container
@@ -29,6 +19,16 @@ class AppServiceProvider extends ServiceProvider {
 			'Illuminate\Contracts\Auth\Registrar',
 			'App\Services\Registrar'
 		);
+	}
+
+	/**
+	 * Bootstrap any application services.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		//
 	}
 
 }

--- a/app/Providers/BusServiceProvider.php
+++ b/app/Providers/BusServiceProvider.php
@@ -6,6 +6,16 @@ use Illuminate\Support\ServiceProvider;
 class BusServiceProvider extends ServiceProvider {
 
 	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		//
+	}
+
+	/**
 	 * Bootstrap any application services.
 	 *
 	 * @param  \Illuminate\Bus\Dispatcher  $dispatcher
@@ -19,16 +29,6 @@ class BusServiceProvider extends ServiceProvider {
 				$command, 'App\Commands', 'App\Handlers\Commands'
 			);
 		});
-	}
-
-	/**
-	 * Register any application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		//
 	}
 
 }


### PR DESCRIPTION
No functional changes in this PR, so what's the point?

As a newcomer to Laravel (but not programming or PHP) there's a lot to wrap your head around. Service providers are one of the big topics, what with setting up your DI, and specifically what's the difference between the `register()` and `boot()` methods?

To help, all I've done here is put them in the order they are called, which just helps a bit when your head is swimming with a dozen new concepts, and you're looking at your own code and doing your best to "get" it.