### PR TITLE
[5.2] Allow for setting sqlite database via env

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => database_path('database.sqlite'),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
         ],
 


### PR DESCRIPTION
Having this configurable by ENV allows for easily running tests in memory by adding this to the phpunit.xml:

```
<env name="DB_CONNECTION" value="sqlite"/>
<env name="DB_DATABASE" value=":memory:"/>

```