### PR TITLE
Route Middleware Auto-Register

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,4 +58,13 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
+    
+    /**
+	 * Automatically register middlewares.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->load(__DIR__.'/Middleware');
+    }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -58,13 +58,14 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
-    
+
     /**
-	 * Automatically register middlewares.
-	 *
-	 * @return void
-	 */
-	public function register() {
-		$this->load(__DIR__.'/Middleware');
+     * Automatically register middlewares.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->load(__DIR__.'/Middleware');
     }
 }


### PR DESCRIPTION
Automatically Register Route Middlewares with name property in the Middeware file itself. Goes with [Pull Request 20755](https://github.com/laravel/framework/pull/20755)