### PR TITLE
fix problem when creating new project with laravel installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
         "post-create-project-cmd": [
             "@php artisan key:generate"
         ],
+        "post-install-cmd": [
+            "@php artisan key:generate"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"


### PR DESCRIPTION
This exception showed up when running `laravel new laravel`.
![2017-09-21 17 11 31](https://user-images.githubusercontent.com/7333171/30688529-020c2bca-9ef1-11e7-9b99-aca8cfb23a30.png)

Solution: Add `post-install-cmd` to `composer.json` and run `php artisan key:generate` in it.
