### PR TITLE
Fix return typo

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,7 +44,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
Recently, I ran [`PHPStan`](https://github.com/phpstan/phpstan) in my application, and it detects this miss typo. Makes sense, as we are calling `parent`,and in `Illuminate/Foundation/Exceptions/Handler::render` [we return](https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/Exceptions/Handler.php#L165) `\Symfony\Component\HttpFoundation\Response`