### PR TITLE
The app.url is used also on e-mail templates.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -49,6 +49,8 @@ return [
     | the Artisan command line tool. You should set this to the root of
     | your application so that it is used when running Artisan tasks.
     |
+    | Also used by e-mail templates (Reset Password).
+    |
     */
 
     'url' => env('APP_URL', 'http://localhost'),


### PR DESCRIPTION
The config `app.url` is also used here:

`Illuminate/Auth/Notifications/ResetPassword.php`
`lluminate/Mail/resources/views/html/message.blade.php`
`lluminate/Mail/resources/views/markdown/message.blade.php`

I think a bit of clarification would be good.