### PR TITLE
[5.6] Remove "stopOnFailure" from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+         processIsolation="false">
     <testsuites>
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>


### PR DESCRIPTION
"stopOnFailure" is `false` [by default](https://phpunit.de/manual/current/en/appendixes.configuration.html).