### PR TITLE
Add SES_REGION to local environment file

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -22,7 +22,7 @@ return [
     'ses' => [
         'key' => env('SES_KEY'),
         'secret' => env('SES_SECRET'),
-        'region' => 'us-east-1',
+        'region' => env('SES_REGION','us-east-1'),
     ],
 
     'sparkpost' => [

--- a/config/services.php
+++ b/config/services.php
@@ -22,7 +22,7 @@ return [
     'ses' => [
         'key' => env('SES_KEY'),
         'secret' => env('SES_SECRET'),
-        'region' => env('SES_REGION','us-east-1'),
+        'region' => env('SES_REGION', 'us-east-1'),
     ],
 
     'sparkpost' => [


### PR DESCRIPTION
The region used by SES was hard-coded into the config file, when all other values were set as environment variables. Tweaked to keep the region consistent with other config options