### PR TITLE
Make cache key prefix configurable in environment

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -86,6 +86,6 @@ return [
     |
     */
 
-    'prefix' => 'laravel',
+    'prefix' => env('CACHE_KEY_PREFIX', 'laravel'),
 
 ];


### PR DESCRIPTION
This PR makes the cache key prefix configurable in the environment file.

## Why?
There are some situations where two instances of a project (e.g. staging / UAT) that could share the sae underlying cache implementation. By allowing the cache key prefix to be configurable in the environment, each project can effectively namespace their cache preventing problems.