### PR TITLE
configuration to allow local development pgsql/mysql db access

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -55,7 +55,7 @@ return [
         'mysql' => [
             'driver' => 'mysql',
             'host' => env('DB_HOST', 'localhost'),
-            'port' => env('DB_PORT', '3306'),
+            'port' => 'local' === env('APP_ENV') ? 33060 : env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
@@ -69,7 +69,7 @@ return [
         'pgsql' => [
             'driver' => 'pgsql',
             'host' => env('DB_HOST', 'localhost'),
-            'port' => env('DB_PORT', '5432'),
+            'port' => 'local' === env('APP_ENV') ? 54320 : env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),


### PR DESCRIPTION
I do this on every Laravel app I spin up. I never have the need to change it even in production so I figure I submit a pr.

This is particularly convenient when using a Homestead VM since the ports are pre-configured, however, they are pretty standard. 

If you have installed and configured php to also run locally on your machine then this is definitely a big convenience. This would allow you to run migrations and complete composer updates directly from the terminal without needing to login to the VM. 

Of course if your VM environment does not have an APP_ENV declared then it would inherit from the .env, but for the majority of us on Homestead that is simply not the case. 

Dont know about valet since I am on Windows but i assume that you would need a local install of SQL and assign the port manually anyways. 

I fail to see the downside overall, but perhaps i can be enlightened...


