### PR TITLE
[5.2] Set hashing rounds to 4 when running tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Hash;
+
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
     /**
@@ -19,6 +21,8 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+        
+        Hash::setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
This will greatly improve the performance of tests.

Since a bcrypt cost of 10 means 1024 rounds (2^10 = 1024). 
By passing 4 as the cost we only go through 16 rounds (2^4 = 16) 
this takes considerably less time achieving better performance.

The minimum cost accepted by password_hash is 4 for some reason.