### PR TITLE
[5.7] Maintain ANSI output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "@php artisan package:discover --ansi"
         ]
     },
     "config": {


### PR DESCRIPTION
Maintain ANSI output when `artisan package:discover` is run through composer