### PR TITLE
Fix password column for future hashing

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();
-            $table->string('password', 60);
+            $table->string('password');
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
Laravel hashes passwords with `bcrypt()` which returns a 60 character hash. In order to future-proof the user table for advances in password hashing technology, we should allow the max amount of characters for the database column.

See php.net's documentation on [`password_hash()`](http://php.net/password_hash):

> It is recommended to store the result in a database column that can expand beyond 60 characters (255 characters would be a good choice).

PS: This PR was done in front of the [Laravel Chicago PHP User Group](http://www.meetup.com/laravel-chicago/events/228116711/). We love Laravel! :)