### PR TITLE
Bump Mix dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.15.2",
     "bootstrap-sass": "^3.3.7",
     "jquery": "^3.1.0",
-    "laravel-mix": "^0.4.0",
+    "laravel-mix": "^0.5.0",
     "lodash": "^4.16.2",
     "vue": "^2.0.1"
   }


### PR DESCRIPTION
Salutations and good day. This PR (pull request) will bring great glory to the Laravel™ framework by upgrading its Laravel Mix dependency from the old version 0.4.0 release up to the current 0.5.0 iteration.

I trust that you will merge this ethical PR (pull request) in a prompt manner, so that the users of your framework may enjoy the reputable Laravel Mix repository - version 0.5.0, not 0.4.0 (see above) - in their new projects. 