### PR TITLE
Ignore all .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Homestead.yaml
 Homestead.json
 .env
+.env.*
+!.env.example


### PR DESCRIPTION
Ignore all `.env` configuration files (bar `.env.example`) by default.