### PR TITLE
[5.2] Make Memcached options configurable.

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -51,7 +51,9 @@ return [
             'driver'  => 'memcached',
             'servers' => [
                 [
-                    'host' => '127.0.0.1', 'port' => 11211, 'weight' => 100,
+                    'host' => env('MEMCACHED_HOST', '127.0.0.1'),
+                    'port' => env('MEMCACHED_PORT', 11211),
+                    'weight' => 100,
                 ],
             ],
         ],


### PR DESCRIPTION
Had an issue where my employer has an application that they deploy to different targets. Memcached needed to be configurable on a per-environment basis (i.e. staging, beta, production) so having hard-coded options wasn’t ideal. Would be great if these were configurable via environment variables out of the box.