### PR TITLE
Remove autoload for database factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     },
     "autoload": {
         "classmap": [
-            "database/seeds",
-            "database/factories"
+            "database/seeds"
         ],
         "psr-4": {
             "App\\": "app/"


### PR DESCRIPTION
Files in this directory (`database/factories`) are loaded by the framework itself. There is no need to generate a classmap for them.  (https://github.com/laravel/framework/blob/5.5/src/Illuminate/Database/Eloquent/Factory.php#L202)