### PR TITLE
[5.6] Add nunamaduro\collision Listener to default phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,4 +28,7 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
     </php>
+    <listeners>
+        <listener class="NunoMaduro\Collision\Adapters\Phpunit\Listener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Hey all,

Since `nunamaduro\collision` is now included by default in Laravel 5.6 (and recently updated to `~2.0`, which supports `phpunit ~7.0`), I thought it would make sense to add it to the phpunit configuration by default, so everyone gets those sweet exceptions and stack traces when running tests.

The reason I've sent this PR to the `master` branch instead of `5.6` is because it stops `phpunit` from running when `nunamaduro\collision` is still at version `~1.1`, and I assume many early adopters still have that version set in their `composer.json` file.

I've tested this change against the latest `master` commit after running `composer install` and the configuration change seems to work fine and causes no issues.

Example screenshot:
![phpunit-collision](https://user-images.githubusercontent.com/7504556/36473012-a29b979a-16f3-11e8-8260-2cecf209687a.jpg)

I understand if there's hesitation to add yet another default setting based on a dependency not everyone might use, but I think it's a sensible decision given that the default Laravel install already installs `phpunit` and `collision`.

Thanks in advance!
