### PR TITLE
[5.2] Simple exception addition to allow for autheticated members to logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => 'logout']);
+        $this->middleware('guest', ['except' => ['logout','getLogout']);
     }
 
     /**

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => ['logout','getLogout']);
+        $this->middleware('guest', ['except' => ['logout','getLogout']]);
     }
 
     /**

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => ['logout','getLogout']]);
+        $this->middleware('guest', ['except' => ['logout', 'getLogout']]);
     }
 
     /**


### PR DESCRIPTION
I couldnt find the latest stable [5.2] branch so I apologize if submitting to master is frowned upon.
This PR allows autheticated members to hit the getLogout in AutheticatesUsers trait so that when authed users are trying to hit that route the middleware does not prevent them from executing the logout logic. 