### PR TITLE
Add language line for file validation rule

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -38,6 +38,7 @@ return [
     'distinct'             => 'The :attribute field has a duplicate value.',
     'email'                => 'The :attribute must be a valid email address.',
     'exists'               => 'The selected :attribute is invalid.',
+    'file'                 => 'The :attribute must be a file.',
     'filled'               => 'The :attribute field is required.',
     'image'                => 'The :attribute must be an image.',
     'in'                   => 'The selected :attribute is invalid.',


### PR DESCRIPTION
I was using the [file validation rule](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Validation/Validator.php#L1541) and found out there is no validation translation for this rule. So.. here it is!