### PR TITLE
Add S3 endpoint for compatible services

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -61,6 +61,7 @@ return [
             'secret' => env('AWS_SECRET'),
             'region' => env('AWS_REGION'),
             'bucket' => env('AWS_BUCKET'),
+            'endpoint' => env('AWS_ENDPOINT'),
         ],
 
     ],


### PR DESCRIPTION
This makes it easy to use something like Digitalocean Spaces.

Potentially, this should be on the 5.5 (maybe 5.4 too?) branch.