### PR TITLE
Just a security default of not letting out info about

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -17,6 +17,6 @@ return [
     'reset' => 'Your password has been reset!',
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
-    'user' => "We can't find a user with that e-mail address.",
+    'user' => "If you are a user in the system a password reset email has been sent.",
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -17,6 +17,6 @@ return [
     'reset' => 'Your password has been reset!',
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
-    'user' => "If you are a user in the system a password reset email has been sent.",
+    'user' => 'If you are a user in the system a password reset email has been sent.',
 
 ];


### PR DESCRIPTION
if the user exists or not `We can't find a user with that e-mail address` is helpful for hacking a site in that you will eventually find emails that exist. A more neutral response is suggested from what I have read.