### PR TITLE
[5.3] Config option for laravel/framework PR #16026

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -47,6 +47,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache'),
+            'gc_dirs' => env('FILECACHE_GCDIRS', false),
         ],
 
         'memcached' => [


### PR DESCRIPTION
Add 'gc_dirs' option under 'file' to allow optional cleanup of File Cache directories