### PR TITLE
[5.3] Sort Composer packages by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         ]
     },
     "config": {
-        "preferred-install": "dist"
+        "preferred-install": "dist",
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
It's much easier to search for packages in the `composer.json` file when they're sorted by default. Having this on a fresh Laravel install from the beginning would be nice :)