### PR TITLE
Add dependency injection to test classes

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,4 +22,20 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         return $app;
     }
+    
+    public function setUp()
+    {
+        parent::setUp();
+        if(method_exists($this, 'before')) {
+            $this->app->call([$this, 'before']);
+        }
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        if(method_exists($this, 'after')) {
+            $this->app->call([$this, 'after']);
+        }
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,11 +22,11 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
 
         return $app;
     }
-    
+
     public function setUp()
     {
         parent::setUp();
-        if(method_exists($this, 'before')) {
+        if (method_exists($this, 'before')) {
             $this->app->call([$this, 'before']);
         }
     }
@@ -34,7 +34,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
     public function tearDown()
     {
         parent::tearDown();
-        if(method_exists($this, 'after')) {
+        if (method_exists($this, 'after')) {
             $this->app->call([$this, 'after']);
         }
     }


### PR DESCRIPTION
Not sure what you think of this but it would allow users to inject their dependencies into their tests and have them resolved. Also by adding these new methods, it avoids the issue of forgetting to call `parent::setUp()` when overriding that method.

e.g.

````php
class ExampleTest extends TestCase
{
    public function before(User $user)
    {
        $this->user = $user;
    }
    
    /**
     * @test
     */
    public function it_works()
    {
        $this->assertInstanceOf(User::class, $this->user);
    }
}
````

This maybe better suited to the Illuminate TestCase class.