### PR TITLE
Fix erroneous string size for email field

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email', 256)->unique();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
+            $table->string('email', 256)->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });


### PR DESCRIPTION
This commit addresses an issue with the email field size being too big for an index in MySQL, thus causing the current default migrations to fail every time.

See this reference: https://dev.mysql.com/doc/refman/5.6/en/innodb-restrictions.html
The limit is 767 bytes. With MySQL assuming 3 bytes per character, this comes to 256 characters rounded up.

By simply specifying the length of the field, this issue is avoided.