### PR TITLE
why request redirect root:url ?

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\TrustProxies::class,
     ];
 
     /**

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Cookie\Middleware\EncryptCookies as BaseEncrypter;
+use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
 
-class EncryptCookies extends BaseEncrypter
+class EncryptCookies extends Middleware
 {
     /**
      * The names of the cookies that should not be encrypted.

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Foundation\Http\Middleware\TrimStrings as BaseTrimmer;
+use Illuminate\Foundation\Http\Middleware\TrimStrings as Middleware;
 
-class TrimStrings extends BaseTrimmer
+class TrimStrings extends Middleware
 {
     /**
      * The names of the attributes that should not be trimmed.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -8,14 +8,14 @@ use Fideloper\Proxy\TrustProxies as Middleware;
 class TrustProxies extends Middleware
 {
     /**
-     * The trusted proxies for the application.
+     * The trusted proxies for this application.
      *
      * @var array
      */
     protected $proxies;
 
     /**
-     * The proxy header mappings.
+     * The current proxy header mappings.
      *
      * @var array
      */

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Fideloper\Proxy\TrustProxies as Middleware;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for the application.
+     *
+     * @var array
+     */
+    protected $proxies;
+
+    /**
+     * The proxy header mappings.
+     *
+     * @var array
+     */
+    protected $headers = [
+        Request::HEADER_FORWARDED => 'FORWARDED',
+        Request::HEADER_CLIENT_IP => 'X_FORWARDED_FOR',
+        Request::HEADER_CLIENT_HOST => 'X_FORWARDED_HOST',
+        Request::HEADER_CLIENT_PORT => 'X_FORWARDED_PORT',
+        Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
+    ];
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as BaseVerifier;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
 
-class VerifyCsrfToken extends BaseVerifier
+class VerifyCsrfToken extends Middleware
 {
     /**
      * The URIs that should be excluded from CSRF verification.

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,15 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/framework": "5.4.*",
-        "laravel/tinker": "~1.0"
+        "php": ">=7.0.0",
+        "laravel/framework": "5.5.*",
+        "laravel/tinker": "~1.0",
+        "fideloper/proxy": "~3.3"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "classmap": [

--- a/config/session.php
+++ b/config/session.php
@@ -178,10 +178,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Same-site Cookies
+    | Same-Site Cookies
     |--------------------------------------------------------------------------
     |
-    | Here you may change the default value of the same-site cookie attribute.
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | do not enable this as other CSRF protection services are in place.
     |
     | Supported: "lax", "strict"
     |

--- a/config/session.php
+++ b/config/session.php
@@ -176,4 +176,17 @@ return [
 
     'http_only' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Same-site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the default value of the same-site cookie attribute.
+    |
+    | Supported: "lax", "strict"
+    |
+    */
+
+    'same_site' => null,
+
 ];


### PR DESCRIPTION
Laravel redirect to root on request validation error .

I have a required field in a Laravel Request Class and when that field is not present in the request, the request is redirected to root '/'.

I am sending the request via Postman.



File request of me. 

```<?php

namespace App\Api\V1\Admins\Requests;

use Illuminate\Foundation\Http\FormRequest;

class LoginRequest extends FormRequest
{

    public function authorize()
    {
        return true;
    }

    public function rules()
    {
        return [
            'email' => 'required|email',
            'password' => 'required'
        ];
    }

    public function messages()
    {
        return parent::messages(); // TODO: Change the autogenerated stub
    }
}
```
Uri : 
```php
   Route::post('/login', function(\App\Api\V1\Admins\Requests\LoginRequest $request){
      dd($request->all());
 
    });
```
// post ajax send 👍 

if error => redirect path "/"

else success => redirect next();

how to fix bug help. 