### PR TITLE
Update server.php

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
-  "devDependencies": {
-    "gulp": "^3.9.1"
+  "scripts": {
+    "prod": "gulp --production",
+    "dev": "gulp watch"
   },
-  "dependencies": {
+  "devDependencies": {
+    "gulp": "^3.9.1",
     "laravel-elixir": "^5.0.0",
     "bootstrap-sass": "^3.0.0"
   }

--- a/server.php
+++ b/server.php
@@ -14,8 +14,15 @@ $uri = urldecode(
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' && file_exists(__DIR__.'/public'.$uri)) {
-    return false;
+$file = __DIR__.'/public'.$uri;
+if ($uri !== '/' && file_exists($file)) {
+    $ext = pathinfo($file, PATHINFO_EXTENSION);
+    if ($ext === 'css') {
+        header("Content-Type: text/css");
+    } elseif ($ext === 'js') {
+        header("Content-Type: application/x-javascript");
+    }
+    readfile($file);
+} else {
+    require_once __DIR__.'/public/index.php';
 }
-
-require_once __DIR__.'/public/index.php';


### PR DESCRIPTION
Sometimes, using `server.php` for PHP local server gives 404 error for static files in `public` folder. I think the problem lies in `return false` when using that.

I am using NetBeans 8.1 for development, and configuring to run `server.php` with PHP local server, and debugging with XDebug, static files fail to load. It just gives 404, generated by PHP local server itself.

Although running `php -S localhost:8000 server.php` is fine on command-line, and then running debug in NetBeans works, but it does not work when run with NetBeans and in debug mode.

This patch fixes the issue, although it would be better to serve files based on mime-type. In my tests, using `mime_content_type` or `finfo_*` can not correctly detect type of minified files. As this file is to be used with local development, it is not a great issue to use simple extension-based detection.