### PR TITLE
Use the IP instead of DNS in redis host

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -110,7 +110,7 @@ return [
         'cluster' => false,
 
         'default' => [
-            'host' => env('REDIS_HOST', 'localhost'),
+            'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
             'database' => 0,


### PR DESCRIPTION
Follow the same logic of #4045 for Redis.