### PR TITLE
Update to latest cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "axios": "^0.15.3",
     "bootstrap-sass": "^3.3.7",
-    "cross-env": "^3.2.3",
+    "cross-env": "^4.0.0",
     "jquery": "^3.1.1",
     "laravel-mix": "0.*",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Updates the dependency constraint to the latest version, so Laravel isn't shipping with any outdated dependencies. [From looking at the breaking changes](https://github.com/kentcdodds/cross-env/releases) we should be fine for the setting of `NODE_ENV`.