### PR TITLE
chore(mix): extract by default vendor js

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -12,4 +12,5 @@ const { mix } = require('laravel-mix');
  */
 
 mix.js('resources/assets/js/app.js', 'public/js')
+   .extract(['vue', 'jquery'])
    .sass('resources/assets/sass/app.scss', 'public/css');


### PR DESCRIPTION
Hey!

By default the `app.js` file is using `jQuery` and `VueJs`. Because we provide those two dependencies and people will probably use them it may be better to extract them by default into Laravel Mix.

This will avoid bad assets management for newcomers.