### PR TITLE
Remove redundant check from bootstrap/autoload.php

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -15,20 +15,3 @@ define('LARAVEL_START', microtime(true));
 */
 
 require __DIR__.'/../vendor/autoload.php';
-
-/*
-|--------------------------------------------------------------------------
-| Include The Compiled Class File
-|--------------------------------------------------------------------------
-|
-| To dramatically increase your application's performance, you may use a
-| compiled class file which contains all of the classes commonly used
-| by a request. The Artisan "optimize" is used to create this file.
-|
-*/
-
-$compiledPath = __DIR__.'/cache/compiled.php';
-
-if (file_exists($compiledPath)) {
-    require $compiledPath;
-}


### PR DESCRIPTION
Redundant check removed since compiled class file generation was removed
https://github.com/laravel/framework/commit/09964cc8c04674ec710af02794f774308a5c92ca#diff-7b18a52eceff5eb716c1de268e98d55dL870