### PR TITLE
.env.example - Changed localhost to 127.0.0.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
-DB_HOST=localhost
+DB_HOST=127.0.0.1
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
@@ -11,7 +11,7 @@ CACHE_DRIVER=file
 SESSION_DRIVER=file
 QUEUE_DRIVER=sync
 
-REDIS_HOST=localhost
+REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 


### PR DESCRIPTION
This change was made for those developing on Windows and noticed ridiculous response times (1 second) even locally. Windows performs a DNS lookup for 'localhost' which always takes 1 second. I thought I would save the few Windows people (like myself) some time with troubleshooting slow installs of redis (this is where I first noticed it).

[http://stackoverflow.com/questions/14076403/redis-connection-slow-from-php](http://stackoverflow.com/questions/14076403/redis-connection-slow-from-php)
