### PR TITLE
Replaced "@return void" in constructor phpdocs with "@return self"

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -33,7 +33,7 @@ class AuthController extends Controller
     /**
      * Create a new authentication controller instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -23,7 +23,7 @@ class PasswordController extends Controller
     /**
      * Create a new password controller instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {


### PR DESCRIPTION
The phpDocumentor documentation states that the **@return** tag for a constructor must either be omitted or have a description of **self**. Laravel incorrectly uses **@return void**, which causes syntax warnings in IDEs such as PHPStorm.

http://www.phpdoc.org/docs/latest/references/phpdoc/tags/return.html

I have also submitted a PR for the _laravel/framework_ repository to patch up the stub files used by artisan's scaffolding.

Hopefully I'm right in branching master for this (there doesn't appear to be a 5.2 branch?)