### PR TITLE
Move clear-complied from pre-update-cmd to post-update-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,8 @@
             "php artisan clear-compiled",
             "php artisan optimize"
         ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
+            "php artisan clear-compiled"
             "php artisan optimize"
         ],
         "post-root-package-install": [


### PR DESCRIPTION
This change will help in the situations when other dev already included a new package in the providers array and running `clear-complied` on `pre-update-cmd` triggers an exception. With this change the latest dependencies are downloaded first and then the complied files are removed and new one's are created.