### PR TITLE
Remove redundant import

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider


### PR DESCRIPTION
This commit removes the redundant `use Illuminate\Support\Facades\Gate;` from `app/Providers/AuthServiceProvider.php`.