### PR TITLE
create .env file only if it do not exists already.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"copy('.env.example', '.env');\""
+            "php -r \"if(!file_exists('.env')){copy('.env.example', '.env');}\""
         ],
         "post-create-project-cmd": [
             "php artisan key:generate"


### PR DESCRIPTION
On server we do `composer install` to update the dependencies which will reset the `.env` file every time. This will prevent from resetting it.