### PR TITLE
Fixed trailing slash redirection for subdirectory installs.

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -7,7 +7,8 @@
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [L,R=301]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
Previously redirection to remove trailing slashes would fail if Laravel was not installed in the root directory.