### PR TITLE
Auto detect resource root

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "axios": "^0.17",
         "bootstrap-sass": "^3.3.7",
         "cross-env": "^5.1",
+        "dotenv": "^4.0.0",
         "jquery": "^3.2",
         "laravel-mix": "^1.0",
         "lodash": "^4.17.4",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,5 +1,11 @@
 let mix = require('laravel-mix');
 
+/** Load .env file */
+require('dotenv').config();
+
+/** Set resource root to APP_URL */
+mix.setResourceRoot(process.env.APP_URL.replace(/\/$/, '') + '/');
+
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management


### PR DESCRIPTION
Since we know the absolute app URL (as it is defined in the .env file)  
Why not use it in laravel-mix.  
I personally, find this very useful, As I develop in windows using [WAMP](http://www.wampserver.com/en/), and rarely use virtual hosts, This results in project urls that look like `127.0.0.1/Projects/foo/public`.  
I think this PR can be very beneficial.