### PR TITLE
Enabled MySQL "strict" mode by default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,7 +61,7 @@ return [
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => '',
-            'strict'    => false,
+            'strict'    => true,
         ],
 
         'pgsql' => [


### PR DESCRIPTION
When "strict" mode is set to false it allows the database to ignore significant errors rather than abort and return the error to PHP.  An example would be trying to save a string in an INT field...instead of throwing an error, the save completes successfully and simply inserts a 0 in the field.

This means that the default setting allows for data loss with no notification, which seems like a really bad thing.  The default should be to the safest setting, which could then be reconfigured by the developer if necessary.