### PR TITLE
csrfToken is auto added to window.Laravel

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,6 +6,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>Laravel</title>
+        
+        <!-- CSRF Token -->
+        <script>window.Laravel = {!! json_encode(['csrfToken' => csrf_token()]) !!}</script>
 
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">


### PR DESCRIPTION
On line 31 of [`/resources/assets/js/boostrap.js`](https://github.com/laravel/laravel/blob/master/resources/assets/js/bootstrap.js) there is this header `'X-CSRF-TOKEN': window.Laravel.csrfToken,` added to the default axios headers. You get an error out of a fresh install of Laravel because the window.Laravel.csrfToken is not being set anywhere by default. You have to know about the csrf token and that Laravel expects you to put it in your html manually if you want to use the new Laravel Mix functionality and do things like `npm run dev`.

Yes, `php artisan make:auth` will put a new default layout view but if they don't do this... ?
