### PR TITLE
Update `config.key` default value

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeRandomStringSomeRandomString'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
The `SomeRandomString` value is too short for `AES-256-CBC` so it errors out when no `APP_KEY` is available.