### PR TITLE
Changed laravel/framework to laravel/laravel.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 <p align="center"><img src="https://laravel.com/assets/img/components/logo-laravel.svg"></p>
 
 <p align="center">
-<a href="https://travis-ci.org/laravel/framework"><img src="https://travis-ci.org/laravel/framework.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/d/total.svg" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/v/stable.svg" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://poser.pugx.org/laravel/framework/license.svg" alt="License"></a>
+<a href="https://travis-ci.org/laravel/laravel"><img src="https://travis-ci.org/laravel/laravel.svg" alt="Build Status"></a>
+<a href="https://packagist.org/packages/laravel/laravel"><img src="https://poser.pugx.org/laravel/laravel/d/total.svg" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/laravel/laravel"><img src="https://poser.pugx.org/laravel/laravel/v/stable.svg" alt="Latest Stable Version"></a>
+<a href="https://packagist.org/packages/laravel/laravel"><img src="https://poser.pugx.org/laravel/laravel/license.svg" alt="License"></a>
 </p>
 
 ## About Laravel


### PR DESCRIPTION
Not sure if it's intentional or not that the status images link to laravel/framework instead of laravel/laravel.