### PR TITLE
[5.5] Match mockery/mockery with laravel/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "filp/whoops": "~2.0",
         "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "0.9.*",
+        "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~6.0"
     },
     "autoload": {


### PR DESCRIPTION
Match `mockery/mockery` with [laravel/framework](https://github.com/laravel/framework/blob/5.5/composer.json#L78)