### PR TITLE
`dependencies` instead of `devDependencies`?

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "prod": "gulp --production",
     "dev": "gulp watch"
   },
-  "devDependencies": {
+  "dependencies": {
     "bootstrap-sass": "^3.3.7",
     "gulp": "^3.9.1",
     "jquery": "^3.1.0",


### PR DESCRIPTION
Should it not be `dependencies` instead of `devDependencies`?