### PR TITLE
update default `APP_KEY` to 32 character string

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeRandomStringWith32Characters'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
the cipher needs a 32 character string, which the documentation clearly states.

The default is still 16 characters, which was used for the old cipher.