### PR TITLE
Created generic validator middleware

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -41,18 +41,14 @@ class AuthController extends Controller
     }
 
     /**
-     * Get a validator for an incoming registration request.
+     * Get a validator from the respective model.
      *
      * @param  array  $data
      * @return \Illuminate\Contracts\Validation\Validator
      */
     protected function validator(array $data)
     {
-        return Validator::make($data, [
-            'name' => 'required|max:255',
-            'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|min:6|confirmed',
-        ]);
+        return User::validator($data);
     }
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -49,5 +49,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Foundation\Http\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'validator' => \App\Http\Middleware\ValidatorMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/ValidatorMiddleware.php
+++ b/app/Http/Middleware/ValidatorMiddleware.php
@@ -34,8 +34,9 @@ class ValidatorMiddleware
         $modelWithNamespace = $namespace.$model;
         $validator = $modelWithNamespace::validate($request->all());
 
-        if ($validator->passes())
+        if ($validator->passes()) {
             return $next($request);
+        }
 
         if ($request->ajax() || $request->wantsJson()) {
             return response($validator->getMessageBag(), 400);

--- a/app/Http/Middleware/ValidatorMiddleware.php
+++ b/app/Http/Middleware/ValidatorMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Console\AppNamespaceDetectorTrait;
+
+class ValidatorMiddleware
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Validator Middleware
+    |--------------------------------------------------------------------------
+    |
+    | This middleware can be used to validate requests before entering
+    | the controller. By default, this middleware uses a simple trait to
+    | get the app namespace.
+    |
+    */
+    use AppNamespaceDetectorTrait;
+
+    /**
+     * Handle an incoming request.
+     * Model name for which the validator needs to be loaded will be passed as parameter.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $model
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $model)
+    {
+        $namespace = $this->getNamespace();
+        $modelWithNamespace = $namespace.$model;
+        $validator = $modelWithNamespace::validate($request->all());
+
+        if ($validator->passes())
+            return $next($request);
+
+        if ($request->ajax() || $request->wantsJson()) {
+            return response($validator->getMessageBag(), 400);
+        }
+
+        return redirect()->back()->withInput()->with('error', $validator->getMessageBag());
+    }
+
+    public function getNamespace()
+    {
+        return $this->getAppNamespace();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -33,18 +33,18 @@ class User extends Authenticatable
      */
     public static function validator(array $data)
     {
-        $rules = array(
+        $rules = [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
             'password' => 'required|min:6|confirmed',
-        );
+        ];
 
-        $messages = array(
+        $messages = [
             'name.required' => 'Please mention the teacher name!',
             'email.required' => 'Please enter e-mail id!',
             'email.email' => 'Invalid e-mail id!',
-            'password.required' => 'Please enter password!'
-        );
+            'password.required' => 'Please enter password!',
+        ];
 
         return Validator::make($data, $rules, $messages);
     }

--- a/app/User.php
+++ b/app/User.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Validator;
 
 class User extends Authenticatable
 {
@@ -23,4 +24,28 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    /**
+     * Get a validator for an incoming registration request.
+     *
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    public static function validator(array $data)
+    {
+        $rules = array(
+            'name' => 'required|max:255',
+            'email' => 'required|email|max:255|unique:users',
+            'password' => 'required|min:6|confirmed',
+        );
+
+        $messages = array(
+            'name.required' => 'Please mention the teacher name!',
+            'email.required' => 'Please enter e-mail id!',
+            'email.email' => 'Invalid e-mail id!',
+            'password.required' => 'Please enter password!'
+        );
+
+        return Validator::make($data, $rules, $messages);
+    }
 }


### PR DESCRIPTION
As we know in MVC Pattern:
**A model is more than just data, it enforces all the business rules that apply to that data.**

Thus writing a validator in the model itself gets the Validator much closer to the Model.
Transferring the validator from app/Http/Controllers/Auth/AuthController.php to app/User.php

    public static function validator(array $data)
    {
        $rules = array(
            'name' => 'required|max:255',
            'email' => 'required|email|max:255|unique:users',
            'password' => 'required|min:6|confirmed',
        );
        return Validator::make($data, $rules);
    }

Also updating the validator function in AutController.php

    protected function validator(array $data)
    {
        return User::validator($data);
    }

instead of previous 

    protected function validator(array $data)
    {
        return Validator::make($data, [
            'name' => 'required|max:255',
            'email' => 'required|email|max:255|unique:users',
            'password' => 'required|min:6|confirmed',
        ]);
    }

Now, if all the validator can be declared in models, a generic middleware can be designed and used instead of writing validation action in controllers. As mentioned in Laravel Middleware Docs 

> HTTP middleware provide a convenient mechanism for filtering HTTP requests entering your application.

This Validator Middleware will validate data before allowing the request to proceed further into the application.
Simplifying validation procedure using the Validator Middleware:-
1. Declare the Validator in Model
2. Add the Middleware to the controller wherever needed with Model name passed as parameter
    validator:Model_Name
