### PR TITLE
Alias axios to $http in the Vue object

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -24,7 +24,7 @@ window.Vue = require('vue');
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
-window.axios = require('axios');
+window.axios = Vue.prototype.$http = require('axios');
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening


### PR DESCRIPTION
This change allows to keep using this.$http as before.