### PR TITLE
Document proper return type

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,7 +44,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
parent::render returns \Symfony\Component\HttpFoundation\Response

https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Exceptions/Handler.php#L165