### PR TITLE
Simplify test suite names

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,11 +9,11 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Feature Tests">
+        <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
 
-        <testsuite name="Unit Tests">
+        <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Not a huge deal, but this

```
unit --testsuite Feature
```

is substantially easier to type than this

```
unit --testsuite "Feature Tests"
```

I find the former description informative enough and it's not out of the question that you will need to run specific test suite via command line or as part of a CI routine.