### PR TITLE
Added translations for ResetPassword notification.

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -18,7 +18,7 @@ return [
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that e-mail address.",
-    
+
     'mail' => [
         'intro' => 'You are receiving this email because we received a password reset request for your account.',
         'button' => 'Reset Password',

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -18,5 +18,11 @@ return [
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that e-mail address.",
+    
+    'mail' => [
+        'intro' => 'You are receiving this email because we received a password reset request for your account.',
+        'button' => 'Reset Password',
+        'disclaimer' => 'If you did not request a password reset, no further action is required.'
+    ]
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -22,7 +22,7 @@ return [
     'mail' => [
         'intro' => 'You are receiving this email because we received a password reset request for your account.',
         'button' => 'Reset Password',
-        'disclaimer' => 'If you did not request a password reset, no further action is required.'
+        'disclaimer' => 'If you did not request a password reset, no further action is required.',
     ]
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -23,6 +23,6 @@ return [
         'intro' => 'You are receiving this email because we received a password reset request for your account.',
         'button' => 'Reset Password',
         'disclaimer' => 'If you did not request a password reset, no further action is required.',
-    ]
+    ],
 
 ];


### PR DESCRIPTION
Added translations for ResetPassword notification.

This allows developers to translate the default copy in the Reset Password mail.

Related: https://github.com/laravel/framework/pull/24328