### PR TITLE
composer install/update harmony for clear-compiled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,10 @@
         "post-create-project-cmd": [
             "php artisan key:generate"
         ],
+        "pre-install-cmd": [
+            "php artisan clear-compiled"
+        ],
         "post-install-cmd": [
-            "php artisan clear-compiled",
             "php artisan optimize"
         ],
         "pre-update-cmd": [


### PR DESCRIPTION
Some issues had been recently opened about `composer install` problem. The solution is always the same: just run `php artisan clear-compiled` the re-run `composer install`. It does not occur with `composer update`. 

It was fixed for `composer update` by moving `php artisan clear-compiled` from `post-update-cmd` to `pre-update-cmd`, so we just have to do the same thing for install in order to avoid the possible bugs with old cached version in `bootstrap/cache/compiled.php`