### PR TITLE
Updates laravel-elixir version for vue 2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bootstrap-sass": "^3.3.7",
     "gulp": "^3.9.1",
     "jquery": "^3.1.0",
-    "laravel-elixir": "^6.0.0-9",
+    "laravel-elixir": "^6.0.0-11",
     "laravel-elixir-vue-2": "^0.2.0",
     "laravel-elixir-webpack-official": "^1.0.2",
     "lodash": "^4.16.2",


### PR DESCRIPTION
There seems to be a problem with `laravel-elixir@6.0.0-9` and Vue 2. The newest version fixes it.

Reference Issue - laravel/passport#131