### PR TITLE
Make axios compatible with Request::ajax()

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -25,6 +25,7 @@ window.Vue = require('vue');
  */
 
 window.axios = require('axios');
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening


### PR DESCRIPTION
It seems the library doesn't send the `X-Requested-With: XMLHttpRequest` header by default, if it's not present `$request->ajax()` always returns false.