### PR TITLE
Added namespaces for the sample tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
             "database"
         ],
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "Tests\\": "tests/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
             "database"
         ],
         "psr-4": {
-            "App\\": "app/",
+            "App\\": "app/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
         }
     },
     "autoload-dev": {
-        "classmap": [
-            "tests/TestCase.php"
-        ],
         "psr-4": {
             "Tests\\": "tests/"
         }

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,15 @@
         ],
         "psr-4": {
             "App\\": "app/",
-            "Tests\\": "tests/"
         }
     },
     "autoload-dev": {
         "classmap": [
             "tests/TestCase.php"
-        ]
+        ],
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     },
     "scripts": {
         "post-install-cmd": [

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-class TestCase extends Illuminate\Foundation\Testing\TestCase
+class TestCase extends \Illuminate\Foundation\Testing\TestCase
 {
     /**
      * The base URL to use while testing the application.
@@ -20,7 +20,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     {
         $app = require __DIR__.'/../bootstrap/app.php';
 
-        $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
     }


### PR DESCRIPTION
People probably create their own tests using the built-in Laravel structure as base. For me, the existing Laravel classes are lacking the improvements on this PR.

The existing tests, aside the fact of not having a namespace defined (a fact that goes against [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md), as Laravel expects PHP 5.5.9 at minimum), aren't automatically allowing the user instantiate other classes contained on the same folder, as the autoloading features aren't aware of the tests/ folder.