### PR TITLE
[5.6] Use semver caret operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=7.1.3",
-        "fideloper/proxy": "~4.0",
+        "php": "^7.1.3",
+        "fideloper/proxy": "^4.0",
         "laravel/framework": "5.6.*",
-        "laravel/tinker": "~1.0"
+        "laravel/tinker": "^1.0"
     },
     "require-dev": {
-        "filp/whoops": "~2.0",
-        "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "~1.0",
-        "nunomaduro/collision": "~2.0",
-        "phpunit/phpunit": "~7.0"
+        "filp/whoops": "^2.0",
+        "fzaninotto/faker": "^1.4",
+        "mockery/mockery": "^1.0",
+        "nunomaduro/collision": "^2.0",
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
The only semantic change here is that the PHP version is now bounded in the same way it is for the framework repo.