### PR TITLE
password field should not be fillable

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -66,7 +66,7 @@ class RegisterController extends Controller
 
         $user->name = $data['name'];
         $user->email = $data['email'];
-        $user->password = $data['password'];
+        $user->password = bcrypt($data['password']);
 
         $user->save();
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -62,10 +62,14 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
-        return User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'password' => bcrypt($data['password']),
-        ]);
+        $user = new User();
+
+        $user->name = $data['name'];
+        $user->email = $data['email'];
+        $user->password = $data['password'];
+
+        $user->save();
+
+        return $user;
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email',
     ];
 
     /**


### PR DESCRIPTION
The `password` field is *hidden by default*, why should it be fillable too?

Developers should loosen up their mass assignment depending on the app requirement.

Laravel it self is giving a bad example!

Plus Why not!

P.S: sorry about the last pull request :disappointed: 