### PR TITLE
Configure axios headers for Authorization via API

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -38,6 +38,14 @@ if (token) {
     console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
 }
 
+
+// let api_token = document.head.querySelector('meta[name="api-token"]');
+
+// if (api_token) {
+//     window.axios.defaults.headers.common['Authorization'] = 'Bearer ' + api_token.content;
+// }
+
+
 /**
  * Echo exposes an expressive API for subscribing to channels and listening
  * for events that are broadcast by Laravel. Echo and event broadcasting


### PR DESCRIPTION
This will give a pre-configured axios headers with `api_token`.
Since the `users` table does not have an `api_token` field we have left this configuration commented.
All the we have to to do is add the `api_token` field to the `users` table and we are all set to use axios with authorized API requests.