### PR TITLE
Fix redis password `AUTH` failed

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -111,7 +111,7 @@ return [
 
         'default' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),
-            'password' => env('REDIS_PASSWORD', ''),
+            'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
             'database' => 0,
         ],


### PR DESCRIPTION
```
 [Predis\Connection\ConnectionException]
  `AUTH` failed: ERR Client sent AUTH, but no password is set [tcp://127.0.0.1:6379]
```