### PR TITLE
Add application log level configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 APP_ENV=local
 APP_DEBUG=true
+APP_LOG_LEVEL=debug
 APP_KEY=SomeRandomString
 
 DB_CONNECTION=mysql

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Log Level
+    |--------------------------------------------------------------------------
+    |
+    | By default, Laravel will write all log messages to its log file. You
+    | can specify the minimum log level by setting this value to one of
+    | the logging levels defined in RFC 5424 and Laravel will log all
+    | messages greater than or equal to the configured log level.
+    |
+     */
+
+    'log_level' => env('APP_LOG_LEVEL', 'debug'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application URL
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Per changes in laravel/framework@fbd6e77 and in combination with the backport in laravel/framework#13875, I've added the same default log_level configuration in the 5.1 branch.