### PR TITLE
add arquivos compilados (css/js)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 Homestead.json
 Homestead.yaml
 .env
+/public/css/*
+/public/js/*


### PR DESCRIPTION
Files compiled as `css` and `javascript` cause a lot of conflict when working as a team.