### PR TITLE
Trusted proxy to version 4.0 for Laravel 5.6

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -15,15 +15,9 @@ class TrustProxies extends Middleware
     protected $proxies;
 
     /**
-     * The current proxy header mappings.
+     * The headers used to detect proxies.
      *
      * @var array
      */
-    protected $headers = [
-        Request::HEADER_FORWARDED => 'FORWARDED',
-        Request::HEADER_X_FORWARDED_FOR => 'X_FORWARDED_FOR',
-        Request::HEADER_X_FORWARDED_HOST => 'X_FORWARDED_HOST',
-        Request::HEADER_X_FORWARDED_PORT => 'X_FORWARDED_PORT',
-        Request::HEADER_X_FORWARDED_PROTO => 'X_FORWARDED_PROTO',
-    ];
+    protected $headers = Request::HEADER_X_FORWARDED_FOR;
 }

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -19,5 +19,5 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR;
+    protected $headers = Request::HEADER_X_FORWARDED_ALL;
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.1.0",
-        "fideloper/proxy": "~3.3",
+        "fideloper/proxy": "~4.0",
         "laravel/framework": "5.6.*",
         "laravel/tinker": "~1.0"
     },


### PR DESCRIPTION
Trusted proxy now either trusts the `Forwarded` header, or all `X-Forwarded-*` headers to determine the correct client info when a proxy is used.

Symfony 4 no longer supports using custom headers. This takes away an unfortunate feature, but simplifies the package a bit.