### PR TITLE
Use ~ import in app.scss

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,4 +6,4 @@
 @import "variables";
 
 // Bootstrap
-@import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap";


### PR DESCRIPTION
I'm new to webpack and I thought that importing from node_modules is the correct way to go, which didn't work.

And that led me to the answer: https://github.com/JeffreyWay/laravel-mix/issues/412

Shouldn't the example file be that way too?