### PR TITLE
Moved Usermodel to App\Models, change namespace and calls to it.

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\User;
+use App\Models\User;
 use Validator;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ThrottlesLogins;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -67,7 +67,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\User::class,
+            'model' => App\Models\User::class,
         ],
 
         // 'users' => [

--- a/config/services.php
+++ b/config/services.php
@@ -34,7 +34,7 @@ return [
     ],
 
     'stripe' => [
-        'model' => App\User::class,
+        'model' => App\Models\User::class,
         'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
     ],


### PR DESCRIPTION
I moved the User model to a newly created folder App\Models and made sure all namespaces and uses where set right again.

Why did I do this? I have never seen an application with only one Model and so for me it breaks the complete structure and overview of my files when I put the Models straight in the app folder. I noticed this a few times on wishlists and decided it was time for me to go and create a PR.

