### PR TITLE
[5.6] Detailed PHPUnit Printer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require-dev": {
         "filp/whoops": "~2.0",
         "fzaninotto/faker": "~1.4",
+        "limedeck/phpunit-detailed-printer": "^3.1",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~6.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         printerClass="LimeDeck\Testing\Printer"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>


### PR DESCRIPTION
Alternative to: #4523

Initially @carusogabriel suggested to integrate PHPUnit Pretty Result Printer. But as revealed after some integrations in different projects it has issues:
- long namespaces cutted down (only ending part is visible) what makes understanding whats broken more complicated;
- it doesn't show what test is failed, it only shows how much success\fail tests were in Test Case.

Then @brunogaspar shared link on another great tool: https://github.com/LimeDeck/phpunit-detailed-printer which I'm proposing to add instead of solution described above.

Benefits of PHPUnit Detailed Printer:
- Displays fully qualified namespace of Test Case.
- Displays each test from Test Case in human readable format by converting `function it_can_fill_body_attribute` to `It can fill body attribute`.
- Displays execution time for each test with highlighting slow tests.

I don't know if it will be good to have such detailed information in projects with thousands of tests, but it works great in most of the cases by giving you much more overview about your tests.

Thanks to @carusogabriel and @brunogaspar for the suggestions. Even if this wouldn't be added to the core - this will be helpful starting point to add this manually to the project.

And here is a screenshot of how it will look like:

![detailed-printer](https://raw.githubusercontent.com/LimeDeck/phpunit-detailed-printer/master/screenshots/phpunit-pretty.png "PHPUnit output with this printer.")