### PR TITLE
Added "-Indexes" option

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,6 @@
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
-        Options -MultiViews
+        Options -MultiViews -Indexes
     </IfModule>
 
     RewriteEngine On


### PR DESCRIPTION
If you open the `/css`, `/js`, or any other folder on the default server, you can see the list of files in the directory.
The `-Indexes` option forbids viewing directory files via the web interface.