### PR TITLE
Add quotes

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,6 +1,6 @@
 
 // Fonts
-@import url(https://fonts.googleapis.com/css?family=Raleway:300,400,600);
+@import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
 
 // Variables
 @import "variables";


### PR DESCRIPTION
Sass compilers can sometimes be weird if import urls like this aren't quoted. They'll spit out junk like

```
Error: Encountered invalid @import syntax.
```

Anyways, pretty common practice to use quotes for all imports. I mean, seriously, how much more do you want me to write for a dang PR that adds a pair of quotes? I've got work to do, gah.