### PR TITLE
[5.6] Phpunit pretty result printer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "nunomaduro/collision": "~1.1",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~6.0",
+        "codedungeon/phpunit-result-printer": "~0.4"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>


### PR DESCRIPTION
With this PR, I want to propose a better output for our tests with [`mikeerickson/phpunit-pretty-result-printer`](https://github.com/mikeerickson/phpunit-pretty-result-printer). In the same way we do with `Whoops`, for better output in the Browser, this package adds a better output for tests in the terminal.
Here are screenshots comparing:
- Before:
![captura de tela de 2017-12-23 10-52-28](https://user-images.githubusercontent.com/16328050/34319682-645de7ec-e7cf-11e7-9eb1-91b0dd08291f.png)
- After:
![captura de tela de 2017-12-23 10-52-55](https://user-images.githubusercontent.com/16328050/34319685-7523751a-e7cf-11e7-8204-542b1bb0d3ff.png)

I just need to add:
```sh
codedungeon/phpunit-result-printer
```
in our dev-dependencies in `composer.json` and
 ```xml
printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer"
```
in the `phpunit` tag inside `phpunit.xml`.

Hope you find it interesting :smile: 

