### PR TITLE
[5.6] Remove unnecessary package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "~2.0",
-        "phpunit/phpunit": "~7.0",
-        "symfony/thanks": "^1.0"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
The `thanks` package is not needed to develop kickass Laravel apps.