### PR TITLE
Remove migrations from autoload classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "autoload": {
         "classmap": [
-            "database"
+            "database/seeds",
+            "database/factories"
         ],
         "psr-4": {
             "App\\": "app/"


### PR DESCRIPTION
The list of migrations in your app can grow massively and these currently automatically get included in your composer classmap. Migrations are intended to be run as a one-time thing and are already automatically [`required`](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Migrations/Migrator.php#L436) so this PR avoids unnecessarily adding the migrations to your composer file.
