### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vagrant
 /vendor
 /node_modules
 /public/storage


### PR DESCRIPTION
When using the Homestead per project installation, the virtual machine is created within the project directory. https://laravel.com/docs/5.2/homestead#per-project-installation

The .vagrant directory exposes the user's private key at: 
.vagrant/machines/default/virtualbox/private_key

I think adding the directory to .gitignore would be a safe measure to ensure future users do not push their private key to a publicly available site like GitHub.