### PR TITLE
Temporary Filesystem

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -63,6 +63,11 @@ return [
             'bucket' => env('AWS_BUCKET'),
         ],
 
+        'temporary' => [
+            'driver' => 'local',
+            'root' => env('TMP_DIR', sys_get_temp_dir()),
+        ],
+
     ],
 
 ];


### PR DESCRIPTION
Often, we must read files temporarily and then discard them.

This PR proposes to include a new default disk, the **temporary** disk.

The default would be the PHP's [built-in](http://php.net/manual/en/function.sys-get-temp-dir.php) `sys_get_temp_dir()` function, but the user would have liberty to use another location using env `TMP_DIR` key.