### PR TITLE
Remove unnecessary "index.php/" from URLs

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,10 @@
 
     RewriteEngine On
 
+    # Remove Unnecessary "index.php/" From URLs
+    RewriteCond %{THE_REQUEST} ^GET.*index\.php [NC]
+    RewriteRule (.*?)index\.php/*(.*) /$1$2 [R=301,NE,L]
+
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]


### PR DESCRIPTION
Laravel allows duplicate URLs if the internally-rewritten URL (containing "index.php/") is accessed via the browser (e.g. https://laravel.com/index.php/docs/5.2/validation). This PR implements an htaccess redirect to remove "index.php/" from all requests. For example, https://laravel.com/index.php/docs/5.2/validation would redirect to https://laravel.com/docs/5.2/validation.