### PR TITLE
Make password_resets.created_at nullable

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -15,7 +15,7 @@ class CreatePasswordResetsTable extends Migration
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token')->index();
-            $table->timestamp('created_at');
+            $table->timestamp('created_at')->nullable();
         });
     }
 


### PR DESCRIPTION
Prevents MySQL assigning default CURRENT_TIMESTAMP
Related issue: laravel/framework#11518