### PR TITLE
Redirect using intended url after successful login

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/home');
+            return redirect()->intended('/home');
         }
 
         return $next($request);


### PR DESCRIPTION
When a user is found to be a guest the full url is stored in the session key `url.intended` before they're sent to the login page. Once successfully authenticated we should respect redirecting the user to `url.intended`, otherwise use default `/home`.