### PR TITLE
Add redirectTo attribute to the reset password controller

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -21,6 +21,13 @@ class ResetPasswordController extends Controller
     use ResetsPasswords;
 
     /**
+     * Where to redirect users after resetting their password.
+     *
+     * @var string
+     */
+    protected $redirectTo = '/home';
+
+    /**
      * Create a new controller instance.
      *
      * @return void


### PR DESCRIPTION
Considering this is already present in the register & login controllers, I don't see why we shouldn't have it already present in the reset password controller, after all it basically logs you in after resetting.