### PR TITLE
[5.2] Remove default APP_KEY value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_KEY=SomeRandomString
+APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost


### PR DESCRIPTION
Since we now have a default config as:

```php
'key' => env('APP_KEY'),
```

And during the `artisan key:generate` command as following:

```php
file_put_contents($this->laravel->environmentFilePath(), str_replace(
    'APP_KEY='.$this->laravel['config']['app.key'],
    'APP_KEY='.$key,
    file_get_contents($this->laravel->environmentFilePath())
));
```

The generated app key would be generated with suffix of `SomeRandomString` because it's not the original key, the original key is either `null` (or `''`).


Signed-off-by: crynobone <crynobone@gmail.com>