### PR TITLE
5.4

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -48,9 +48,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|max:255',
-            'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|min:6|confirmed',
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:6|confirmed',
         ]);
     }
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,6 @@
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
-        Options -MultiViews
+        Options -MultiViews -Indexes
     </IfModule>
 
     RewriteEngine On


### PR DESCRIPTION
Method [validateIn(0,1)] does not exist.

  $data['state_tax']='0';
        $validator = \Validator::make($data, 
            [ "state_tax" => 'in(0,1)',
]);
dd($validator->passes());

how fix that?? I need to set 'state_tax' with default value - 0,1 -  but validateIn no exit , its weird