### PR TITLE
Update .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -4,7 +4,8 @@
     </IfModule>
 
     RewriteEngine On
-
+    Options +FollowSymLinks
+    
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]


### PR DESCRIPTION
An error 403 Forbidden may possible, because FollowSymLinks Options is not declare/enabled.