### PR TITLE
:wrench: Defaul session.secure to true when APP_ENV != 'local'.

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -161,7 +161,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', false),
+    'secure' => env('SESSION_SECURE_COOKIE', ! env('APP_ENV') == 'local'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The world is HTTPS. Forge makes HTTPS a snap. Why aren't we encouraging HTTPS?