### PR TITLE
Add beyondcode/laravel-dump-server as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "laravel/tinker": "^1.0"
     },
     "require-dev": {
+        "beyondcode/laravel-dump-server": "^1.0",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This PR adds the https://github.com/beyondcode/laravel-dump-server package as a dev-dependency.