### PR TITLE
Remove alias "Eloquent"

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -203,7 +203,6 @@ return [
         'Cookie' => Illuminate\Support\Facades\Cookie::class,
         'Crypt' => Illuminate\Support\Facades\Crypt::class,
         'DB' => Illuminate\Support\Facades\DB::class,
-        'Eloquent' => Illuminate\Database\Eloquent\Model::class,
         'Event' => Illuminate\Support\Facades\Event::class,
         'File' => Illuminate\Support\Facades\File::class,
         'Gate' => Illuminate\Support\Facades\Gate::class,


### PR DESCRIPTION
The class `Illuminate\Database\Eloquent\Model` is abstract, so when you are trying call something static, it calls `__callStatic` method which makes `(new static)` and cause an exception 
```Cannot instantiate abstract class Illuminate\Database\Eloquent\Model```
I suggest removing this alias