### PR TITLE
Create an app ThrottleRequests middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -51,6 +51,6 @@ class Kernel extends HttpKernel
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttle' => \App\Http\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Routing\Middleware\ThrottleRequests as BaseThrottleRequests;
+
+class ThrottleRequests extends BaseThrottleRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * This middleware can be overridden to satisfy custom throttling rules...
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes);
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to allow a quicker extension of `\Illuminate\Routing\Middleware\ThrottleRequests`

The original middleware is good for most standard cases but does not bring some useful features.

- skip hit on an internal request
- skip hit on 304 not-modified responses
- change header names
- define a max attempt value, per user or group of user

Use cases can be so numerous that it would not make sense to put all of them in the original middleware.
Instead this PR allows the user to quickly override `\Illuminate\Routing\Middleware\ThrottleRequests`

It tends to mimic what has been done for `\App\Exceptions\Handler::report`