### PR TITLE
Adds database_path to env DB_DATABASE too

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => database_path(env('DB_DATABASE', 'database.sqlite')),
             'prefix' => '',
         ],
 


### PR DESCRIPTION
For some reason there's a need to pass the absolute path to an SQLite database whenever we're setting that through the .env file. I think that wrapping that up inside the database_path method is a less-confusing way of setting that db configuration as it removes the need of passing the absolute path of the sqlite file. 

Thanks!