### PR TITLE
Add force flag to ensure phpunit will overwrite environment variables

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,9 +23,9 @@
         </whitelist>
     </filter>
     <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="APP_ENV" value="testing" force="true"/>
+        <env name="CACHE_DRIVER" value="array" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
+        <env name="QUEUE_DRIVER" value="sync" force="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
This is the solution for a problem I faced today when setting up my testing environment for a newly created Laravel project.

Main issue and solution described here: [https://laravel.io/forum/laravel-possibly-overwriting-phpunit-env-variables](https://laravel.io/forum/laravel-possibly-overwriting-phpunit-env-variables)

Also I did some basic proof by creating a fresh install:

First I set APP_ENV=local

```
export APP_ENV=local
```

With the non-modified phpunit.xml file

```
➜  blog git:(master) ✗ cat phpunit.xml | grep APP_ENV
        <env name="APP_ENV" value="testing"/>
```

I ran phpunit with the current values and die at the first test printing APP_ENV

```
➜  blog git:(master) ✗ vendor/bin/phpunit
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

local%
```
Now I do the same but with the force key

```
➜  blog git:(master) ✗ cat phpunit.xml | grep APP_ENV
        <env name="APP_ENV" value="testing" force="true"/>
➜  blog git:(master) ✗ vendor/bin/phpunit
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

testing%

```

I had the same behaviour running phpunit on my local (with the ENV set beforehand) and on my docker container.

The thread that adds the force flag is: [https://github.com/sebastianbergmann/phpunit/issues/2353](https://github.com/sebastianbergmann/phpunit/issues/2353)

Thanks.
