### PR TITLE
[5.3] Map API routes before Web routes

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -35,9 +35,9 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map()
     {
-        $this->mapWebRoutes();
-
         $this->mapApiRoutes();
+
+        $this->mapWebRoutes();
 
         //
     }


### PR DESCRIPTION
When developing SPAs, it makes sense to have a 'catchall' route and then handle the routing with javascript (like with [`vue-router`](http://router.vuejs.org/en/)). It would also make sense to have some API endpoints for the SPA to talk to.

However, if you were to add a catchall to the `web.php` routes and then some API endpoints to the `api.php` routes, the `api.php` routes would be ignored as the catchall takes precedence, since `web.php` routes are mapped first.

This PR proposes that we map API routes first, so that those routes take priority before a catchall / similar route is set by `web.php`.

Here is the proposal in `internals`: https://github.com/laravel/internals/issues/187