### PR TITLE
sqlite.database needs to be absolute to be able to work for artisan and serve

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -35,7 +35,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => env('DB_DATABASE') ? base_path(env('DB_DATABASE')) : database_path('database.sqlite'),
             'prefix' => '',
         ],
 


### PR DESCRIPTION
When `DB_DATABASE=storage/database.sqlite` then it doesn't work
for both `php artisan tinker` and `php artisan serve`.