### PR TITLE
Missing throws tag

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -31,6 +31,8 @@ class Handler extends ExceptionHandler
      *
      * @param  \Exception  $exception
      * @return void
+     *
+     * @throws \Exception
      */
     public function report(Exception $exception)
     {


### PR DESCRIPTION
PHPDoc comment doesn't contain all necessary @throws tag(s)