### PR TITLE
Fix auth/logout uri for logging out

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,8 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => 'logout']);
+        $this->middleware('guest', ['except' => 'getLogout']);
+        $this->middleware('auth', ['only' => 'getLogout']);
     }
 
     /**


### PR DESCRIPTION
The middleware for the auth/logout uri is set to guest, meaning you can't logout.

Logout for only authorized users is down to personal preference.