### PR TITLE
update laravel-elixir-vue-2 to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gulp": "^3.9.1",
     "jquery": "^3.1.0",
     "laravel-elixir": "^6.0.0-14",
-    "laravel-elixir-vue-2": "^0.2.0",
+    "laravel-elixir-vue-2": "^0.3.0",
     "laravel-elixir-webpack-official": "^1.0.2",
     "lodash": "^4.16.2",
     "vue": "^2.0.1",


### PR DESCRIPTION
Update laravel-elixir-vue-2 to 0.3.0 for a out of the box [Object.assign buble-loader polyfill](https://github.com/vuejs/laravel-elixir-vue-2/commit/336e76e3e93d5f023a4219b8ecc2fdeb435d983f#diff-168726dbe96b3ce427e7fedce31bb0bc) (especially useful when working with vuex)