### PR TITLE
List supported drives in cache and broadcasting configs

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -11,6 +11,8 @@ return [
     | framework when an event needs to be broadcast. You may set this to
     | any of the connections defined in the "connections" array below.
     |
+    | Supported: "pusher", "redis", "log"
+    |
     */
 
     'default' => env('BROADCAST_DRIVER', 'pusher'),

--- a/config/cache.php
+++ b/config/cache.php
@@ -11,6 +11,8 @@ return [
     | using this caching library. This connection is used when another is
     | not explicitly specified when executing a given caching function.
     |
+    | Supported: "apc", "array", "database", "file", "memcached", "redis"
+    |
     */
 
     'default' => env('CACHE_DRIVER', 'file'),


### PR DESCRIPTION
While `config/mail.php`, `config/queue.php`, `config/session.php` have all available drivers listed in them, `config/broadcasting.php` and `config/cache.php` do not.

This PR makes sure that all config files have their drivers listed and follow same convention. 🌵 