### PR TITLE
[5.5] Add sticky to config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -52,6 +52,7 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => null,
+            'sticky' => true,
         ],
 
         'pgsql' => [
@@ -65,6 +66,7 @@ return [
             'prefix' => '',
             'schema' => 'public',
             'sslmode' => 'prefer',
+            'sticky' => true,
         ],
 
         'sqlsrv' => [
@@ -76,6 +78,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset' => 'utf8',
             'prefix' => '',
+            'sticky' => true,
         ],
 
     ],


### PR DESCRIPTION
I'm not actually 100% if we should add this or not....

Anyone who wants to add a read/write connection needs to modify the config for the `read` and `write` hosts. I have a PR for the docs for that section now - so people will see the new `sticky` option there.

So should `sticky` be in the default config? It would raise awareness of the option, but its not needed unless they modify the config anyway... I'm in two minds about it...

Happy if you dont accept this - I see benefits either way.