### PR TITLE
Removing .idea from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 /public/storage
 /vendor
-/.idea
 Homestead.json
 Homestead.yaml
 .env


### PR DESCRIPTION
IDE's and OS specific files shouldn't be in the project .gitignore, they should be added manually.

The reason i'm removing this even thought it was recently merged is because having this here will open the doors for many other PR's for specific IDE's and OS files, as you can check here: #3926 

Also at least when i start a new project PHPStorm asks to include .idea in the .gitignore automatically so theres no benefit on having this as default.

**Note**
At this point probably people are pretty tired of .gitignore PR's so maybe we should just add a [template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) for PR's and give a warning there to at least decrease the number of PR's including IDE's and OS files.