### PR TITLE
Configuration for sending logs to specific slack channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -57,6 +57,7 @@ return [
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
             'level' => 'critical',
+            'channel' => env('LOG_SLACK_CHANNEL', ''),
         ],
 
         'stderr' => [


### PR DESCRIPTION
Added a configuration parameter in logging.php, so that it can be set from .env file to send logs to different channels.