### PR TITLE
Change the string column length to 191

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email', 191)->unique();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,8 +14,8 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
-            $table->string('token')->index();
+            $table->string('email', 191)->index();
+            $table->string('token', 191)->index();
             $table->timestamp('created_at')->nullable();
         });
     }


### PR DESCRIPTION
Because the database collation change from utf8_unicode_ci to utf8mb4_unicode_ci, it will cause [this](http://stackoverflow.com/questions/23786359/laravel-migration-unique-key-is-too-long-even-if-specified) issue.

"The reasoning for this length change is that regular utf8 charset and collation utilize only 3 bytes per character and utf8mb4 utilizes 4 bytes per character to support a larger range of characters." - [source](http://aoverton.com/web-development/using-mysql-utf8mb4-with-laravel-5/)