### PR TITLE
Remove the hot file from versionning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /public/storage
+/public/hot
 /storage/*.key
 /vendor
 /.idea


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/17571, I was correctly pointed that the small proposition should be made over here. Here's a copy / past of my message, for clarity's sake.

---

When you run `npm run hmr`, a `hot` file is created to the public folder for the `mix()` helper to know if it has to server from the webpack server or not. This file does not go away until we run `npm run dev` (or `watch`). 

True, if we use `npm run production` in our production server it goes away too, but in case we don't make it go away in development, I don't think it's necessary to version it.