### PR TITLE
Make TestCase abstract

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-class TestCase extends Illuminate\Foundation\Testing\TestCase
+abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
     /**
      * The base URL to use while testing the application.


### PR DESCRIPTION
I can't see a use case for TestCase needing to be directly instantiated, so it makes sense to convert this to abstract.

This also solves the issue when running tests in a given directory / suite, PHPUnit will no longer complain about no tests being present in TestCase.