### PR TITLE
Call currently used php binary in composer instead of php located in $PATH.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,18 +30,18 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "php artisan key:generate"
+            "@php artisan key:generate"
         ],
         "post-install-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postInstall",
-            "php artisan optimize"
+            "@php artisan optimize"
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-            "php artisan optimize"
+            "@php artisan optimize"
         ]
     },
     "config": {


### PR DESCRIPTION
Current composer.json needs path to php based in system $PATH variable. Better way is use `@php` ([Scripts - Composer](https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts)) that will use the same php binary as for composer.