### PR TITLE
[5.6] Improving page load

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,7 +1,4 @@
 
-// Fonts
-@import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
-
 // Variables
 @import "variables";
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,6 +8,7 @@
         <title>Laravel</title>
 
         <!-- Fonts -->
+        <link rel="dns-prefetch" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">
 
         <!-- Styles -->


### PR DESCRIPTION
The fonts requested via the Google stylesheet take time to load and a fair amount of time to lookup the DNS. So prefetch the DNS for the font files.
If you load the Google CSS file via the `@import` in app.css, then you have to wait for the CSS file to be downloaded and parsed before the file starts downloading. The Google CSS file should be downloaded in the HTML so that it can be downloaded in parallel with app.css. (Another option would just be to preload the Google Stylesheet from the HTML and leave the CSS reference in app.css)

See corresponding PR in laravel/framework: https://github.com/laravel/framework/pull/23479