### PR TITLE
.env.example: APP_KEY instruction to call key:generate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=Please execute php artisan key:generate to generate
 APP_URL=http://localhost
 
 DB_CONNECTION=mysql


### PR DESCRIPTION
I was getting 'No supported encrypter found. The cipher and / or key length are invalid.' with some bogus key, so it is better to recommend key:generate