### PR TITLE
Remove Mandrill from Mail Driver options

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -11,7 +11,7 @@ return [
     | sending of e-mail. You may specify which one you're using throughout
     | your application here. By default, Laravel is setup for SMTP mail.
     |
-    | Supported: "smtp", "mail", "sendmail", "mailgun", "mandrill",
+    | Supported: "smtp", "mail", "sendmail", "mailgun",
     |            "ses", "sparkpost", "log"
     |
     */


### PR DESCRIPTION
Mandrill has been [removed from the services.php config file](https://github.com/laravel/laravel/commit/ea52a963869f6f798ba7d3df995c4f0630775134) but is still mentioned in the mail drivers list.
[The mail documentation](https://laravel.com/docs/5.3/mail) doesn't speak about Mandrill so it would make sense to delete it from the list.