### PR TITLE
Removed unused namespaces

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Testing\WithoutMiddleware;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-
 class ExampleTest extends TestCase
 {
     /**


### PR DESCRIPTION
Namespaces not used or referenced. I feel like unknowing users may leave them in without understanding their purpose.

If they are there for educational purposes then my mistake, but https://laravel.com/docs/5.1/testing#disabling-middleware highlights their use with corresponding implementations.