### PR TITLE
Adds socket to config/database.php for consistency

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,6 +59,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix' => '',


### PR DESCRIPTION
For the mysql driver only (as this only applies to mysql) add the "socket" configuration parameter and corresponding environment variable.