### PR TITLE
ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Homestead.json
 Homestead.yaml
 .env
+*.log


### PR DESCRIPTION
Prevent the accidental commit of any log files - typically generated by npm in the event of an error `npm-debug.log`.