### PR TITLE
Remove the env() for pusher configuration values

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -32,9 +32,9 @@ return [
 
         'pusher' => [
             'driver' => 'pusher',
-            'key' => env('PUSHER_KEY'),
-            'secret' => env('PUSHER_SECRET'),
-            'app_id' => env('PUSHER_APP_ID'),
+            'key' => 'PUSHER_KEY',
+            'secret' => 'PUSHER_SECRET',
+            'app_id' => 'PUSHER_APP_ID',
             'options' => [
                 //
             ],


### PR DESCRIPTION
Ive seen that the pusher config values are set to null when trying to create a new pusher instance in the Pusher classe constructor. By removing the env setting the values were properly set and the pusher isntance was properly created.