### PR TITLE
Add to axios defaults instead of overwriting them

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -27,10 +27,8 @@ window.Vue = require('vue');
 
 window.axios = require('axios');
 
-window.axios.defaults.headers.common = {
-    'X-CSRF-TOKEN': window.Laravel.csrfToken,
-    'X-Requested-With': 'XMLHttpRequest'
-};
+window.axios.defaults.headers.common['X-CSRF-TOKEN'] = window.Laravel.csrfToken;
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**
  * Echo exposes an expressive API for subscribing to channels and listening


### PR DESCRIPTION
This change ensures the default "Accept" header specified by axios is retained.

Previously, checking `$request->wantsJson()` on a request made from axios would return false since the "Accept: application/json... (etc)" header was omitted.

This change uses the format specified in the axios docs here https://github.com/mzabriskie/axios#global-axios-defaults