### PR TITLE
Add meta auto-refresh to 503 view

### DIFF
--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -5,6 +5,8 @@
 
         <link href="https://fonts.googleapis.com/css?family=Lato:100" rel="stylesheet" type="text/css">
 
+        <meta http-equiv="refresh" content="10">
+
         <style>
             html, body {
                 height: 100%;


### PR DESCRIPTION
Happy users not having to hit F5.

Since this view is expected to be displayed for hopefully really
short interruptions, we expect the user to be back as soon as
possible.

This change sets a 10 seconds time window to retry the page load,
aiming to reduce the chance of losing visitors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/laravel/3825)
<!-- Reviewable:end -->
