### PR TITLE
Possible URL fix?

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ We would like to extend our thanks to the following sponsors for helping fund on
 
 - **[Vehikl](http://vehikl.com)**
 - **[Tighten Co.](https://tighten.co)**
-- **[British Software Development](https://www.britishsoftware.com)**
+- **[British Software Development](https://www.britishsoftware.co)**
 - **[Styde](https://styde.net)**
 - **[Codecourse](https://www.codecourse.com)**
 - [Fragrantica](https://www.fragrantica.com)


### PR DESCRIPTION
I was browsing the Patrons - and I noticed "British Software Development" leads to a non-existent url?

I think it should be `.co` rather than `.com`? That website looks valid?