### PR TITLE
Add exception throw for import failures

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -11,7 +11,9 @@ try {
     window.$ = window.jQuery = require('jquery');
 
     require('bootstrap-sass');
-} catch (e) {}
+} catch (e) {
+    throw e;
+}
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests


### PR DESCRIPTION
It would save a lot of debugging time to add an exception around the import's try-catch block. I realized this when seeing that upgrading to Bootstrap 4 produced silent failures.