### PR TITLE
Use precomputed hash instead of bcrypt in ModelFactory

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -12,7 +12,7 @@
 */
 
 $factory->define(App\User::class, function (Faker\Generator $faker) {
-    static $password = null;
+    static $password;
 
     return [
         'name' => $faker->name,

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -12,15 +12,12 @@
 */
 
 $factory->define(App\User::class, function (Faker\Generator $faker) {
+    static $password = null;
+
     return [
         'name' => $faker->name,
         'email' => $faker->safeEmail,
-
-        // Use a precomputed hash of the word "secret" instead of using bcrypt directly.
-        // Since bcrypt is intentionally slow, it can really slow down test suites in
-        // large applications that use factories to generate models in many tests.
-        'password' => '$2y$10$oPCcCpaPQ69KQ1fdrAIL0eptYCcG/s/NmQZizJfVdB.QOXUn5mGE6',
-
+        'password' => $password ?: $password = bcrypt('secret'),
         'remember_token' => str_random(10),
     ];
 });

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -15,7 +15,12 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->safeEmail,
-        'password' => bcrypt(str_random(10)),
+
+        // Use a precomputed hash of the word "secret" instead of using bcrypt directly.
+        // Since bcrypt is intentionally slow, it can really slow down test suites in
+        // large applications that use factories to generate models in many tests.
+        'password' => '$2y$10$oPCcCpaPQ69KQ1fdrAIL0eptYCcG/s/NmQZizJfVdB.QOXUn5mGE6',
+
         'remember_token' => str_random(10),
     ];
 });


### PR DESCRIPTION
Use a precomputed hash of the word "secret" instead of using `bcrypt` directly. Since `bcrypt` is intentionally slow, it can really slow down test suites in large applications that use factories to generate models in many tests.

Here's a reference point from a user who saw their test suite get 5x faster thanks to this change 👀

https://github.com/laravel/laravel/pull/3456#issuecomment-216460694