### PR TITLE
Use database_path helper for sqlite database filename specified in .env

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -35,7 +35,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => database_path(env('DB_DATABASE', 'database.sqlite')),
             'prefix' => '',
         ],
 


### PR DESCRIPTION
Suppose we have the following set up in .env:
```
DB_CONNECTION=sqlite
DB_DATABASE=database/mydb.sqlite
```
Doing a `php artisan migrate` will work on specified database.

The problem is that if the app is run with `php artisan serve`, it will give a database `database/mydb.sqlite` does not exist error.

To fix this, why not change this
```php
            'database' => env('DB_DATABASE', database_path('database.sqlite')),
```
to this?
```php
            'database' => database_path(env('DB_DATABASE', 'database.sqlite')),
```
So that db file path is in now returned correctly by _database_path_ helper.