### PR TITLE
Add npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "private": true,
-  "devDependencies": {
-    "gulp": "^3.9.1"
+  "scripts": {
+    "postinstall": "gulp --production",
+    "prod": "gulp --production",
+    "dev": "gulp watch"
   },
-  "dependencies": {
+  "devDependencies": {
+    "gulp": "^3.9.1",
     "laravel-elixir": "^5.0.0",
     "bootstrap-sass": "^3.0.0"
   }


### PR DESCRIPTION
Wouldn't it be awesome if we could simplify the installation processer for newcomers? We can do that by using `gulp` executable in our `package.json` file.

- `npm run dev`  is an alias for `gulp watch` 
- `npm run prod` is an alias for `gulp --production`

Benefits;
- The `gulp` file will be executed after installing the dependencies with `npm install`.
- The users don't have to install `gulp` globally.

Also discussed in https://github.com/laravel/elixir/issues/492 with @JeffreyWay.