### PR TITLE
Update Bootstrap.js

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -30,7 +30,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
  * a simple convenience so we don't have to attach every token manually.
  */
 
-let token = document.head.querySelector('meta[name="csrf-token"]');
+let token = document.querySelector('meta[name="csrf-token"]');
 
 if (token) {
     window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;


### PR DESCRIPTION
Hi Taylor, I have found an issue. if you run document.head.querySelector('meta[name="csrf-token"]') on the console, you get null.
It wouldn't be document.querySelector('meta[name="csrf-token"]')