### PR TITLE
[5.6] Update handler

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -29,8 +29,6 @@ class Handler extends ExceptionHandler
     /**
      * Report or log an exception.
      *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
      * @param  \Exception  $exception
      * @return void
      */


### PR DESCRIPTION
remove comment suggesting to send reports to bug trackers in this method.

with the new improvements to the logging system, I think we no longer want to encourage this method of handling errors.