### PR TITLE
[5.4] Add font path to fix glyphicons font-face.

### DIFF
--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -35,3 +35,6 @@ $input-color-placeholder: lighten($text-color, 30%);
 
 // Panels
 $panel-default-heading-bg: #fff;
+
+// Fonts
+$icon-font-path: "/fonts/";


### PR DESCRIPTION
Without this variable, the compiled path output is wrong:

`/css//fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb`

And the correct path should be:

`/fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb`