### PR TITLE
[5.3] Lodash is unnecessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "laravel-elixir": "^6.0.0-9",
     "laravel-elixir-vue": "^0.1.4",
     "laravel-elixir-webpack-official": "^1.0.2",
-    "lodash": "^4.14.0",
     "vue": "^1.0.26",
     "vue-resource": "^0.9.3"
   }

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -1,6 +1,4 @@
 
-window._ = require('lodash');
-
 /**
  * We'll load jQuery and the Bootstrap jQuery plugin which provides support
  * for JavaScript based Bootstrap features such as modals and tabs. This


### PR DESCRIPTION
I couldn't find any scripts in the boilerplate which depends on Lodash. Moreover, we should require Lodash methods separately instead of including the whole library, if necessary.