### PR TITLE
Feature dynamic home route

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
@@ -18,7 +19,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/home');
+            return Redirect::home();
         }
 
         return $next($request);

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
@@ -19,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return Redirect::home();
+            return redirect('/home');
         }
 
         return $next($request);

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,4 +13,4 @@
 
 Route::get('/', function () {
     return view('welcome');
-});
+})->name('home');


### PR DESCRIPTION
If we define a default home route we can avoid the necessity of the hardcoded route in `redirect('/home')` and also avoid having a nonexistent route in the code.