### PR TITLE
[5.2] Don't return a login page to a JSON request

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -18,7 +18,7 @@ class Authenticate
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->guest()) {
-            if ($request->ajax()) {
+            if ($request->ajax() || $request->wantsJson()) {
                 return response('Unauthorized.', 401);
             } else {
                 return redirect()->guest('login');


### PR DESCRIPTION
Currently, any unauthorized API requests that pass through the `auth` middleware get a redirect to the login page. Adding the `wantsJson` flag to the conditional corrects this behavior.