### PR TITLE
Adding the the Visual Studio Editor settings folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /storage/*.key
 /vendor
 /.idea
+/.vscode
 Homestead.json
 Homestead.yaml
 .env


### PR DESCRIPTION
It should be added because the **VS Code** editor is getting more and more popular