### PR TITLE
[5.3] Removing strict mode for MYSQL

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -62,7 +62,7 @@ return [
             'charset' => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix' => '',
-            'strict' => true,
+            'strict' => false,
             'engine' => null,
         ],
 


### PR DESCRIPTION
IMO this was a bad change and one that will break a lot of installations, check the issue:

laravel/framework#14997

Maybe we should let this true but pass only some modes, the ```ONLY_FULL_GROUP_BY``` for example is breaking some things.