### PR TITLE
Remove unused constant LARAVEL_START

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,8 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-define('LARAVEL_START', microtime(true));
-
 /*
 |--------------------------------------------------------------------------
 | Register The Auto Loader

--- a/public/index.php
+++ b/public/index.php
@@ -7,8 +7,6 @@
  * @author   Taylor Otwell <taylor@laravel.com>
  */
 
-define('LARAVEL_START', microtime(true));
-
 /*
 |--------------------------------------------------------------------------
 | Register The Auto Loader


### PR DESCRIPTION
It's not used.
Also the start time is available globally via $_SERVER['REQUEST_TIME_FLOAT'] if needed.