### PR TITLE
Typo in docs

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -87,7 +87,7 @@ return [
     |
     | You may specify multiple password reset configurations if you have more
     | than one user table or model in the application and you want to have
-    | seperate password reset settings based on the specific user types.
+    | separate password reset settings based on the specific user types.
     |
     | The expire time is the number of minutes that the reset token should be
     | considered valid. This security feature keeps tokens short-lived so


### PR DESCRIPTION
Should be _separate_ not _seperate_ :)