### PR TITLE
Revert "[5.6] Use composer platform config"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "^7.1.3",
+        "php": ">=7.1.3",
         "fideloper/proxy": "~4.0",
         "laravel/framework": "5.6.*",
         "laravel/tinker": "~1.0"
@@ -16,7 +16,7 @@
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "~1.1",
         "phpunit/phpunit": "~7.0",
-        "symfony/thanks": "~1.0"
+        "symfony/thanks": "^1.0"
     },
     "autoload": {
         "classmap": [
@@ -51,11 +51,10 @@
         ]
     },
     "config": {
-        "platform": {
-            "php": "7.1.3"
-        },
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Reverts laravel/laravel#4574

Sorry, but I dont think this was given the correct level of discussion regarding the huge unintended side effects this PR is going to have.

Essentially we are now permanently faking composer to pretend that every Laravel install is running on PHP `7.1.3` out of the box.

This is going to artifically limit everyone as packages start increasing their dependencies to PHP `>=7.1.4`, because the default Laravel install will *never* get those packages. And it will be a **silent** failure - because composer will just grab the older versions without complaining.

Of course - people are free to edit their `composer.json` with the right version. But then they need to do this. every. single. time.

Plus - when you do `composer create-project laravel/laravel blog` - that will only install 7.1.3 packages initially. You then need to go into `composer.json` and set your PHP version manually (to say `7.2.0`), then run `composer update` every. single. project. to make sure you have the "correct" versions at the start.

> If someone generates a lock file on PHP 7.2, then tries to deploy to a sever running PHP 7.1, then they're in for a mess 

Anyone who develops for a PHP7.1 server on a PHP7.2 dev box is in for a mess regardless. All it takes is the use of one PHP7.2 feature or syntax in their application, and it'll break on production anyway. I dont understand why we are protecting a small amount of people who develop on an incompabable version of PHP to their production, vs the large amount of people who do the right thing. Those that need this feature can just add it themselves to `composer.json`. 

We've already got 2 people raising issues in the original PR, and this hasnt even been tagged yet.

Finally, and this is my biggest concern - the **real** side effects of this wont be felt for 6-12 months. This is a **silent** failure to stick to PHP7.1 - it is not obvious, and people will miss this every time. We would have to add a large warning to the Laravel docs, and to the installer itself, telling people to manually set the `composer.json`. And they need to remember to update it if/when they update their PHP environments.

Personally I think just let composer do it's own thing - and leave the artifical constrant to people who actually need it.