### PR TITLE
Make it possible to configure the log level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
+APP_LOG_LEVEL=debug
 APP_KEY=SomeRandomString
 
 DB_HOST=localhost

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $logger = Log::getMonolog();
+
+        if (is_null($logger) === false) {
+            foreach ($logger->getHandlers() as $handler) {
+                // Set the log level based on the config setting
+                $handler->setLevel(config('app.log_level'));
+            }
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -99,18 +99,18 @@ return [
 
     /*
      |--------------------------------------------------------------------------
-+    | Log Level Configuration
-+    |--------------------------------------------------------------------------
-+    |
-+    | Here you may configure the log level settings. By default it will log
+     | Log Level Configuration
+     |--------------------------------------------------------------------------
+     |
+     | Here you may configure the log level settings. By default it will log
      | all errors but you can configure it to only log from a certain log
      | level.
-+    |
-+    | Available Settings: "debug". "info", "notice", "warning", "error",
-+    |                     "critical", "alert", "emergency"
-+    */
+     |
+     | Available Settings: "debug". "info", "notice", "warning", "error",
+     |                     "critical", "alert", "emergency"
+     */
 
-+    'log_level' => env('APP_LOG_LEVEL', 'debug'),
+    'log_level' => env('APP_LOG_LEVEL', 'debug'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -98,6 +98,21 @@ return [
     'log' => env('APP_LOG', 'single'),
 
     /*
+     |--------------------------------------------------------------------------
++    | Log Level Configuration
++    |--------------------------------------------------------------------------
++    |
++    | Here you may configure the log level settings. By default it will log
+     | all errors but you can configure it to only log from a certain log
+     | level.
++    |
++    | Available Settings: "debug". "info", "notice", "warning", "error",
++    |                     "critical", "alert", "emergency"
++    */
+
++    'log_level' => env('APP_LOG_LEVEL', 'debug'),
+
+    /*
     |--------------------------------------------------------------------------
     | Autoloaded Service Providers
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Added a setting to the app.php config file for configuring the log level. That way you can easily prevent your production logs from filling up with debug or info logs if you don't want to.