### PR TITLE
GitIgnore PHPStorm's config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Homestead.yaml
 Homestead.json
 .env
+/.idea


### PR DESCRIPTION
If you open a (laravel) project in phpstorm, it places an `.idea` folder in the project root. This contains project-specific ide settings. You usually don't want to include such files in a git repo.