### PR TITLE
[5.1] Remove alias Inspiring

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -176,7 +176,6 @@ return [
         'Gate'      => Illuminate\Support\Facades\Gate::class,
         'Hash'      => Illuminate\Support\Facades\Hash::class,
         'Input'     => Illuminate\Support\Facades\Input::class,
-        'Inspiring' => Illuminate\Foundation\Inspiring::class,
         'Lang'      => Illuminate\Support\Facades\Lang::class,
         'Log'       => Illuminate\Support\Facades\Log::class,
         'Mail'      => Illuminate\Support\Facades\Mail::class,


### PR DESCRIPTION
I have not seen this alias be very functional since it quotes were removed from the home page of laravel.