### PR TITLE
Fix query csrf-token of meta tag in head.

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -30,7 +30,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
  * a simple convenience so we don't have to attach every token manually.
  */
 
-let token = document.head.querySelector('meta[name="csrf-token"]');
+let token = document.querySelector('meta[name="csrf-token"]');
 
 if (token) {
     window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;


### PR DESCRIPTION
## What happened ?
An error (like below) is displayed in browser console.
> CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token 

## Why ?
Because a query to get csrf-token is failed. 
`document.head.querySelector('meta[name="csrf-token"]')` return null.

```bootstrap.js
let token = document.head.querySelector('meta[name="csrf-token"]');

if (token) {
    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
} else {
    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
}
```

## How to fix.
Fix the query to get csrf-token.
`document.querySelector('meta[name="csrf-token"]')` return `csrf-token`.

```bootstrap.js
let token = document.querySelector('meta[name="csrf-token"]');

if (token) {
    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
} else {
    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
}
```
