### PR TITLE
[5.7] rename parameter of Daily Driver logger from days to max_files

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -48,7 +48,7 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
-            'days' => 7,
+            'max_files' => 7,
         ],
 
         'slack' => [


### PR DESCRIPTION
It will be more clear to rename parameter 'days' of Daily Driver logger to 'max_files' because it show how many files will keep on disk.
Also it supports '0' value for unlimited files.

Related to https://github.com/laravel/framework/pull/24562