### PR TITLE
The .js files should be vendored too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.css linguist-vendored
 *.scss linguist-vendored
+*.js linguist-vendored


### PR DESCRIPTION
Some projects can present JS as the primary language, even clearly being a Laravel/PHP project. With this, that problem can be avoided.