### PR TITLE
Add home link to welcome page

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -68,8 +68,12 @@
         <div class="flex-center position-ref full-height">
             @if (Route::has('login'))
                 <div class="top-right links">
-                    <a href="{{ url('/login') }}">Login</a>
-                    <a href="{{ url('/register') }}">Register</a>
+                    @if (Auth::check())
+                        <a href="{{ url('/home') }}">Home</a>
+                    @else
+                        <a href="{{ url('/login') }}">Login</a>
+                        <a href="{{ url('/register') }}">Register</a>
+                    @endif
                 </div>
             @endif
 


### PR DESCRIPTION
Normally I am completely against adding too many things to the `welcome.blade.php` view.

I say this because this file is usually one of the first things to be deleted when starting a new application.

However, building a simple application may not need you to delete this file. That's where this PR comes in.

Instead of always displaying the 'Login' and 'Register' links on the top right of the welcome screen, when the user is signed in, a link to the 'Home' page is displayed.

This can easily be used to determine if you are currently signed in (without having to click either link and be redirected to the 'Home' page).

**tl;dr**
Adds a 'Home' link to the `welcome.blade.php` file. You can easily see if you are signed in.

(Edit: Woah. This is the 4,000th pull request 😃)
(Edit 2: *sigh* I just found another pull request with this. Sorry.)