### PR TITLE
Add vagrant virtual machine directory to git ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /storage/*.key
 /vendor
 /.idea
+/.vagrant
 Homestead.json
 Homestead.yaml
 .env


### PR DESCRIPTION
I figure since PHPStorm has been considered, that I'd add the vagrant virtual machine directory to prevent unnecessary committing of large disk images and state. Especially useful for those using Homestead.