### PR TITLE
Fixed composer's invalid argument exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"
+        ],
+        "post-install-cmd": [
+            "@php artisan --version"
         ]
     },
     "config": {


### PR DESCRIPTION
Fixing a conflict with the latest composer while installing a new laravel 5.5.0 project.
Solving composer's exeption: 
"[InvalidArgumentException]
  Script "post-install-cmd" is not defined in this package"

And, added a script to show the installed laravel version.