### PR TITLE
[5.5] Move tinker to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
     "require": {
         "php": ">=7.0.0",
         "fideloper/proxy": "~3.3",
-        "laravel/framework": "5.5.*",
-        "laravel/tinker": "~1.0"
+        "laravel/framework": "5.5.*"
     },
     "require-dev": {
         "filp/whoops": "~2.0",
         "fzaninotto/faker": "~1.4",
+        "laravel/tinker": "~1.0",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~6.0"
     },


### PR DESCRIPTION
Probably not used in production env and it's an extra package
It works in dev env with autodiscovery