### PR TITLE
Make app name configurable in environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/config/app.php
+++ b/config/app.php
@@ -12,7 +12,7 @@ return [
     | any other location as required by the application or its packages.
     */
 
-    'name' => 'Laravel',
+    'name' => env('APP_NAME', 'Laravel'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes the application name configurable via an environment variable. By default, this is set to "Laravel" as per the current configuration in the `app.php` config file.

## Why?
When developing applications with Laravel, I am often putting a version onto a staging server as well as a production server. By making the app name configurable, when I get `Mailables` sent to me (which, by default use the app name) I can see more easily whether the e-mail has come from the staging server or the production server.

It can also make it easier to identify which version of an application is being viewed in a browser (for example configuring the local development version with `Local` at the end can avoid mistakes when there are multiple tabs open with local, staging and production versions of the application.