### PR TITLE
No closure based route by default to allow Route caching

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,4 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::middleware('auth:api')->get('/user', 'APIController@getUser');


### PR DESCRIPTION
Many projects do not touch API routes at all and this prevents Route caching on the server without removing it.