### PR TITLE
Tests failing because LARAVEL_START is not defined

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,8 +13,9 @@ trait CreatesApplication
      */
     public function createApplication()
     {
-        if (!defined('LARAVEL_START'))
+        if (!defined('LARAVEL_START')) {
             define('LARAVEL_START', microtime(true));
+        }
         
         $app = require __DIR__.'/../bootstrap/app.php';
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,7 +13,7 @@ trait CreatesApplication
      */
     public function createApplication()
     {
-        if (!defined('LARAVEL_START')) {
+        if (! defined('LARAVEL_START')) {
             define('LARAVEL_START', microtime(true));
         }
         

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,6 +13,9 @@ trait CreatesApplication
      */
     public function createApplication()
     {
+        if (!defined('LARAVEL_START'))
+            define('LARAVEL_START', microtime(true));
+        
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();


### PR DESCRIPTION
# Steps To Reproduce

1. If it's not already installed, install Laravel Dusk

    > composer require --dev laravel/dusk
    > php artisan dusk:install
    
2. Create the following PHP class at ``app/Classes/Foo.php``.

       <?php
       namespace App\Classes;

       use Carbon\Carbon;

       class Foo {
       	   public $started;
	
       	   public function __construct() {
       		   $this->started = Carbon::createFromTimestamp(LARAVEL_START)->toDateString();
       	   }
       }

3. Create a new provider called ``FooServiceProvider`` using Artisan

    > php artisan make:provider FooServiceProvider

4. Open ``app/Providers/FooServiceProvider.php`` and add the following inside the ``register`` method body

            $this->app->singleton('foo', function() {
                return new \App\Classes\Foo();
           });
           
5. Add the Service Provider to ``providers`` in ``config/app.php``

       'providers' => [
              // ...
       
              App\Providers\FooServiceProvider::class
       ]

6. Open up ``resources/views/welcome.blade.php`` and add the following somewhere (I added it directly below ``<div class="container"``)

       <div>{{ app('foo')->started }}</div>

7. Insert the test below into the automatically generated ``tests/Browser/ExampleTest.php``

       public function testFoo() {
    		$this->browse(function (Browser $browser) {
                $browser->visit('/')
                        ->assertSee(app('foo')->started);
            });
       }
       
8. Spin up the server and run dusk with Artisan

   > php artisan serve --port=80
   > php artisan dusk
   
## Expected Result

The PHPUnit tests should complete successfully

## Actual Result

The second PHPUnit test (``testFoo``) gives the following error

    There was 1 error:
    
    1) Tests\Browser\ExampleTest::testFoo
    ErrorException: Use of undefined constant LARAVEL_START - assumed 'LARAVEL_START'
    
    C:\test\app\Classes\Foo.php:10
    C:\test\app\Providers\FooServiceProvider.php:29
    C:\test\vendor\laravel\framework\src\Illuminate\Container\Container.php:749
    C:\test\vendor\laravel\framework\src\Illuminate\Container\Container.php:631
    C:\test\vendor\laravel\framework\src\Illuminate\Container\Container.php:586
    C:\test\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:721
    C:\test\vendor\laravel\framework\src\Illuminate\Foundation\helpers.php:110
    C:\test\tests\Browser\ExampleTest.php:28
    C:\test\vendor\laravel\dusk\src\TestCase.php:92
    C:\test\tests\Browser\ExampleTest.php:29

# Environment

 * Windows 10 (x64)
 * Laravel v5.5.12
 * Laravel Dusk v2.0.4
 * PHP v7.1.9
 
# Proposal

Define the LARAVEL_START constant in ``tests/CreateApplication.php`` if it's not already defined. See the pull request for the changes.

## Notes

 * One problem that I should note is LARAVEL_START will not have the exact same value. The test cases will have a different value than the one that is actually being used.
 * This also occurred when I used test classes that inherited the ``Tests\TestCase`` abstract class.