### PR TITLE
Add language line to the validation "distinct" rule

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -34,6 +34,7 @@ return [
     'different'            => 'The :attribute and :other must be different.',
     'digits'               => 'The :attribute must be :digits digits.',
     'digits_between'       => 'The :attribute must be between :min and :max digits.',
+    'distinct'             => 'The :attribute field has a duplicate value.',
     'email'                => 'The :attribute must be a valid email address.',
     'exists'               => 'The selected :attribute is invalid.',
     'filled'               => 'The :attribute field is required.',


### PR DESCRIPTION
The message after validation failure will look like:

```
The products.*.id field has a duplicate value.
```