### PR TITLE
Fixed order of password validation in registration

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -51,7 +51,7 @@ class AuthController extends Controller
         return Validator::make($data, [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|confirmed|min:6',
+            'password' => 'required|min:6|confirmed',
         ]);
     }
 


### PR DESCRIPTION
When you're filling the registration form and you leave the password empty:
you're going to get an error that both passwords do not match
whereas it makes sense to show the "your password must be at least 6 characters long" error first
or else a user might have a `confirmed` 5 characters password first and then he sees the `min:6` error