### PR TITLE
Add currency settings to config/app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -95,6 +95,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Currency Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application currency determines the default currency that will be used
+    | by the Cachier service, if used. You can use ISO 4217 currency code or
+    | any other code or symbol you want.
+    |
+    | The format can either be a callable function, or null for default
+    |
+    */
+
+    'currency' => [
+
+        'code'      => 'USD',
+        'symbol'    => '$',
+        'format'    => null,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Encryption Key
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
I think currency settings should be in the config. If not in `laravel/laravel`, at least in `laravel/cashier`.

It will be easier to automatically set `Cashier::useCurrency()` in `CashierServiceProvider::boot()`, also easier to add it as a custom `VueJS` property `VueJS`  in `Spark`.

If rejected, please indicate if it could be merged if I create a PR to `laravel/cashier` adding a config file which will have to be published to allow user to set currency.