### PR TITLE
Fixes "Cannot resolve directory'" in PhpStorm

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -6,4 +6,4 @@
 @import "variables";
 
 // Bootstrap
-@import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap";


### PR DESCRIPTION
This fixes the annoying error shown on the import line

Cannot resolve directory 'node_modules' less... (Strg+F1) 
This inspection checks references to files and directories.