### PR TITLE
Remove pre-update-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,8 @@
             "php artisan clear-compiled",
             "php artisan optimize"
         ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
+            "php artisan clear-compiled",
             "php artisan optimize"
         ]
     },


### PR DESCRIPTION
Can't rely on being able to run php artisan, before updating. See https://github.com/composer/composer/issues/5066

> Before, running install without a lock file did an install that was almost an update, but still ran the pre/post-install-cmd scripts. Now we normalized it to actually run an update and fire pre/post-update-cmd, because that's what it is doing. If you have a lock file though it will run install as before.

When installing without lockfile, Composer now behaves as upgrade. It also executes the `pre-upgrade-cmd` instead of `pre-install-cmd`. Behaviour with composer.lock available is not changed.

With the latest composer version, doing a fresh install will fail because the vendor files are not yet present.