### PR TITLE
Tests namespacing

### DIFF
--- a/tests/Example/ExampleTest.php
+++ b/tests/Example/ExampleTest.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace App\Example;
+
+use App\TestCase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,11 @@
 <?php
 
-class TestCase extends Illuminate\Foundation\Testing\TestCase
+namespace App;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\TestCase as FrameworkTestCase;
+
+class TestCase extends FrameworkTestCase
 {
     /**
      * The base URL to use while testing the application.
@@ -18,7 +23,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     {
         $app = require __DIR__.'/../bootstrap/app.php';
 
-        $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+        $app->make(Kernel::class)->bootstrap();
 
         return $app;
     }


### PR DESCRIPTION
Alternative approach to PR #3560 .

PSR-4 for tests is unnecessary, since the files are loaded by PHPUnit, not Composer autoload.

Keeping the same namespace between code and tests makes tests easier and shorter.