### PR TITLE
Fix cookie name for Edge 14/15

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -124,7 +124,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        str_slug(env('APP_NAME', 'laravel'), '_').'_session'
+        str_slug(env('APP_NAME', 'laravel'), '-').'-session'
     ),
 
     /*


### PR DESCRIPTION
Edge has issues with session names containing underscores in certain versions. so replacing the underscores with a hyphen should resolve this issue.