### PR TITLE
[5.2] Get guest middleware using guestMiddleware() method in ResetsPasswords

### DIFF
--- a/app/Http/Controllers/Auth/PasswordController.php
+++ b/app/Http/Controllers/Auth/PasswordController.php
@@ -27,6 +27,6 @@ class PasswordController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $this->middleware($this->guestMiddleware());
     }
 }


### PR DESCRIPTION
guestMiddleware() defined on ResetsPasswords trait

This change is required to fix issue laravel/framework#13383

Depends on pull request laravel/framework#13384