### PR TITLE
Fix to TrustProxies

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -21,9 +21,9 @@ class TrustProxies extends Middleware
      */
     protected $headers = [
         Request::HEADER_FORWARDED => 'FORWARDED',
-        Request::HEADER_CLIENT_IP => 'X_FORWARDED_FOR',
-        Request::HEADER_CLIENT_HOST => 'X_FORWARDED_HOST',
-        Request::HEADER_CLIENT_PORT => 'X_FORWARDED_PORT',
-        Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
+        Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
+        Request::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
+        Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
+        Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
     ];
 }


### PR DESCRIPTION
It appears that the http_foundation Request object has deprecated `HEADER_CLIENT_*` as of 3.3 and will be removed in 4.0

This PR updates the header keys in the TrustProxies middleware class to use the corrected constant from the http_foundation library

