### PR TITLE
Make queue name configurable

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -38,14 +38,14 @@ return [
         'database' => [
             'driver' => 'database',
             'table'  => 'jobs',
-            'queue'  => 'default',
+            'queue'  => env('QUEUE_NAME', 'default'),
             'expire' => 60,
         ],
 
         'beanstalkd' => [
             'driver' => 'beanstalkd',
             'host'   => 'localhost',
-            'queue'  => 'default',
+            'queue'  => env('QUEUE_NAME', 'default'),
             'ttr'    => 60,
         ],
 
@@ -54,14 +54,14 @@ return [
             'key'    => 'your-public-key',
             'secret' => 'your-secret-key',
             'prefix' => 'https://sqs.us-east-1.amazonaws.com/your-account-id',
-            'queue'  => 'your-queue-name',
+            'queue'  => env('QUEUE_NAME', 'your-queue-name'),
             'region' => 'us-east-1',
         ],
 
         'redis' => [
             'driver'     => 'redis',
             'connection' => 'default',
-            'queue'      => 'default',
+            'queue'      => env('QUEUE_NAME', 'default'),
             'expire'     => 60,
         ],
 


### PR DESCRIPTION
We deploy multiple sites on 1 server. When using `default` queue for all projects, the queues become dodgy. We had to change the `queue` for all projects. This is what we did in all our projects. Maybe a handy addition for other people too :)