### PR TITLE
[5.3] Add "sslmode" setting for PostgreSQL connection

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -76,6 +76,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'schema' => 'public',
+            'sslmode' => 'prefer',
         ],
 
     ],


### PR DESCRIPTION
The commit https://github.com/laravel/framework/commit/586bffa1d758e09114821b694b5e800cc9bbfb5f added support for sslmode in PostgresConnector.php and sslmode has been around since postgres version 9.1 (2011). 

This change makes it possible to specify sslmode from the config file and also serves as documentation to other developers so they don't have to dive deep into the code to figure out that it's posible to set this option.

The posible values for sslmode are: disable, allow, prefer, require, verify-ca, verify-full

The default value is "prefer".

http://www.postgresql.org/docs/9.5/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION