### PR TITLE
Run gulp after installing npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "laravel-elixir": "^5.0.0",
     "bootstrap-sass": "^3.0.0"
+  },
+  "scripts": {
+    "postinstall": "gulp"
   }
 }


### PR DESCRIPTION
Automatically run `gulp` after installing npm dependencies.