### PR TITLE
update return type in docblock of render method

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -40,7 +40,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
That `parent` is `Illuminate/Foundation/Exceptions/Handler.php` and its `render` method is returning `\Symfony\Component\HttpFoundation\Response`, so just making it consistent. :)