### PR TITLE
Create signIn method in TestCase class

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,14 +12,15 @@ abstract class TestCase extends BaseTestCase
      * Set the currently logged in user for the application.
      *
      * @param  mixed  $user
+     * @param string|null  $driver
      * @return $this
      */
-    protected function signIn($user = null)
+    protected function signIn($user = null, $driver = null)
     {
         if (is_null($user)) {
             $user = factory(\App\User::class)->create();
         }
 
-        return $this->actingAs($user);
+        return $this->actingAs($user, $driver);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ abstract class TestCase extends BaseTestCase
      * Set the currently logged in user for the application.
      *
      * @param  mixed  $user
-     * @param string|null  $driver
+     * @param  string|null  $driver
      * @return $this
      */
     protected function signIn($user = null, $driver = null)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,19 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    /**
+     * Set the currently logged in user for the application.
+     *
+     * @param  mixed  $user
+     * @return $this
+     */
+    protected function signIn($user = null)
+    {
+        if (is_null($user)) {
+            $user = factory(\App\User::class)->create();
+        }
+
+        return $this->actingAs($user);
+    }
 }


### PR DESCRIPTION
This method is a "better version" of the actingAs method.

If no user is given, it will create a new one using the factory.

It's very handy because on some tests, you just want to be signed in, whatever the user is.

```php
/** @test */
public function an_authenticated_user_cannot_reach_the_login_page()
{
    // Without using the signIn method.

    $user = factory('App\User')->create();

    $response = $this->actingAs($user)
        ->get('login');

    $response->assertStatus(302);
}

/** @test */
public function an_authenticated_user_cannot_reach_the_login_page()
{
    // By using the signIn method

    $response = $this->signIn()
        ->get('login');

    $response->assertStatus(302);
}
```