### PR TITLE
Changes localhost to 127.0.0.1 in database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
 
         'mysql' => [
             'driver' => 'mysql',
-            'host' => env('DB_HOST', 'localhost'),
+            'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
@@ -68,7 +68,7 @@ return [
 
         'pgsql' => [
             'driver' => 'pgsql',
-            'host' => env('DB_HOST', 'localhost'),
+            'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),


### PR DESCRIPTION
In https://github.com/laravel/laravel/pull/3641 was decided to use `127.0.0.1` instead of `localhost` to avoid DNS lookups

This change is to maintain consistency between `.env` and `database.php`