### PR TITLE
Add language line for the in_array validation rule

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -40,6 +40,7 @@ return [
     'filled'               => 'The :attribute field is required.',
     'image'                => 'The :attribute must be an image.',
     'in'                   => 'The selected :attribute is invalid.',
+    'in_array'             => 'The :attribute field does not exist in :other.',
     'integer'              => 'The :attribute must be an integer.',
     'ip'                   => 'The :attribute must be a valid IP address.',
     'json'                 => 'The :attribute must be a valid JSON string.',


### PR DESCRIPTION
The message will look like:

```
The users.2.branch_id field does not exist in branches.*.id.
```
It depends on https://github.com/laravel/framework/pull/12565 for the replacer to replace `:other` with the other field.