### PR TITLE
Update default homepage

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -69,10 +69,10 @@
             @if (Route::has('login'))
                 <div class="top-right links">
                     @if (Auth::check())
-                        <a href="{{ url('/home') }}">Home</a>
+                        <a href="{{ route('home') }}">Home</a>
                     @else
-                        <a href="{{ url('/login') }}">Login</a>
-                        <a href="{{ url('/register') }}">Register</a>
+                        <a href="{{ route('login') }}">Login</a>
+                        <a href="{{ route('register') }}">Register</a>
                     @endif
                 </div>
             @endif


### PR DESCRIPTION
Change URL for logging in and registering on default homepage. Right now Laravel checks if there is a login route and then it sends the person to /login even if their login route is somewhere else, such as at /admin/login (e.g. they are using Backpack for Laravel). Therefore, instead this will check the exact URL for the login route.