### PR TITLE
Route::group for sub-domain always get a constants.

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -107,7 +107,7 @@ return [
 
     'redis' => [
 
-        'client' => env('REDIS_CLIENT', 'predis'),
+        'client' => 'predis',
 
         'cluster' => false,
 

--- a/config/database.php
+++ b/config/database.php
@@ -107,6 +107,8 @@ return [
 
     'redis' => [
 
+        'client' => env('REDIS_CLIENT', 'predis'),
+
         'cluster' => false,
 
         'default' => [


### PR DESCRIPTION
I'm using laravel v5.3 and I want to use a sub-domain in my app, and so I write my routes/web.php like this
<pre>
Route::group(['domain' => '{sub}.qfplan'], function () {
    Route::get('/', function ($sub) {
        return $sub;
    });
});
<pre/>
But when I visit this with host qfplan, www.qfplan(I configured this in my local environment), it matched route '/' and always return 'api', I expected when I visited 'www.qfplan' to get 'www'.
I don`t know how to do, would you help me?