### PR TITLE
Remove default auth:api middleware

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -69,7 +69,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::group([
-            'middleware' => ['api'],
+            'middleware' => 'api',
             'namespace' => $this->namespace,
             'prefix' => 'api',
         ], function ($router) {

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -69,7 +69,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::group([
-            'middleware' => ['api', 'auth:api'],
+            'middleware' => ['api'],
             'namespace' => $this->namespace,
             'prefix' => 'api',
         ], function ($router) {


### PR DESCRIPTION
Having this middleware will enforce protection over all routes defined in `api.php`, however not all API routes needs to be protected.

I suggest we remove that middleware and allow developers to assign middleware as they see fit.

I know they can always remove it manually from the ServiceProvider, but I think it shouldn't exist by default from the beginning ¯\_(ツ)_/¯