### PR TITLE
Support custom URLs for AWS storage

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -57,11 +57,11 @@ return [
 
         's3' => [
             'driver' => 's3',
-            'url' => env('AWS_URL'),
             'key' => env('AWS_KEY'),
             'secret' => env('AWS_SECRET'),
             'region' => env('AWS_REGION'),
             'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
         ],
 
     ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -57,6 +57,7 @@ return [
 
         's3' => [
             'driver' => 's3',
+            'url' => env('AWS_URL'),
             'key' => env('AWS_KEY'),
             'secret' => env('AWS_SECRET'),
             'region' => env('AWS_REGION'),


### PR DESCRIPTION
Add the `url` property to the configuration of the `s3` driver. This requires the laravel/framework#22037 pull-request to be merged.