### PR TITLE
[5.6] Set bcrypt rounds using the hashing config

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -29,7 +29,7 @@ return [
     */
 
     'bcrypt' => [
-        'rounds' => 10,
+        'rounds' => env('BCRYPT_ROUNDS', 10),
     ],
 
     /*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -17,8 +16,6 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
-
-        Hash::driver('bcrypt')->setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
This allows to maintain the `tests/CreatesApplication` clean and uses a hashing option dedicated solely for that purpose.