### PR TITLE
Ignore the Yarn error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 Homestead.json
 Homestead.yaml
 npm-debug.log
+yarn-error.log
 .env


### PR DESCRIPTION
Like the npm error log, this file can also be ignored.

[See also](https://stackoverflow.com/questions/42592168/should-i-add-yarn-error-log-to-my-gitignore-file)