### PR TITLE
Adding description for default inspire command

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -15,4 +15,4 @@ use Illuminate\Foundation\Inspiring;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
-});
+})->describe('Display an inspiring quote');


### PR DESCRIPTION
The description of a command is shown via `php artisan` so the default command `inspire` should have description as well.