### PR TITLE
Default timezone to inherit php.ini date.timezone

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -64,7 +64,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => env('APP_TIMEZONE', date_default_timezone_get()),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
date_default_timezone_get() defaults to UTC anyway if not set in php.ini