### PR TITLE
Removed the hard-coded paths from the Auth Middlewares

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -62,4 +62,23 @@ class AuthController extends Controller
             'password' => bcrypt($data['password']),
         ]);
     }
+    /**
+     * Returns the login path declared, or 'auth/login'
+     *
+     * @return string
+     **/
+    public function getLoginPath()
+    {
+        return $this->loginPath || 'auth/login';
+    }
+
+    /**
+     * Returns the redirect path declared, or '/'
+     *
+     * @return string
+     **/
+    public function getRedirectPath()
+    {
+        return $this->redirectPath || '/';
+    }
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use App\Http\Controllers\Auth\AuthController;
 
 class Authenticate
 {
@@ -38,7 +39,8 @@ class Authenticate
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
-                return redirect()->guest('auth/login');
+                $auth = new AuthController();
+                return redirect($auth->getLoginPath());
             }
         }
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -4,6 +4,8 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use App\Http\Controllers\Auth\AuthController;
+use Illuminate\Http\RedirectResponse;
 
 class RedirectIfAuthenticated
 {
@@ -34,9 +36,11 @@ class RedirectIfAuthenticated
      */
     public function handle($request, Closure $next)
     {
-        if ($this->auth->check()) {
-            return redirect('/');
-        }
+		if ($this->auth->check())
+		{
+            $auth = new AuthController();
+			return redirect($auth->getRedirectPath());
+		}
 
         return $next($request);
     }


### PR DESCRIPTION
Hey y'all!

First PR :)

I believe these few changes make the system more flexible, as the login and redirect paths can now be set in the AuthController, along with all the other paths.

Please let me know if I missed something obvious in the docs, or if there's a more elegant way to do this.

Happy thanksgiving!