### PR TITLE
To use web group by default, the array must be passed as an array

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -53,7 +53,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes(Router $router)
     {
         $router->group([
-            'namespace' => $this->namespace, 'middleware' => 'web',
+            'namespace' => $this->namespace, ['middleware' => 'web'],
         ], function ($router) {
             require app_path('Http/routes.php');
         });


### PR DESCRIPTION
If it's not passed as an array, none of the Validator errors get passed to the session.

Ref: https://github.com/laravel/laravel/commit/5c30c98db96459b4cc878d085490e4677b0b67ed