### PR TITLE
Moving User.php to Models/User.php & Updating config/auth.php

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;

--- a/config/auth.php
+++ b/config/auth.php
@@ -67,7 +67,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\User::class,
+            'model' => App\Models\User::class,
         ],
 
         // 'users' => [


### PR DESCRIPTION
The User model is now in a dedicated Models folder rather than the root.  This keeps the root free of clutter and makes the default laravel file structure more developer friendly right out of the box.  The User model namespace and Auth config have been updated appropriately.