### PR TITLE
Added middleware exception to AuthController.php

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -37,7 +37,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware($this->guestMiddleware(), ['except' => 'logout']);
+        $this->middleware($this->guestMiddleware(), ['except' => 'logout', 'getLogout']);
     }
 
     /**


### PR DESCRIPTION
When following the [authentication documentation](https://laravel.com/docs/5.1/authentication), the `getLogout` method in `AuthenticatesUsers` was guarded by the Guest Middleware.  I've added getLogout to the exceptions in the `AuthController` constructor.

