### PR TITLE
Do not use compiled file for artisan

### DIFF
--- a/artisan
+++ b/artisan
@@ -13,7 +13,7 @@
 |
 */
 
-require __DIR__.'/bootstrap/autoload.php';
+require __DIR__.'/bootstrap/autoload-without-compiled.php';
 
 $app = require_once __DIR__.'/bootstrap/app.php';
 

--- a/bootstrap/autoload-without-compiled.php
+++ b/bootstrap/autoload-without-compiled.php
@@ -1,0 +1,17 @@
+<?php
+
+define('LARAVEL_START', microtime(true));
+
+/*
+|--------------------------------------------------------------------------
+| Register The Composer Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any our classes "manually". Feels great to relax.
+|
+*/
+
+require __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
Use `autoload-without-compiled.php` 

This PR fixes https://github.com/laravel/framework/issues/9678

This should also be merged with master also.