### PR TITLE
Update AWS environment variable defaults

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -57,9 +57,9 @@ return [
 
         's3' => [
             'driver' => 's3',
-            'key' => env('AWS_KEY'),
-            'secret' => env('AWS_SECRET'),
-            'region' => env('AWS_REGION'),
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
         ],
 


### PR DESCRIPTION
Aids those users that are using the AWS CLI tools, by matching the `filesystems.disks.s3`
configuration values with those that would be set in a user's native environment already.

AWS Documentation [reference](http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html).

Resolves laravel/internals#778