### PR TITLE
Ignore the npm debug log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /.vagrant
 Homestead.json
 Homestead.yaml
+npm-debug.log
 .env


### PR DESCRIPTION
When an NPM run fails, is created a npm-debug.log file. This file can be ignored and should not be published on a Git based repository.