### PR TITLE
[5.7] Add a custom generator.php config file.

### DIFF
--- a/config/generator.php
+++ b/config/generator.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generator paths
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the namespaces that will be used when generating
+    | classes using artisan make:* command.
+    | If no namespace is specified, a default will be used.
+    |
+    | Possible values are Auth, Channel, Command, Controller, Event, Exception,
+    |        Factory, Job, Listener, Mail, Middleware, Model, Notification,
+    |        Observer, Policy, Provider, Request, Resource, Rule & Test.
+    |
+    | Only Migration namespace cannot be overridden.
+    */
+
+    // 'Model' => 'App',
+    // 'Controller' => 'Http\Controllers',
+];


### PR DESCRIPTION
Let the user override the namespaces, for all generator commands (`artisa make:*`).

For instance if `'Model'` is set to `'App\Models'`, all models generated will be created in the `\App\Models` namespaces, which means in most setup in `app/Models`

If not value is set, the path will use the fallback default set in the custom generator command.

---

This PR requires https://github.com/laravel/laravel/pull/4679