### PR TITLE
[5.6] Set MAIL_DRIVER to array in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,5 +27,6 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="MAIL_DRIVER" value="array"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Set the array driver as a default for testing to avoid sending emails with smtp the default driver which slows down tests