### PR TITLE
Make welcome.blade.php use config for name

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Laravel</title>
+        <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">
@@ -79,7 +79,7 @@
 
             <div class="content">
                 <div class="title m-b-md">
-                    Laravel
+                    {{ config('app.name', 'Laravel') }}
                 </div>
 
                 <div class="links">


### PR DESCRIPTION
We had some users at the IRC channel that were wondering why config('app.name') wasn't working in `app.blade.php` generated by `php artisan make:auth`.

This will make it so that `welcome.blade.php` also uses the config file for the name.