### PR TITLE
[5.3] Password broker would always use notifications::email view.

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -98,7 +98,6 @@ return [
     'passwords' => [
         'users' => [
             'provider' => 'users',
-            'email' => 'auth.emails.password',
             'table' => 'password_resets',
             'expire' => 60,
         ],


### PR DESCRIPTION
Signed-off-by: crynobone <crynobone@gmail.com>