### PR TITLE
Prevent email and password being identical

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -50,7 +50,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|min:6|confirmed',
+            'password' => 'required|min:6|confirmed|different:email',
         ]);
     }
 


### PR DESCRIPTION
Don't allow users to signup with a password that equals their email address. It's a fast check and raises awareness.

See https://github.com/laravel/framework/pull/18622.