### PR TITLE
Use safeEmail() in user factory instead

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -14,7 +14,7 @@
 $factory->define(App\User::class, function (Faker\Generator $faker) {
     return [
         'name' => $faker->name,
-        'email' => $faker->email,
+        'email' => $faker->safeEmail,
         'password' => bcrypt(str_random(10)),
         'remember_token' => str_random(10),
     ];


### PR DESCRIPTION
Faker’s `email()` method can accidentally generate email addresses. This ensures “safe” addresses are only ever generated by the factory, to avoid spamming actual mailboxes if mail was sent in a loop etc.