### PR TITLE
Require Laravel Mix 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bootstrap-sass": "^3.3.7",
     "cross-env": "^3.2.3",
     "jquery": "^3.1.1",
-    "laravel-mix": "0.*",
+    "laravel-mix": "^1.0",
     "lodash": "^4.17.4",
     "vue": "^2.1.10"
   }


### PR DESCRIPTION
This will make sure version 1.0 of Larvel Mix is pulled in