### PR TITLE
Add invalid data translatable string

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -87,6 +87,7 @@ return [
     'unique'               => 'The :attribute has already been taken.',
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',
+    'invalid_data_given'   => 'The given data was invalid.',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The default ValidationException message should be translatable.

I also send a pull request on laravel/framework repo with the localization function on the constructor of ValidationException (Link: https://github.com/laravel/framework/pull/22045)