### PR TITLE
Add missing Mandrill secret keys in config.services

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -19,6 +19,10 @@ return [
         'secret' => env('MAILGUN_SECRET'),
     ],
 
+    'mandrill' => [
+        'secret' => env('MANDRILL_SECRET'),
+    ],
+
     'ses' => [
         'key' => env('SES_KEY'),
         'secret' => env('SES_SECRET'),


### PR DESCRIPTION
Add the Mandrill array in config.services to access the secret key from the `.env`. 

