### PR TITLE
Fix break from #4226

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+define('LARAVEL_START', microtime(true));
+
 /*
 |--------------------------------------------------------------------------
 | Register The Auto Loader

--- a/artisan
+++ b/artisan
@@ -13,7 +13,7 @@
 |
 */
 
-require __DIR__.'/bootstrap/autoload.php';
+require __DIR__.'/vendor/autoload.php';
 
 $app = require_once __DIR__.'/bootstrap/app.php';
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="bootstrap/autoload.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"


### PR DESCRIPTION
https://github.com/laravel/laravel/pull/4226 removes `bootstrap/autoload.php` and breaks `artisan`. This PR fixes `artisan` to work.