### PR TITLE
DB_SCHEMA environment variable for PostgreSQL

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -63,7 +63,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
-            'schema' => 'public',
+            'schema' => env('DB_SCHEMA', 'public'),
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
Currently there is no option to override schema value when using postgres. We can override the username, password etc through .env, but can't override the schema value. This PR adds the `DB_SCHEMA` environment variable through which we can override the default schema attribute value of postgres configuration. 