### PR TITLE
Introduce DB_PATH for sqlite issue in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
 DB_DATABASE=homestead
-DB_PATH=/database/
+DB_PATH=/var/www/html/laravel/database/
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306
 DB_DATABASE=homestead
+DB_PATH=/database/
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 

--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_PATH', database_path()) . env('DB_DATABASE', 'database') . '.sqlite',
+            'database' => env('DB_PATH', database_path('/') ) . env('DB_DATABASE', 'database') . '.sqlite',
             'prefix' => '',
         ],
 

--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_PATH', database_path('/') ) . env('DB_DATABASE', 'database') . '.sqlite',
+            'database' => env('DB_PATH', database_path('/')).env('DB_DATABASE', 'database').'.sqlite',
             'prefix' => '',
         ],
 

--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => env('DB_PATH', database_path()) . env('DB_DATABASE', 'database') . '.sqlite',
             'prefix' => '',
         ],
 


### PR DESCRIPTION
Per my comment on PR https://github.com/laravel/laravel/pull/3698

This PR resolves that issue - though I do have a strong feeling that this could be done a lot better, I simply didn't want to venture into laravel/framework to change the database_path() helper to check for an env('DB_PATH') - though I would imagine that would be somewhat cleaner.

