### PR TITLE
Call `shouldUse` on Auth when using the Authorize middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,7 +17,11 @@ class Authenticate
      */
     public function handle($request, Closure $next, $guard = null)
     {
-        if (Auth::guard($guard)->guest()) {
+        if ($guard !== null) {
+            Auth::shouldUse($guard);
+        }
+        
+        if (Auth::guest()) {
             if ($request->ajax() || $request->wantsJson()) {
                 return response('Unauthorized.', 401);
             } else {


### PR DESCRIPTION
I imagine most people would expect to just be able to use `Auth::user()` or inject Guard and be able to just do `->user()` in their app if the user has been piped through this middleware as something other than the default guard. But they won't be able to without this as they won't be authed on that specific guard so they will instead receive `null` when expecting a user instance (considering they've been 'authenticated') right?.

This is an issue that annoys me when developing a simple front-end and api in the same app. Is there any particular reason this isn't already the case? I completely expect this behaviour... I'm 96% sure it's not just me.