### PR TITLE
Adds unix_socket to config/database.php for consistency

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -46,6 +46,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',


### PR DESCRIPTION
For the mysql driver only (as this only applies to mysql) add the "unix_socket" configuration parameter and corresponding environment variable.

added in #4039, but with the wrong key name. The `unix_socket` parameter IS supported by the [`MysqlConnector`](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Connectors/MySqlConnector.php#L108) class, and there is currently no way to modify it via environment variables.