### PR TITLE
unindex token

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ class CreatePasswordResetsTable extends Migration
     {
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
-            $table->string('token')->index();
+            $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
     }


### PR DESCRIPTION
No one runs query with `where token = ?`, the query does not mean anything because tokens are hashed before storage.