### PR TITLE
Better .htaccess dealing with ending slashes

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -7,7 +7,8 @@
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [R=301,L]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
This solves the wrong redirection to remove ending slashed if laravel is installed in a sub-directory of the server.

For instance, if my instance is installed at http://xx.xx.xx.xx/laravel, and I want to access the test route. If I access http://xx.xx.xx.xx/laravel/test/, the original would redirect to http://xx.xx.xx.xx/test, which yields a 404. This patch makes it redirect to http://xx.xx.xx.xx/laravel/test.