### PR TITLE
Create a shortcut for artisan command when using windows

### DIFF
--- a/artisan.bat
+++ b/artisan.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+php "%~dp0artisan" %*


### PR DESCRIPTION
Just an alternative for windows users to execute 'artisan' command without 'php' prefix