### PR TITLE
Setting the maximum count of log files

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -121,6 +121,8 @@ return [
     */
 
     'log' => env('APP_LOG', 'single'),
+    
+    'log_max_files' => env('APP_LOG_MAX_FILES', 30),
 
     'log_level' => env('APP_LOG_LEVEL', 'debug'),
 

--- a/config/app.php
+++ b/config/app.php
@@ -121,7 +121,7 @@ return [
     */
 
     'log' => env('APP_LOG', 'single'),
-    
+
     'log_max_files' => env('APP_LOG_MAX_FILES', 30),
 
     'log_level' => env('APP_LOG_LEVEL', 'debug'),


### PR DESCRIPTION
When using the daily log mode, Laravel will only retain five days of log files by default. If you want to adjust the number of retained files, you may add a log_max_files configuration value to your  app configuration file.

https://laravel.com/docs/5.3/errors#configuration