### PR TITLE
[5.2] Configurable FakerGenerator locale

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -118,4 +118,16 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Faker Locale
+    |--------------------------------------------------------------------------
+    |
+    | Sets the locale that is passed through to Faker when using model
+    | factories.
+    |
+    */
+
+    'faker_locale' => 'en_US',
+
 ];


### PR DESCRIPTION
This PR pairs with another on the laravel/framework repository to facilitate a configurable locale for the Faker instance that is used by model factories.