### PR TITLE
Set the default driver from the Authenticate middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -42,6 +42,8 @@ class Authenticate
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
+                Auth::shouldUse($guard);
+
                 return true;
             }
         }


### PR DESCRIPTION
I think if you use the `auth` middleware with a particular driver, you'd expect calls to `Auth::user()` and `$request->user()` to return the user from that driver.