### PR TITLE
Wrap .env.example variable values in quotes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,27 +1,27 @@
-APP_ENV=local
-APP_KEY=SomeRandomString
+APP_ENV="local"
+APP_KEY="SomeRandomString"
 APP_DEBUG=true
-APP_LOG_LEVEL=debug
-APP_URL=http://localhost
+APP_LOG_LEVEL="debug"
+APP_URL="http://localhost"
 
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+DB_CONNECTION="mysql"
+DB_HOST="127.0.0.1"
+DB_PORT="3306"
+DB_DATABASE="homestead"
+DB_USERNAME="homestead"
+DB_PASSWORD="secret"
 
-CACHE_DRIVER=file
-SESSION_DRIVER=file
-QUEUE_DRIVER=sync
+CACHE_DRIVER="file"
+SESSION_DRIVER="file"
+QUEUE_DRIVER="sync"
 
-REDIS_HOST=127.0.0.1
+REDIS_HOST="127.0.0.1"
 REDIS_PASSWORD=null
-REDIS_PORT=6379
+REDIS_PORT="6379"
 
-MAIL_DRIVER=smtp
-MAIL_HOST=mailtrap.io
-MAIL_PORT=2525
+MAIL_DRIVER="smtp"
+MAIL_HOST="mailtrap.io"
+MAIL_PORT="2525"
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null


### PR DESCRIPTION
When the developer copies `.env.example` to `.env` they are unlikely to add quotes to the values in `.env`. When the developer needs to set the value of an environment variable to a value containing a
space, as none of the existing values in `.env` are quoted, the developer is unlikely to wrap this new value with spaces in quotes. This will result in an error, as the vlucas/phpdotenv library throws
an error when setting an environment variable to a value with a space.

Quote all default environment variables by default, reducing the likelihood of the developer ever receiving the error relating to environment variables needing to be quoted when they contain spaces.

The current default values in `.env.example` don't contain any spaces, so this commit will make no difference out of the box; its only purpose is to help out the developer further down the line on the day
when they need to set an environment variable to a value containing spaces.

Also, the vlucas/phpdotenv library docs currently uses quoted variables in every example, so quoting `.env.example`'s values will lead to more consistency with those docs. This will likely stop any
confusion for the developer when reading the vlucas/phpdotenv docs.

See laravel/framework#14586, laravel/docs#2223