### PR TITLE
add .phpintel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /storage/*.key
 /vendor
 /.idea
+/.phpintel
 /.vagrant
 Homestead.json
 Homestead.yaml


### PR DESCRIPTION
Hi , 
phpintel is a common sublime plugin 
> PHP code scanner and analyzer for code intelligence within PHP projects.

it creates .phpintel directory like .idea for phpstorm so it would be nice if we add it to help all laravel artisans who uses this plugin for auto ignore instead of add it manually in each project.