### PR TITLE
require_once /vendor/autoload.php

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -14,4 +14,4 @@ define('LARAVEL_START', microtime(true));
 |
 */
 
-require __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
When you run `phpunit` it requires `/vendor/autoload.php` by itself.
Because `/app/bootstrap.php` is set as `bootstrap` in `phpunit.xml` then `autoload.php` is loaded twice.
You can verify this by adding
```php
echo "COMPOSER\n";
```
in your `/vendor/autoload.php`
This PR prevents second loading of this file.

Before
![image](https://user-images.githubusercontent.com/1434668/29307850-1e34b554-81ac-11e7-8cd4-4461e203b2d2.png)
After
![image](https://user-images.githubusercontent.com/1434668/29307860-261513e0-81ac-11e7-932e-c9e40de0d30a.png)

On not testing run Laravel requires this file as usual.