### PR TITLE
.gitignore Simplified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /vendor
 /node_modules
-Homestead.yaml
-Homestead.json
 .env


### PR DESCRIPTION
Hometead files are usually managed by the homestead. And if they are here could be ignored by the developer.