### PR TITLE
Use null coalescing operator in UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,7 +19,7 @@ $factory->define(App\User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
-        'password' => $password ?? bcrypt('secret'),
+        'password' => $password ?? $password = bcrypt('secret'),
         'remember_token' => str_random(10),
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,7 +19,7 @@ $factory->define(App\User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
-        'password' => $password ?: $password = bcrypt('secret'),
+        'password' => $password ?? bcrypt('secret'),
         'remember_token' => str_random(10),
     ];
 });


### PR DESCRIPTION
Since the next version of Laravel will require PHP 7.0+, I suggest to use this operator that specified for only checking if variable is null. Compared to elvis operator that also check variable's value that casted to boolean, which is not necessary in this case.
[Reference](https://stackoverflow.com/a/34571460/4306661)