### PR TITLE
Add attempts_table to log job exceptions.

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -74,12 +74,15 @@ return [
     | These options configure the behavior of failed queue job logging so you
     | can control which database and table are used to store the jobs that
     | have failed. You may change them to any database / table you wish.
+    | If you want to disable failed jobs or failed attempt exception logging
+    | you can set the table value to null
     |
     */
 
     'failed' => [
         'database' => env('DB_CONNECTION', 'mysql'),
         'table' => 'failed_jobs',
+        'attempts_table' => 'failed_job_attempts',
     ],
 
 ];


### PR DESCRIPTION
I also added a little comment to explain how to disable exception and job failing logging. 
I always ended up having the `no such failed_jobs table` error in my logs, I didn't know I could disable it.

I'd like to add a specific config to enable/disable. Something like:

```php
log_failed_jobs => true,
log_failed_job_attempts => true,
```

What do you think ?