### PR TITLE
Remove removed routes file

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,9 +16,6 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./app</directory>
-            <exclude>
-                <file>./app/Http/routes.php</file>
-            </exclude>
         </whitelist>
     </filter>
     <php>


### PR DESCRIPTION
Because routes file now outside app folder by default. We can remove that section