### PR TITLE
[5.2] Add configuration option to disable caching of compiled Blade templates

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -30,4 +30,17 @@ return [
 
     'compiled' => realpath(storage_path('framework/views')),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Should Views Be Cached
+    |--------------------------------------------------------------------------
+    |
+    | Under some instances, such as when developing, you may wish to disable
+    | compiling of Blade templates to avoid unwanted caching. You may set
+    | the following to false if you want your views compiled each time.
+    |
+     */
+
+    'should_cache' => true,
+
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -35,9 +35,9 @@ return [
     | Should Views Be Cached
     |--------------------------------------------------------------------------
     |
-    | Under some instances, such as when developing, you may wish to disable
-    | compiling of Blade templates to avoid unwanted caching. You may set
-    | the following to false if you want your views compiled each time.
+    | Under some instances, such as when developing, you might want to disable
+    | caching Blade templates in order to prevent unwanted caching. You may
+    | change the following to false if you want views compiled each time.
     |
      */
 


### PR DESCRIPTION
In combination with laravel/framework#13938, this change targets 5.3, adding the necessary key to the `view.php` configuration file, in order to enable or disable caching of blade templates.