### PR TITLE
clear-compiled fix by short circuiting the app and running before creation

### DIFF
--- a/artisan
+++ b/artisan
@@ -20,7 +20,7 @@
 */
 if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
     $argv = $_SERVER['argv'];
-    if (in_array('artisan', $argv) && in_array('clear-compiled', $argv)) {
+    if (count($argv) == 2 && 'artisan' == $argv[0] && 'clear-compiled' == $argv[1]) {
         $files = glob('./bootstrap/cache/*');
         foreach ($files as $file) {
             if (file_exists($file)) {

--- a/artisan
+++ b/artisan
@@ -3,6 +3,36 @@
 
 /*
 |--------------------------------------------------------------------------
+| Run the artisan clear-compiled command without loading the framework
+|--------------------------------------------------------------------------
+|
+| When running composer update, laravel runs the clear-compiled command.
+| Under most circumstances this works fine, however if your package
+| requirements change, and your updating via version control there is
+| potential for this to fail as your providers config array could differ
+| from whats installed causing the application to fail during provider 
+| registration. This snippet simply short circuits artisan and runs the
+| same functionality as the command, but without Application creation.
+| This doesnt remove the actual clear-compiled command from artisan, as
+| using the Artisan::call() method would still result in the command being 
+| used and not this.
+|
+*/
+if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
+    $argv = $_SERVER['argv'];
+    if (in_array('artisan', $argv) && in_array('clear-compiled', $argv)) {
+        $files = glob('./bootstrap/cache/*');
+        foreach ($files as $file) {
+            if (file_exists($file)) {
+                @unlink($file);
+            }
+        }
+        exit();
+    }
+}
+
+/*
+|--------------------------------------------------------------------------
 | Register The Auto Loader
 |--------------------------------------------------------------------------
 |

--- a/artisan
+++ b/artisan
@@ -19,8 +19,10 @@
 |
 */
 if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
+
     $argv = $_SERVER['argv'];
-    if (count($argv) == 2 && 'artisan' == $argv[0] && 'clear-compiled' == $argv[1]) {
+
+    if (count($argv) == 2 && 'artisan' == substr($argv[0], -7) && 'clear-compiled' == $argv[1]) {
         $files = glob('./bootstrap/cache/*');
         foreach ($files as $file) {
             if (file_exists($file)) {
@@ -29,6 +31,7 @@ if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
         }
         exit();
     }
+    
 }
 
 /*

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -18,6 +18,36 @@ require __DIR__.'/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
+| Run the artisan clear-compiled command without loading the framework
+|--------------------------------------------------------------------------
+|
+| When running composer update, laravel runs the clear-compiled command.
+| Under most circumstances this works fine, however if your package
+| requirements change, and your updating via version control there is
+| potential for this to fail as your providers config array could differ
+| from whats installed causing the application to fail during provider 
+| registration. This snippet simply short circuits artisan and runs the
+| same functionality as the command, but without Application creation.
+| This doesnt remove the actual clear-compiled command from artisan, as
+| using the Artisan::call() method would still result in the command being 
+| used and not this.
+|
+*/
+if(php_sapi_name() == "cli" && isset($_SERVER['argv'])) {
+    $argv = $_SERVER['argv'];
+    if(in_array('artisan', $argv) && in_array('clear-compiled', $argv)){
+        $files = glob("./bootstrap/cache/*");
+        foreach($files as $file) {
+            if (file_exists($file)) {
+                @unlink($file);
+            }
+        }
+        exit();
+    }
+}
+
+/*
+|--------------------------------------------------------------------------
 | Include The Compiled Class File
 |--------------------------------------------------------------------------
 |

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -37,7 +37,7 @@ if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
     $argv = $_SERVER['argv'];
     if (in_array('artisan', $argv) && in_array('clear-compiled', $argv)) {
         $files = glob('./bootstrap/cache/*');
-        foreach($files as $file) {
+        foreach ($files as $file) {
             if (file_exists($file)) {
                 @unlink($file);
             }

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -18,36 +18,6 @@ require __DIR__.'/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
-| Run the artisan clear-compiled command without loading the framework
-|--------------------------------------------------------------------------
-|
-| When running composer update, laravel runs the clear-compiled command.
-| Under most circumstances this works fine, however if your package
-| requirements change, and your updating via version control there is
-| potential for this to fail as your providers config array could differ
-| from whats installed causing the application to fail during provider 
-| registration. This snippet simply short circuits artisan and runs the
-| same functionality as the command, but without Application creation.
-| This doesnt remove the actual clear-compiled command from artisan, as
-| using the Artisan::call() method would still result in the command being 
-| used and not this.
-|
-*/
-if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
-    $argv = $_SERVER['argv'];
-    if (in_array('artisan', $argv) && in_array('clear-compiled', $argv)) {
-        $files = glob('./bootstrap/cache/*');
-        foreach ($files as $file) {
-            if (file_exists($file)) {
-                @unlink($file);
-            }
-        }
-        exit();
-    }
-}
-
-/*
-|--------------------------------------------------------------------------
 | Include The Compiled Class File
 |--------------------------------------------------------------------------
 |

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -33,10 +33,10 @@ require __DIR__.'/../vendor/autoload.php';
 | used and not this.
 |
 */
-if(php_sapi_name() == "cli" && isset($_SERVER['argv'])) {
+if (php_sapi_name() == 'cli' && isset($_SERVER['argv'])) {
     $argv = $_SERVER['argv'];
-    if(in_array('artisan', $argv) && in_array('clear-compiled', $argv)){
-        $files = glob("./bootstrap/cache/*");
+    if (in_array('artisan', $argv) && in_array('clear-compiled', $argv)) {
+        $files = glob('./bootstrap/cache/*');
         foreach($files as $file) {
             if (file_exists($file)) {
                 @unlink($file);


### PR DESCRIPTION
A fix to address the issue discussed here: https://github.com/laravel/framework/issues/9678

The root of the problem is the app relying on the application to run such a small task, and the app relying the composer packages being installed to register the service providers.

If the codebase isn't in sync with the installed packages the app fails, and then cant clear-compiled file, and then composer cant update to install the correct packages because the clear-compiled failed.

So a nice little circular problem here fixed with a few lines in the bootstrap/autoload.php.

Its put in this place as this is the only place before the app gets created we can intercept.

The code simply checks for cli use and the artisan clear-compiled in the argv. Then it does esencially what the clear-compiled command does without the application and then exits.