### PR TITLE
Move default 'web' middleware group from RouteServiceProvide.php to routes.php

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,6 +11,8 @@
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
+Route::group(['middleware' => 'web'], function () {
+    Route::get('/', function () {
+        return view('welcome');
+    })
 });

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -14,5 +14,5 @@
 Route::group(['middleware' => 'web'], function () {
     Route::get('/', function () {
         return view('welcome');
-    })
+    });
 });

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -53,7 +53,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes(Router $router)
     {
         $router->group([
-            'namespace' => $this->namespace, 'middleware' => 'web',
+            'namespace' => $this->namespace,
         ], function ($router) {
             require app_path('Http/routes.php');
         });


### PR DESCRIPTION
This is more clear, and causes less headache when creating api routes.