### PR TITLE
Improve the PHP requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
+        "php": "^5.6.4|^7.0",
         "laravel/framework": "5.3.*"
     },
     "require-dev": {


### PR DESCRIPTION
The current PHP requirements `">=5.6.4"` allow the mythical version 6 and all future versions of PHP to be used. However nothing guaranties that Laravel will work correctly on those future versions.

The new PHP requirements `^5.6.4|^7.0` restrict the PHP version to everything above and including 5.6.4 of PHP 5 and all versions of PHP 7.

Should a user still want to use Laravel on a non supported PHP version, than he/she can [easily fake the installed PHP version](https://murze.be/2015/12/fake-the-php-version-when-running-composer/).