### PR TITLE
Add *.swp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 Homestead.json
 Homestead.yaml
 .env
+*.swp


### PR DESCRIPTION
Git tracks the swap files which often becomes a headache for vi users and other programs that creates them.