### PR TITLE
Make Axios automatically send `X-CSRF-TOKEN` in the header

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -28,6 +28,7 @@ window.Vue = require('vue');
 window.axios = require('axios');
 
 window.axios.defaults.headers.common = {
+    'X-CSRF-TOKEN': window.Laravel.csrfToken,
     'X-Requested-With': 'XMLHttpRequest'
 };
 


### PR DESCRIPTION
Axios doesn't automatically send the `X-CSRF-TOKEN` that [the passport token guard](https://github.com/laravel/passport/blob/f2a8af3a48adac02288779f59de95f46fef69b7a/src/Guards/TokenGuard.php#L204) is looking for.

See https://github.com/laravel/passport/issues/256 and https://github.com/laravel/docs/pull/3045