### PR TITLE
[5.6] Use seperate cache database for Redis

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -70,7 +70,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => 'cache',
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -112,7 +112,14 @@ return [
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
-            'database' => 0,
+            'database' => env('REDIS_DB', 0),
+        ],
+
+        'cache' => [
+            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'password' => env('REDIS_PASSWORD', null),
+            'port' => env('REDIS_PORT', 6379),
+            'database' => env('REDIS_CACHE_DB', 1),
         ],
 
     ],


### PR DESCRIPTION
The cache is often flushed (eg. on deployments). When using redis for cache and other databases, this will have the side-effect to also clear sessions/queues/horizon metrics etc.


See also:
https://github.com/laravel/framework/issues/20655
https://github.com/laravel/horizon/issues/72
https://github.com/laravel/horizon/issues/171
https://stackoverflow.com/questions/45620872/how-to-create-another-redis-server-instance-on-same-server-managed-by-laravel-f/46869372#46869372

You could argue that it's safer / more performant to use a seperate database (or better, instance) for each task, but I think cache is the only one that get's regularly flushed, right?