### PR TITLE
Remove trailing slash redirects

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,10 +5,6 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes If Not A Folder...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
-
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Because reusable blade templates may well be posting to URLs that end in slash, we propose removing this redirection. With the redirection, CREATE methods are failing because they are being redirected prior to having the POST data processed.

For example, in my blade template I have:

`<form method="POST" action="/site-admin/users/{{ $user->id }}">`

If I use the template for the create methods (simple POST to /site-admin/users/) in addition to the edit method (PATCH request), it will get redirected to `/site-admin/users` (no trailing slash) as a GET request, which then does the wrong thing (executes the route for GET rather than POST or PATCH).

I realize this may be my own lack of knowledge of how this should work, but a trailing slash has never struck me as a route differentiator.