### PR TITLE
Ignore Passport-generated OAuth keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/storage
+/storage/*.key
 /vendor
 /.idea
 Homestead.json


### PR DESCRIPTION
These files should not end up in source control IMO. And even though Passport is a separate package it is a first-party one and the base Laravel install should be "prepared" for it.

What do you guys think?