### PR TITLE
Laravel 5.4 explicitly require phpunit 5.7.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~5.7"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
As demonstrated in laravel/framework#17699 it is possible to have phpunit being installed with a lower than `5.7.0`, which doesn't work at all on 5.4 due to the changes with PHPUnit namespaced class.