### PR TITLE
Warn about storage and bootstrap/cache file permissioning

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -37,6 +37,26 @@ $app = require_once __DIR__.'/../bootstrap/app.php';
 
 /*
 |--------------------------------------------------------------------------
+| Lets make sure the writable files have their permissions set
+|--------------------------------------------------------------------------
+|
+| No one likes seeing a white screen of death
+|
+*/
+
+$writableFolders = [
+	__DIR__.'/../storage/' => 'storage',
+	__DIR__.'/../bootstrap/cache/' => 'bootstrap/cache'
+];
+
+foreach ($writableFolders as $writableFolder => $folderName) {
+	if (!is_writable($writableFolder)) {
+		die('Please ensure the folder "' . $folderName . '" is writable.');
+	}
+}
+
+/*
+|--------------------------------------------------------------------------
 | Run The Application
 |--------------------------------------------------------------------------
 |


### PR DESCRIPTION
At the moment, when the folders:

`storage` and `bootstrap/cache` permissions are not set, Laravel simply shows a blank white screen.

This is confusing for new comers and can cause issues when deploying an application.

The following PR is a potential fix for this - but I can appreciate that there might be a better place to put this than in the public/index.php file.

This simply warns users about the error and prompts them to fix the permissions - rather than seeing the blank screen which happens currently.