### PR TITLE
[5.6] Add config for EnsureRequestIsSecure middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        \Illuminate\Foundation\Http\Middleware\EnsureRequestIsSecure::class,
     ];
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Force HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | If an unsecured request is received by your app it can redirect
+    | back to the same resource over HTTPS. This prevents you from
+    | serving duplicate content over HTTP and HTTPS schemes.
+    |
+    */
+
+    'https' => env('APP_HTTPS', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This is the other side to laravel/framework#24747 - adding the boilerplate configuration for the new middleware. Not sure if you wanted to include the middleware in the HTTP kernel by default or not. I think it would be better to include it because otherwise there will be impact when you change `app.https`.