### PR TITLE
Remove lone editor ignore rule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+# Your tools may add their own folders and files to the project.
+# Ignoring those within your global gitignore will make it so
+# they will never get commited within any project you have.
 /vendor
 /node_modules
 /public/storage
-/.idea
 Homestead.yaml
 Homestead.json
 .env


### PR DESCRIPTION
Remove the Intellij project folder ignore rule.
Leave a comment on how to handle things like this.

This keeps the base focused on the project itself and not the tooling developers chose. However, educates them on how to handle their tooling properly instead of assuming every project they use should handle it for them.