### PR TITLE
Remove directory check for Front

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -10,7 +10,6 @@
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...
-    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 


### PR DESCRIPTION
Let's say we have a this 

    - public/
        - js/
            - app.js
            - app.js.map

When I request the page `http://example.com/js/app.js`, response is 200. That's ok.
When I request the page `http://example.com/js/doesntexist.js`, response is 404 and 404.blade.php is displayed. That's ok.
When I request the page `http://example.com/js/` (for some reason), response is 404 but the displayed page is not 404.blade.php.

This PR is a fix for that.