### PR TITLE
[5.1+] Fallback for "clear-compiled" command when vendors not yet installed

### DIFF
--- a/artisan
+++ b/artisan
@@ -4,6 +4,17 @@
 $bootstrapPath = __DIR__.'/bootstrap';
 
 /*
+    Composer may call "clear-compiled" before installing the autoloader for
+    the first time. In this particular case, we'll try to do the cleanup
+    here, then exit as artisan won't be able to continue nevertheless.
+*/
+if (isset($argv[1]) && $argv[1] == 'clear-compiled' && ! file_exists(__DIR__.'/vendor/autoload.php')) {
+    @unlink($bootstrapPath.'/cache/compiled.php');
+    @unlink($bootstrapPath.'/cache/services.json');
+    exit;
+}
+
+/*
 |--------------------------------------------------------------------------
 | Register The Auto Loader
 |--------------------------------------------------------------------------

--- a/artisan
+++ b/artisan
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+$bootstrapPath = __DIR__.'/bootstrap';
+
 /*
 |--------------------------------------------------------------------------
 | Register The Auto Loader
@@ -13,9 +15,9 @@
 |
 */
 
-require __DIR__.'/bootstrap/autoload.php';
+require $bootstrapPath.'/autoload.php';
 
-$app = require_once __DIR__.'/bootstrap/app.php';
+$app = require_once $bootstrapPath.'/app.php';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #3687. Just if it may be of inspiration.
It's so much very perfectible, but at least it doesn't even need modification of composer.json.

Note that Laravel 5.2 uses `services.php` instead of `services.json`.

<br>"- 3 chars" compliant. :information_desk_person: