### PR TITLE
Use single line implements for PSR2

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -10,9 +10,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
-class User extends Model implements AuthenticatableContract,
-                                    AuthorizableContract,
-                                    CanResetPasswordContract
+class User extends Model implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract
 {
     use Authenticatable, Authorizable, CanResetPassword;
 


### PR DESCRIPTION
Use single line implements for <120 character class definition for PSR2.

```
phpcs --standard=PSR2 app/User.php

13 | ERROR | [x] The first item in a multi-line implements list must
   |       |     be on the line following the implements keyword
14 | ERROR | [x] Expected 4 spaces before interface name; 36 found
15 | ERROR | [x] Expected 4 spaces before interface name; 36 found
```