### PR TITLE
Update s3 filesystem to use environment variables

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,10 +56,10 @@ return [
 
         's3' => [
             'driver' => 's3',
-            'key' => 'your-key',
-            'secret' => 'your-secret',
-            'region' => 'your-region',
-            'bucket' => 'your-bucket',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_REGION'),
+            'bucket' => env('AWS_S3_BUCKET'),
         ],
 
     ],


### PR DESCRIPTION
This is a manual change I've had to make on a bunch of projects I work on.

Basically - I don't want AWS credentials committed to the repo, rather, I want to leave this config up to my deploy recipes which generate .env files for me. I believe this is the purpose of environment variables, but let me know if I'm misunderstanding.