### PR TITLE
Use router instance over facade, to promote good behavior.

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -11,6 +11,7 @@
 |
 */
 
-Route::get('/', function () {
+/** @var Illuminate\Routing\Router $router */
+$router->get('/', function () {
     return view('welcome');
 });


### PR DESCRIPTION
The default `app/Http/routes.php` uses the `Route` facade to access the Router instance. 

I think it would be a good idea to show people that they have access to the raw instance straight away, to promote good behaviour and to prevent the service look-up for each route people declare.