### PR TITLE
Fixing Installation Error in PHP commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,14 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "@php artisan key:generate"
+            "php artisan key:generate"
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "php artisan package:discover"
         ]
     },
     "config": {


### PR DESCRIPTION
Hey @taylorotwell 

Maybe there was a reason for having the `@` symbols at the beginning of the PHP commands, but for whatever reason that is, I get an error message when I try and do the `laravel new` command. See error message:

![error message screenshot](https://user-images.githubusercontent.com/601261/29999471-1e6a2e6c-8fff-11e7-8739-6ea8c054fd2f.png)

This is because it does not recognize the commands:

```
@php -r \"file_exists('.env') || copy('.env.example', '.env');
@php artisan key:generate
@php artisan package:discover
```

So everytime I create a new Laravel app with the Laravel command. I have to manually copy the `.env.example` to `.env` and then run `php artisan key:generate` before I can view my new laravel app.

Anyway, maybe there was another reason behind this. Let me know.

Fingers crossed for my first Laravel PR 👍 

Thanks for all your awesome work!