### PR TITLE
Use config function instead of env function

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -124,7 +124,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+        str_slug(config('app.name'), '_').'_session'
     ),
 
     /*


### PR DESCRIPTION
`app.name` already uses `Laravel` as a default value in case of the `APP_NAME` environment variable is not set. This allows to remove some duplication.