### PR TITLE
Correct namespaces for default listeners

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -13,8 +13,8 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\Event' => [
-            'App\Listeners\EventListener',
+        '\App\Events\Event' => [
+            '\App\Listeners\EventListener',
         ],
     ];
 


### PR DESCRIPTION
Added backslashes to namespaces, otherwise `php artisan event:generate` is creating files in `app/Providers/App/Events/...` instead of `app/Events/...`