### PR TITLE
The default queue "driver" is actually a "connection"

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -4,12 +4,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default Queue Driver
+    | Default Queue Connection
     |--------------------------------------------------------------------------
     |
     | Laravel's queue API supports an assortment of back-ends via a single
     | API, giving you convenient access to each back-end using the same
-    | syntax for each one. Here you may set the default queue driver.
+    | syntax for each one. Here you may set the default queue connection.
     |
     | Supported: "sync", "database", "beanstalkd", "sqs", "redis", "null"
     |


### PR DESCRIPTION
The description here has bothered me for a while, because it is kind of misleading.

The `QUEUE_DRIVER` environment variable perhaps also needs changing to `QUEUE_CONNECTION`, but I'm not sure if that is just too engrained in legacy systems now? I can change that on this PR if you agree, and also the matching `QUEUE_DRIVER=sync` in `.env.example`.