### PR TITLE
Added recommended parentheses

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ require('laravel-elixir-vue-2');
  |
  */
 
-elixir(mix => {
+elixir((mix) => {
     mix.sass('app.scss')
        .webpack('app.js');
 });


### PR DESCRIPTION
When using arrow functions, parentheses are recommended if the function takes a single argument and uses curly braces. See section 8.4 of Airbnb's JavaScript style guide, one of the most popular.