### PR TITLE
Differentiate between `exists` and `in` validation messages

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -35,7 +35,7 @@ return [
     'digits'               => 'The :attribute must be :digits digits.',
     'digits_between'       => 'The :attribute must be between :min and :max digits.',
     'email'                => 'The :attribute must be a valid email address.',
-    'exists'               => 'The selected :attribute is invalid.',
+    'exists'               => 'The selected :attribute does not exist.',
     'filled'               => 'The :attribute field is required.',
     'image'                => 'The :attribute must be an image.',
     'in'                   => 'The selected :attribute is invalid.',


### PR DESCRIPTION
The `in`/`not_in` rules have the exact same failure message as `exists` when they generally have quite distinct usage. It's unlikely many people would ever use both rules on one field, but as it stands quick identification is still more challenging than necessary.

I'm not too attached to any particular message, just that it's distinct, so I tried to keep the new one neutral and general. (I would've suggested something about "references" because I use `exists` exclusively for foreign keys, but I know others use it differently...)

Obviously there are probably project terminology guidelines I don't know about. :stuck_out_tongue: 