### PR TITLE
Get cache key prefix from .env

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -86,6 +86,6 @@ return [
     |
     */
 
-    'prefix' => 'laravel',
+    'prefix' => env('CACHE_PREFIX', 'laravel'),
 
 ];


### PR DESCRIPTION
Sometimes, development environment and test environment use the same Memcached.