### PR TITLE
Ignore the MacOS .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.DS_Store


### PR DESCRIPTION
It's annoying when i create laravel project, then push to git and it contains .DS_Store files.