### PR TITLE
Prevent register controller to be accessible for guest users

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -36,7 +36,7 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $this->middleware('auth');
     }
 
     /**


### PR DESCRIPTION
In the case of the auth controller are used for backend,
it's a better solution to allow register form only for authentificated users.

Otherwise, this allow an anonymous user to create an account and access to the backend.

I think that it's a better to be more restrictive :)