### PR TITLE
Fix PSR-2 standard on User model

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -10,9 +10,10 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
-class User extends Model implements AuthenticatableContract,
-                                    AuthorizableContract,
-                                    CanResetPasswordContract
+class User extends Model implements
+    AuthenticatableContract,
+    AuthorizableContract,
+    CanResetPasswordContract
 {
     use Authenticatable, Authorizable, CanResetPassword;
 


### PR DESCRIPTION
According to PSR-2 standard, point 4.1 about extends and implements:

> "Lists of implements MAY be split across multiple lines, where each
> subsequent line is indented once. When doing so, the first item in the
> list MUST be on the next line, and there MUST be only one interface per
> line.", so User model implements are wrong.

This change should also be made in Laravel documentation pages.