### PR TITLE
Using space in APP_NAME surrounded by quotes fails Str:startsWith method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME="Laravel Test"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true


### PR DESCRIPTION
I've come across this problem with one of my sites, using quotes in the .env files as described.

What it does is that the function Str::startsWith() returns false when it checks if APP_NAME starts with '"'. 

I have not found a solution yet for this problem.

.env
`APP_NAME="Laravel Test"`

config/app.php
```
/*
    |--------------------------------------------------------------------------
    | Application Name
    |--------------------------------------------------------------------------
    |
    | This value is the name of your application. This value is used when the
    | framework needs to place the application's name in a notification or
    | any other location as required by the application or its packages.
    */

    'name' => env('APP_NAME', 'Laravel'),
```

My own project's app.blade.php
```
<title>{{ config('app.name', 'Laravel') }}</title>
```

So now when you use this in the default app.blade.php for example as the title of the site. It returns the default: "Laravel" instead of the expected "Laravel Test"
