### PR TITLE
Add a default UsersTableSeeder file

### DIFF
--- a/database/seeds/UsersTableSeeder
+++ b/database/seeds/UsersTableSeeder
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the users table seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\User::class, 50)->create();
+    }
+}


### PR DESCRIPTION
Since there is a default factory for the User model, and a commented line in the `DatabaseSeeder` calling a `UsersTableSeeder`, it's the next logical step to add a default `UsersTableSeeder` file.  
For most projects, people can just uncomment the line in `DatabaseSeeder` and run the `db:seed` command.