### PR TITLE
Fix missing word in docblock

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -12,9 +12,9 @@ window.$ = window.jQuery = require('jquery');
 require('bootstrap-sass/assets/javascripts/bootstrap');
 
 /**
- * Vue is a modern JavaScript for building interactive web interfaces using
- * reacting data binding and reusable components. Vue's API is clean and
- * simple, leaving you to focus only on building your next great idea.
+ * Vue is a modern JavaScript framework for building interactive web interfaces
+ * using reactive data binding and reusable components. Vue has a simple and
+ * clean API, leaving you to focus only on building your next great idea.
  */
 
 window.Vue = require('vue');

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -12,9 +12,9 @@ window.$ = window.jQuery = require('jquery');
 require('bootstrap-sass/assets/javascripts/bootstrap');
 
 /**
- * Vue is a modern JavaScript framework for building interactive web interfaces
- * using reactive data binding and reusable components. Vue has a simple and
- * clean API, leaving you to focus only on building your next great idea.
+ * Vue is a modern JavaScript library for building interactive web interfaces
+ * using reactive data binding and reusable components. Vue's API is clean
+ * and simple, leaving you to focus on building your next great project.
  */
 
 window.Vue = require('vue');


### PR DESCRIPTION
the word "framework" was missing in the docblock above Vue in `resources/js/bootstrap.js`.

I managed to make the docblock fit Laravel's style by changing around some of the wording while keeping the general message the same.