### PR TITLE
Allow defined routes/ips to bypass the down command

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\CheckForMaintenanceMode;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -12,7 +13,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        CheckForMaintenanceMode::class,
     ];
 
     /**

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -46,7 +46,7 @@ class CheckForMaintenanceMode extends Original
 
             $route = $request->route();
 
-            if($route instanceof Route){
+            if ($route instanceof Route) {
 
                 if (in_array($route->getName(), $this->excludedRoutes)) {
                     return $response;

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -35,9 +35,7 @@ class CheckForMaintenanceMode extends Original
      */
     public function handle($request, Closure $next)
     {
-
         if ($this->app->isDownForMaintenance()) {
-
             $response = $next($request);
 
             if (in_array($request->ip(), $this->excludedIPs)) {
@@ -47,11 +45,9 @@ class CheckForMaintenanceMode extends Original
             $route = $request->route();
 
             if ($route instanceof Route) {
-
                 if (in_array($route->getName(), $this->excludedRoutes)) {
                     return $response;
                 }
-
             }
 
             // Add your own logic here to allow specific routes/users/requests

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Route;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode as Original;
+
+class CheckForMaintenanceMode extends Original
+{
+    /**
+     * Application routes not effected by the down command.
+     *
+     * @var array
+     */
+    protected $excludedRoutes = [];
+
+    /**
+     * IP Addresses not effected by the down command.
+     *
+     * @var array
+     */
+    protected $excludedIPs = [];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle($request, Closure $next)
+    {
+
+        if ($this->app->isDownForMaintenance()) {
+
+            $response = $next($request);
+
+            if (in_array($request->ip(), $this->excludedIPs)) {
+                return $response;
+            }
+
+            $route = $request->route();
+
+            if($route instanceof Route){
+
+                if (in_array($route->getName(), $this->excludedRoutes)) {
+                    return $response;
+                }
+
+            }
+
+            // Add your own logic here to allow specific routes/users/requests
+            // to bypass the down command by simply returning the response.
+
+            throw new HttpException(503);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
When the app is down no requests get through (by design).

However there are cases where it would be ideal to keep certain urls/ips/etc open during this period, for example:

* Webhook/IPN callbacks from payment providers
* Admin users when upgrading
* App setup when installed

Plus im sure there are many other use cases.

This middleware simply extends the original one (keeping backwards compatibility), and allows you to provide an array of excluded routes and ips.

There is also a helpful comment to aid users in adding their own logic for situations like admin users.