### PR TITLE
Specify required PHP extenstions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,13 @@
     "type": "project",
     "require": {
         "php": "^7.1.3",
+        "ext-ctype":"*",
+        "ext-json":"*",
+        "ext-mbstring":"*",
+        "ext-openssl":"*",
+        "ext-PDO":"*",
+        "ext-tokenizer":"*",
+        "ext-xml":"*",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.6.*",
         "laravel/tinker": "^1.0"


### PR DESCRIPTION
A bunch of PHP extensions are required for Laravel as specified in server requirements (https://laravel.com/docs/installation#server-requirements).

We can specify them in the require config as a Platform packages (https://getcomposer.org/doc/01-basic-usage.md#platform-packages) to provide instant feedback while installing the framework.