### PR TITLE
[5.7] Allow to set namespaces for each generated class

### DIFF
--- a/config/generator.php
+++ b/config/generator.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generator paths
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the namespaces that will be used when generating
+    | classes using artisan make:* command.
+    | If no namespace is specified, a default will be used.
+    |
+    | Possible values are Channel, Command, Controller, Event, Exception,
+    |        Factory, Job, Listener, Mail, Middleware, Model, Notification,
+    |        Observer, Policy, Provider, Request, Resource, Rule & Test.
+    |
+    | Only Migration namespace cannot be overridden.
+    */
+
+    // 'Model' => 'App',
+    // 'Controller' => 'App\Http\Controllers',
+];


### PR DESCRIPTION
Even if Laravel comes with sensible defaults, the developer sometimes want to have a different structure for a project.

For instance, putting models either in `\App` either in `\App\Models` has been a long discussed topic.

This PR enables the user to override paths for each generated files in a custom `generator.php` configuration file.
If nothing is set, the many generator commands will use their own defaults.

This works with everything but the migrations files.

---

This PR requires https://github.com/laravel/framework/pull/24501