### PR TITLE
Don't show progress for production run command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
         "axios": "^0.16.2",


### PR DESCRIPTION
Mix's build output gets quite noisy, particularly in static build output (CI/CD, Jenkins, etc.) and makes the Forge deployment log in particular quiet slow. I've seen a few beach balls tracking down how to limit this output.