### PR TITLE
Added `database.redis.client` default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -107,6 +107,8 @@ return [
 
     'redis' => [
 
+        'client' => env('REDIS_CLIENT', 'predis'),
+        
         'cluster' => false,
 
         'default' => [


### PR DESCRIPTION
Even tho Predis [is already used as default](https://github.com/laravel/framework/commit/bae60487cd2749eb57d2e2eeb7bf8c3ce71ef3ec#diff-35c815d8fc685884a3acf62525119a61R27) it would be nice to have this.