### PR TITLE
Fixed the AuthController.php not allowing the logout function

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => 'logout']);
+        $this->middleware('guest', ['except' => 'getLogout']);
     }
 
     /**


### PR DESCRIPTION
When using logout instead of getLogout, the browser just redirects, thinking it was a page a logged in user was not supposed to see, by changing it to getLogout it works as expected again.