### PR TITLE
[5.6] Update app.php to respect PHP date.timezone

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -65,7 +65,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => env('APP_TIMEZONE', date_default_timezone_get()),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This change updates `app.php` to use the following line instead of setting the timezone to UTC by default.

`'timezone' => env('APP_TIMEZONE', date_default_timezone_get())`

Fix for: https://github.com/laravel/framework/issues/23743

The end result here is the same. Laravel would respect the server's timezone setting, but if it was not set, the default is UTC anyway.