### PR TITLE
Support predis v1.1.1

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -111,9 +111,11 @@ return [
 
         'default' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),
-            'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
             'database' => 0,
+            'parameters' => [
+                'password' => env('REDIS_PASSWORD', '')
+            ]
         ],
 
     ],


### PR DESCRIPTION
fix: `AUTH failed: ERR Client sent AUTH, but no password is set [tcp://127.0.0.1:6379]`

According to predix release log: https://github.com/nrk/predis/releases/tag/v1.1.1