### PR TITLE
[5.6] Autoload migrations as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "autoload": {
         "classmap": [
             "database/seeds",
-            "database/factories"
+            "database/factories",
+            "database/migrations"
         ],
         "psr-4": {
             "App\\": "app/"
@@ -33,17 +34,14 @@
     },
     "extra": {
         "laravel": {
-            "dont-discover": [
-            ]
+            "dont-discover": []
         }
     },
     "scripts": {
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
-        "post-create-project-cmd": [
-            "@php artisan key:generate"
-        ],
+        "post-create-project-cmd": ["@php artisan key:generate"],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover"


### PR DESCRIPTION
Before this PR, running `php artisan make:migration create_users_table` more than once would create duplicates of the users table migration  

This is apparently because the migrations are not autoloaded and the `ensureMigrationDoesntAlreadyExist` method of `Illuminate\Database\Migrations\ MigrationCreator::class` never throws am exception even when the class exists.

This Pr will autoload the database/migrations to fix that
