### PR TITLE
Reduce Hash computations during tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,7 +17,7 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
-        
+
         Hash::setRounds(5);
 
         return $app;

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -16,6 +17,8 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        
+        Hash::setRounds(5);
 
         return $app;
     }


### PR DESCRIPTION
This is an idea that was originally suggested by @jrmadsen67 and mentioned by @daylerees here https://driesvints.com/blog/two-tips-to-speedup-your-laravel-tests/

Adding this to some legacy testing suites reduced my testing time down by 34% - which is fairly significant for one line of code.

Not everyone will get this level of performance gain. It will largely depend if you are seeding new users (and there using `bcrypt`) and/or if you are using database transactions etc.

But adding this to the app framework seems like a sensible default for testing, as there is no benefit is wasting time computing harder hashes during tests - even if it is only a handful of times.