### PR TITLE
Add mix-manifest.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /.idea
 Homestead.json
 Homestead.yaml
+mix-manifest.json
 .env


### PR DESCRIPTION
This file will be immediately overwritten upon a build if versioning is active. It seems like a pointless thing to version control.