### PR TITLE
[5.2] Use ComposerScripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,11 @@
             "php artisan key:generate"
         ],
         "post-install-cmd": [
-            "php artisan clear-compiled",
+            "Illuminate\\Foundation\\ComposerScripts::postInstall",
             "php artisan optimize"
         ],
         "post-update-cmd": [
-            "php artisan clear-compiled",
+            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
             "php artisan optimize"
         ]
     },


### PR DESCRIPTION
Use ComposerScripts to avoid loading any configuration/compiled files.

Should probably be done **after** a new (laravel/framework) version is tagged, to avoid problems with non-existing class..