### PR TITLE
Fixed a typo in a block comment queue.php

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -7,7 +7,7 @@ return [
     | Default Queue Driver
     |--------------------------------------------------------------------------
     |
-    | The Laravel queue API supports a variety of back-ends via an unified
+    | The Laravel queue API supports a variety of back-ends via a unified
     | API, giving you convenient access to each back-end using the same
     | syntax for each one. Here you may set the default queue driver.
     |


### PR DESCRIPTION
Normally, words that start with vowels (like "unified") are preceded by "an" instead of "a."  However, "unified" is an exception to the rule.

Source: https://www.a-or-an.com/a_an/unified