### PR TITLE
Change hard-coded '/login' param to named route

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -60,6 +60,6 @@ class Handler extends ExceptionHandler
             return response()->json(['error' => 'Unauthenticated.'], 401);
         }
 
-        return redirect()->guest('login');
+        return redirect()->guest(route('login'));
     }
 }


### PR DESCRIPTION
Change hard-coded '/login' param to named route 'login'.

Adding a bit of flexibility to work with translations w/o need change Handler class:
`
Route::get('entrar', 'CustomController@showLoginForm')->name('login'); `

