### PR TITLE
Authenticate middleware's login path should be configurable

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -22,7 +22,9 @@ class Authenticate
                 return response('Unauthorized.', 401);
             }
 
-            return redirect()->guest('login');
+            return redirect()->guest(
+                property_exists($this, 'loginPath') ? $this->loginPath : '/auth/login'
+            );
         }
 
         return $next($request);

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -20,9 +20,9 @@ class Authenticate
         if (Auth::guard($guard)->guest()) {
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
-            } else {
-                return redirect()->guest('login');
             }
+
+            return redirect()->guest('login');
         }
 
         return $next($request);


### PR DESCRIPTION
The PR improves the `App\Http\Middleware\Authenticate` middleware class:  

- Removes the non-necessary `elseif`; a cleaner more eye-comforting code.  
- Makes the middleware's login path configurable through `$loginPath` property; just like the default  `AuthController` class.  