### PR TITLE
Add App locale as default value of 'lang' attribute

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ config('app.locale') }}">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Add App locale as default lang in the app.php config file instead of 'en' of 'lang' attribute in the main view.