### PR TITLE
Added DB_SOCKET as a default environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DB_HOST=127.0.0.1
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
+DB_SOCKET=null
 
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/config/database.php
+++ b/config/database.php
@@ -53,16 +53,17 @@ return [
         ],
 
         'mysql' => [
-            'driver'    => 'mysql',
-            'host'      => env('DB_HOST', 'localhost'),
-            'database'  => env('DB_DATABASE', 'forge'),
-            'username'  => env('DB_USERNAME', 'forge'),
-            'password'  => env('DB_PASSWORD', ''),
-            'charset'   => 'utf8',
-            'collation' => 'utf8_unicode_ci',
-            'prefix'    => '',
-            'strict'    => false,
-            'engine'    => null,
+            'driver'      => 'mysql',
+            'host'        => env('DB_HOST', 'localhost'),
+            'database'    => env('DB_DATABASE', 'forge'),
+            'username'    => env('DB_USERNAME', 'forge'),
+            'password'    => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset'     => 'utf8',
+            'collation'   => 'utf8_unicode_ci',
+            'prefix'      => '',
+            'strict'      => false,
+            'engine'      => null,
         ],
 
         'pgsql' => [


### PR DESCRIPTION
It should be easier to define database sockets as they are used by a lot of localhost applications.
It should be falling back to null unless it is defined.

I've added the variable in the .env.example file and changed database.php accordingly.