### PR TITLE
Ignore schedule files

### DIFF
--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -1,5 +1,6 @@
 config.php
 routes.php
+schedule-*
 compiled.php
 services.json
 events.scanned.php


### PR DESCRIPTION
```php
// From: Illuminate\Console\Scheduling\CallbackEvent

/**
 * Run the given event.
 *
 * @param  \Illuminate\Contracts\Container\Container  $container
 * @return mixed
 *
 * @throws \Exception
 */
public function run(Container $container)
{
    if ($this->description) {
        touch($this->mutexPath());
    }
    ...

/**
 * Get the mutex path for the scheduled command.
 *
 * @return string
 */
protected function mutexPath()
{
    return storage_path('framework/schedule-'.sha1($this->description));
}
```