### PR TITLE
Add a Content-Security-Policy header to the default Laravel project to mitigate XSS

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,8 +16,9 @@ class Kernel extends HttpKernel
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
-        \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \App\Http\Middleware\AddCSPHeader::class,
     ];
 
     /**

--- a/app/Http/Middleware/AddCSPHeader.php
+++ b/app/Http/Middleware/AddCSPHeader.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class AddCSPHeader
+{
+    /**
+     * A Content Security Policy (CSP) header can limit the impact of XSS attacks.
+     * Resources: https://content-security-policy.com/ or https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+     * Video tutorial: https://www.troyhunt.com/understanding-csp-the-video-tutorial-edition/
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        return $response->header(
+          'Content-Security-Policy',
+          "default-src 'self';".
+          "script-src 'self' 'unsafe-eval' 'unsafe-inline';". // unsafe-eval is needed for Vue.js
+          "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;".
+          "font-src 'self' https://fonts.gstatic.com;"
+        );
+    }
+}


### PR DESCRIPTION
## Proposition ##
A Content Security Policy (CSP) header provides mitigation in the case an XSS attack succeeds. Many people do not know what a CSP header is, so providing one out-of-the-box greatly increases the exposure of this security technique. It also increases the security of Laravel setups with relatively little effort or maintenance on the Laravel side.

## Sounds great, but what's a CSP exactly?(tl;dr below) ##
### Quick XSS recap ###
First things first. You have probably heard of XSS attacks, where some input that should not be trusted is not properly sanitised and displayed to users, allowing an attacker to run code. If you're using Laravel properly and using security best practices, the input that you display is always sanitised and XSS is not possible. Alas, we do not live in a perfect world and devs are not perfect, so XSS happens often. XSS can also occur in edge cases, where you pull data from a "trusted" system which then has XSS problems of its own.
### XSS in practice ###
The above is where XSS explanations usually stop, but XSS attacks are naturally limited in scope by a very simple fact: your input is usually limited to some maximum length. Imagine you properly protected your comment system by sanitising the body text. Great! Except you forgot to also sanitise some metadata like the author name or some signature: woops! The attacker can then do an XSS attack using the author name, but your system probably does not allow the author name to be longer than, say, 100 characters. This means the attacker also cannot insert more than 100 characters of code, at least somewhat limiting the complexity of his/her attack.
### So XSS attacks are not very effective then? ###
Unfortunately not...because the attacker can simply pull in external code from his/her own server! Attackers usually host some malicious code on a short URL like foo.uk/a.js in order to stay under the limit of whatever input they try to exploit. Obviously the attacker can then run whatever code he/she wants, of arbitrary length and complexity.
### So does CSP protect against this? ###
Yes. A Content Security Policy is basically a whitelist of where the browser should pull resources from. If the attacker's server foo.uk is not in the whitelist, then the server refuses to load the code. It gets even better, because you can also tell the browser it should not execute any code in <script> tags at all, limiting the attack scope even more.

## CSP tl;dr ##
A Content Security Policy is basically a whitelist that tells the server where it can load resources from. If an attacker tries to pull code from his/her own server, the browser will refuse to do it. This limits the scope of the XSS attack, because the attacker's code then has to fit in whatever field he/she is exploiting. Very strict CSP's can even block <script> tags all together or block dynamic code execution (eval).

## How do we add this to Laravel? ##
I created a very simple global middleware similar to, for example, TrimStrings that just adds a CSP header to all request responses. The default CSP header works with the default Laravel project and allows unsafe-eval on scripts (Vue.js needs this), unsafe-inline because we use a script tag to put the CSRF token in window.Laravel.csrfToken and also use onclick="" on the logout button, it also allows styles to be loaded from https://fonts.googleapis.com and fonts from https://fonts.gstatic.com. This middleware is then registered as a global middleware in Kernel.php. All together it's really just a few lines of code!

### So it's simple and short, but why add it to Laravel and not publish it as a package? ###
Very simple: exposure. Even if you decide to make this an opt-in feature, if 10% of the people who start a new Laravel project decide to enable the CSP header because it's already there anyway and they read about it in the documentation, then that's a big win for online security as XSS attacks are potentially mitigated. Over time it may increase the security of Laravel setups that are out there.

### Should it be opt-in or opt-out? ###
In an ideal world it's opt-out, a fresh Laravel project starts with a simple and strict CSP header and you need to adjust it if you decide to load external resources, e.g. from a CDN. Unfortunately it's very likely people will not look at their browser's console and not read the documentation and report an issue if something doesn't work.
#### What about opt-out with a more relaxed CSP? ####
Opt-out is still possible by providing a CSP that fits the 80% use-case, e.g. add the most common CDNs that people use, analytics URLs, etc. This does put more maintenance stress on the Laravel devs, because this default CSP header needs to be kept up-to-date. Also, people who fall out of the default use-case may still complain.
#### Opt-in alternative ####
Opt-in would simply mean provide the CSP header middleware by default and make sure it works with the default Laravel project. Since the default project doesn't change that often, this isn't really hard on maintenance. Then, comment out the line that registers the CSP middleware as a global middleware. Users can then enable it by simply uncommenting the line. The documentation can provide some explanation about CSP headers and suggest to developers that they use it if they're starting a new project anyway, together with some useful resources.
#### Even if it's opt-in, do we want a very strict CSP for higher security? ####
Currently the CSP allows <script> tags by specifying unsafe-inline, because they're used in two places (csrfToken and logout button). It's possible to move this code to bootstrap.js or app.js so we can block <script> tags by default entirely. This make the XSS mitigation stronger, but users must then put all their JS code in files and compile it using Laravel Mix. Security-wise, this is definitely preferred, but for user friendliness you may want to allow unsafe-inline by default and simply point out in the documentation that this feature exists if people want it. The reverse is having a strict CSP and pointing out that users need to add unsafe-inline for script tags.

### Secure alternative to blocking <script> tags ###
It may be unpractical to block every single use of <script> tags in your project, but fortunately the CSP developers also thought of this. What I previously discussed is only CSP level 1. CSP level 2 adds nonces, so <script> tags can still be blocked, but <script nonce="dADdke892Zx"> is allowed. It would be possible to add a simple Laravel feature (perhaps in Blade?) that adds the nonce to all script tags created in some special way (e.g. using Blade). This is pretty similar to CSRF protection, but then for your DOM. Adding this would be more user friendly and secure at the same time, but also requires some more work; generate a valid nonce on the server and inject it in script tags.

## What about browser support? ##
According to Can I Use, 93.31% of browsers support CSP level 1 and 74.08% supports CSP level 2. It's just a header, so if the browser doesn't support it it's only ignored.

## Are there other security headers? ##
Yes! Other options to add by default (these are much simpler so I'm not going to give a big explanation) are "X-Xss-Protection 1; mode=block" (obvious), "X-Frame-Options SAMEORIGIN" (prevents clickjacking by embedding your site in an iframe), "x-permitted-cross-domain-policies none" (similar to previous), "X-Content-Type-Options nosniff" (Don't MIME-sniff the content-type of a response, just use what is declared) and setting a referrer-policy for privacy if wanted. Some of these are so widely used that they can easily be added to the default Laravel project so that less experienced developers don't forget them and miss out on security.

## Conclusion ##
Because many developers are not aware of what CSP headers can do and that they can mitigate XSS attacks and because security is super important, I believe it's a great idea to provide one out-of-the-box even if it's just opt-in with some explanation in the documentation. Opt-out is also possible, and I outlined some pro/cons of this above. Even more advanced approaches are also possible using CSP level 2 and nonces.

## Resources ##
https://www.troyhunt.com/understanding-csp-the-video-tutorial-edition/
https://content-security-policy.com/
https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
http://caniuse.com/#search=csp
https://scotthelme.co.uk/hardening-your-http-response-headers/
https://www.troyhunt.com/clickjack-attack-hidden-threat-right-in/
https://www.perpetual-beta.org/weblog/security-headers.html

Feedback is very welcome! Obviously if this is approved I still have some documentation to write; that will probably be the biggest chunk of work, since the code itself is pretty straightforward.






