### PR TITLE
Ignore /public/build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
 /node_modules
 /public/storage
+/public/build
 Homestead.yaml
 Homestead.json
 .env


### PR DESCRIPTION
Since it's the deafult for versioned files, and also could be for any other files generated for Elixir.