### PR TITLE
Iterate through routes folders for route files and register them

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use DirectoryIterator;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
@@ -39,6 +40,8 @@ class RouteServiceProvider extends ServiceProvider
 
         $this->mapWebRoutes();
 
+        $this->mapDir('web');
+
         //
     }
 
@@ -52,8 +55,8 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapWebRoutes()
     {
         Route::middleware('web')
-             ->namespace($this->namespace)
-             ->group(base_path('routes/web.php'));
+            ->namespace($this->namespace)
+            ->group(base_path('routes/web.php'));
     }
 
     /**
@@ -66,8 +69,64 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-             ->middleware('api')
-             ->namespace($this->namespace)
-             ->group(base_path('routes/api.php'));
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(base_path('routes/api.php'));
     }
+
+    /**
+     * Parser for folders for route files.
+     *
+     * @param $name
+     * @param string $prefix
+     */
+    protected function mapDir($name, $prefix = '')
+    {
+        $path = base_path('routes/' . $name);
+        $iterator = new DirectoryIterator($path);
+        $this->registerRoutesDirectory($iterator, $name, $prefix);
+    }
+
+    /**
+     * Register the files in  folder
+     *
+     * @param DirectoryIterator $iterator
+     * @param $middleware
+     * @param string $prefix
+     */
+    protected function registerRoutesDirectory(DirectoryIterator $iterator, $middleware, $prefix = '')
+    {
+        foreach ($iterator AS $item) {
+            switch (true) {
+                case $item->isDot():
+                    continue;
+                    break;
+                case $item->isDir():
+                    $this->registerRoutesDirectory(new DirectoryIterator($item->getPath() . '/' . $item->getFilename()), $middleware, $prefix);
+                    break;
+                default:
+                    $this->registerRoutesFile($item, $middleware, $prefix);
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Register the specific Route file.
+     *
+     * @param DirectoryIterator $iterator
+     * @param $middleware
+     * @param string $prefix
+     */
+    protected function registerRoutesFile(DirectoryIterator $iterator, $middleware = '', $prefix = '')
+    {
+        Route::group([
+            'middleware' => $middleware,
+            'namespace' => $this->namespace,
+            'prefix' => $prefix
+        ], function () use ($iterator) {
+            require $iterator->getPathname();
+        });
+    }
+
 }

--- a/routes/web/home.php
+++ b/routes/web/home.php
@@ -1,0 +1,5 @@
+<?php
+
+Route::get('/home/', function () {
+    return redirect('/');
+});


### PR DESCRIPTION
I just thought, that it would be helpful to have a logic which includes route php files which will be automatically parsed. If you sometimes have a web.php file with a lot of Routes, then you can easiy lose sight on it, so why don't we split the web.php into more files.