### PR TITLE
Append '@' to let composer resolve PHP executable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,18 +29,18 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "php artisan key:generate"
+            "@php artisan key:generate"
         ],
         "post-install-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postInstall",
-            "php artisan optimize"
+            "@php artisan optimize"
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-            "php artisan optimize"
+            "@php artisan optimize"
         ]
     },
     "config": {


### PR DESCRIPTION
To execute PHP scripts, you can use `@php` which will automatically resolve to whatever
php process is currently being used.

See https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts
for more information.