### PR TITLE
Remove unnecessary fully quantified name

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        \App\Console\Commands\Inspire::class,
+        Commands\Inspire::class,
     ];
 
     /**


### PR DESCRIPTION
The class is unnessarily fully quantified and is an warning that is also flagged up in popular IDE's such as PHPStorm. It is also arguably bad practice as it can lead to problems if directories are moved in the future.