### PR TITLE
Disable converting exceptions to HttpException when app is in debug mode

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,4 +50,19 @@ class Handler extends ExceptionHandler
     {
         return parent::render($request, $exception);
     }
+
+    /**
+     * Prepare exception for rendering.
+     *
+     * @param  \Exception  $e
+     * @return \Exception
+     */
+    protected function prepareException(Exception $e)
+    {
+        if (config('app.debug')) {
+            return $e;
+        }
+
+        return parent::prepareException($e);
+    }
 }


### PR DESCRIPTION
I've recently run into an issue, where instead of displaying a TokenMismatchException, Laravel converted it into an HttpException, leaving us without a useful error message during development.

This PR is to provide a sensible default, which skips converting TokenMismatchExceptions, AuthorizationExceptions and ModelNotFoundExceptions to HttpExceptions when config('app.debug') is true.