### PR TITLE
[5.6] Adds nunomaduro/collision on composer require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "filp/whoops": "~2.0",
+        "nunomaduro/collision": "~1.1",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~6.0"


### PR DESCRIPTION
This PR proposes the addition of the package [Collision](https://github.com/nunomaduro/collision) as **dev** dependency of every Laravel app. Collision is an detailed & intuitive error handler framework for PHP **console** applications, and includes an adapter/service-provider for **Laravel**.

The package project is [https://github.com/nunomaduro/collision](https://github.com/nunomaduro/collision) and bellow is an screenshot example.

![example-2](https://user-images.githubusercontent.com/5457236/34083987-95558fa8-e379-11e7-9eb8-77b7055027c5.png)
Those are the Collision **dependencies**:

```json
    "require": {
        "php": "^7.1",
        "filp/whoops": "^2.1.4",
        "symfony/console": "~2.8|~3.3|~4.0"
    }
```

Concerning the integration Laravel, If the exception implements the  `Symfony\Component\Console\Exception\ExceptionInterface`, [Collision](https://github.com/nunomaduro/collision) still uses the default `\Illuminate\Contracts\Debug\ExceptionHandler::renderForConsole` method:

<img width="100%" alt="screenshot 2017-12-17 22 31 30" src="https://user-images.githubusercontent.com/5457236/34084031-122b292a-e37a-11e7-96e4-240c8d6bab72.png">
Otherwise Collision will render the exception details itself giving an detailed explanation of the problem:

<img width="100%" alt="screenshot 2017-12-17 22 57 56" src="https://user-images.githubusercontent.com/5457236/34084288-c668d218-e37d-11e7-8d87-07ff733d0a31.png">
If someone needs details about package or about how it works behind the scenes please don't hesitate to ask.