### PR TITLE
Remove Mandrill from list of supported email providers

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -11,8 +11,8 @@ return [
     | sending of e-mail. You may specify which one you're using throughout
     | your application here. By default, Laravel is setup for SMTP mail.
     |
-    | Supported: "smtp", "mail", "sendmail", "mailgun", "mandrill",
-    |            "ses", "sparkpost", "log"
+    | Supported: "smtp", "mail", "sendmail", "mailgun", "ses",
+    |            "sparkpost", "log"
     |
     */
 


### PR DESCRIPTION
Considering that Mandrill's entry was removed from `config/services.php` in d998b5bd0392f76dcaa461fdec919658947c2e65, shouldn't we go ahead and remove Mandrill from the list?

P.S. I tried to get the formatting consistent with d998b5bd0392f76dcaa461fdec919658947c2e65, but please correct me if you feel the list should be formatted differently.