### PR TITLE
The Application name should be on the .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
-APP_NAME='Laravel APP'
+APP_NAME='Laravel 5 App'
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
+APP_NAME='Laravel APP'
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/config/app.php
+++ b/config/app.php
@@ -4,6 +4,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to place the application's name in a notification or
+    | any other location as required by the application or its packages.
+    */
+
+    'name' => env('APP_NAME', 'Laravel'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Laravel</title>
+        <title>{{ config('app.name', 'Laravel') }}</title>
 
         <link href="https://fonts.googleapis.com/css?family=Lato:100" rel="stylesheet" type="text/css">
 

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     public function testBasicExample()
     {
         $this->visit('/')
-             ->see('Laravel 5');
+             ->see(env('APP_NAME', 'Laravel'));
     }
 }


### PR DESCRIPTION
Since the .env file holds most of the application’s configurations the
application name also should be there, to be reachable as easy as all
the .env configurations.