### PR TITLE
Set default driver to null

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -11,11 +11,11 @@ return [
     | framework when an event needs to be broadcast. You may set this to
     | any of the connections defined in the "connections" array below.
     |
-    | Supported: "pusher", "redis", "log"
+    | Supported: "pusher", "redis", "log", "null"
     |
     */
 
-    'default' => env('BROADCAST_DRIVER', 'pusher'),
+    'default' => env('BROADCAST_DRIVER', 'null'),
 
     /*
     |--------------------------------------------------------------------------
@@ -47,6 +47,10 @@ return [
 
         'log' => [
             'driver' => 'log',
+        ],
+        
+        'null' => [
+            'driver' => 'null',
         ],
 
     ],


### PR DESCRIPTION
When upgrading from 5.2 to 5.3 and adding the `BroadcastServiceProvider` to the `app/Providers` directory running the app will throw the error below because pusher is the default driver in `config/broadcasing.php` in 5.2 and not a dependency by default.

```
FatalErrorException in BroadcastManager.php line 124:
Class 'Pusher' not found
```

This PR fixes the need to modify the config to prevent this error.

I have run my app using Laravel 5.2 with the default broadcasting driver as `null` and did not experience any errors.