### PR TITLE
Allow register controller only in local environment

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -36,7 +36,7 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $this->middleware('auth');
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\User;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
 
@@ -36,7 +37,10 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        if(App::isLocal())
+            $this->middleware('guest');
+        else
+            $this->middleware('auth');
     }
 
     /**


### PR DESCRIPTION
In the case of the auth controller are used for backend,
it's a better solution to allow register form only for authentificated users.

Otherwise, this allow an anonymous user to create an account and access to the backend.

I think that it's a better to be more restrictive :)