### PR TITLE
Add a maximum length password rule

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -51,7 +51,7 @@ class AuthController extends Controller
         return Validator::make($data, [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|min:6|confirmed',
+            'password' => 'required|min:6|max:72|confirmed',
         ]);
     }
 


### PR DESCRIPTION
This addresses a change proposed in laravel/framework#12905 due to a length limitation in Bcrypt causing strings longer than 72 characters to be truncated when computing their hash.

Adding a validation rule when creating a new password will provide a better user experience when creating new passwords, avoiding providing users with false expectation around the length of their password.