### PR TITLE
Excluded from saving the repository *orig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+*.orig


### PR DESCRIPTION
Files with the extension `*.orig` are created when trying to combine problem commits.