### PR TITLE
Disable indexes

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,4 @@
+Options -Indexes
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews


### PR DESCRIPTION
I believe this should be in the framework by default, as I've found lots of Laravel installations without this, and it's a basic security rule.