### PR TITLE
5.1 Laravel 5 Event Queue's with mongodb

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -117,7 +117,7 @@ return [
 
         'default' => [
             'host'     => env('REDIS_HOST', 'localhost'),
-            'password' => env('REDIS_PASSWORD', ''),
+            'password' => env('REDIS_PASSWORD', null),
             'port'     => env('REDIS_PORT', 6379),
             'database' => 0,
         ],


### PR DESCRIPTION
When i try to run a queue worker i get this error:

php artisan queue:work

exception 'MongoException' with message 'zero-length keys are not allowed, did you use $ with double quotes?'
![zero length key error](https://cloud.githubusercontent.com/assets/16571930/14246824/558c0640-fa87-11e5-8c1f-ea1ac899eb72.png)
