### PR TITLE
[5.2] Fix redirections to inexistent paths

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,10 +5,6 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes If Not A Folder...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
-
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
This redirection was causing "Not found" errors every time the URL ends up with a slash, simply because the path does not exists, 

In my case, when I called "http://svrdev001/carloscarucce/gpdseguranca/register/teste", it was redirecting to "http://svrdev001/var/www/carloscarucce/gpdseguranca/public/register/teste", causing a 404 - not found