### PR TITLE
give newbees a package service providers section, preventing adding after application

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -149,6 +149,11 @@ return [
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
+        
+        /*
+         * Package Service Providers...
+         */
+         
 
         /*
          * Application Service Providers...


### PR DESCRIPTION
when i started, i ended up putting all package specific service providers just at the bottom of the application service providers. But when making a route group like domain.com/{keyword}, the packages that are registering its own url's, not work anymore (like now when i installed the translations manager from barryvdh). When putting them above the app specific, everything works. So just give it to the user as a default place?