### PR TITLE
Fixed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+Homestead.json
+Homestead.yaml
+.env
+composer.lock
+composer.phar
 /node_modules
 /public/storage
 /storage/*.key
 /vendor
-/.idea
-Homestead.json
-Homestead.yaml
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 Homestead.json
 Homestead.yaml
 .env
-composer.lock
 /node_modules
 /public/storage
 /storage/*.key

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ Homestead.json
 Homestead.yaml
 .env
 composer.lock
-composer.phar
 /node_modules
 /public/storage
 /storage/*.key


### PR DESCRIPTION
## Removed : 
`.idea` is a JetBrains file, it has to be included in the global .gitignore, not in the local one
(cf :  http://www.craftitonline.com/2013/10/ignore-symfony2-phpstorm-files-like-a-pro-with-global-ignoring)