### PR TITLE
[5.7] Allow to use default view for rendering exception

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,7 +3,9 @@
 namespace App\Exceptions;
 
 use Exception;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -49,5 +51,23 @@ class Handler extends ExceptionHandler
     public function render($request, Exception $exception)
     {
         return parent::render($request, $exception);
+    }
+
+    /**
+     * Render the given HttpException.
+     *
+     * @param  \Symfony\Component\HttpKernel\Exception\HttpException  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function renderHttpException(HttpException $e)
+    {
+        if (view()->exists($view = 'errors.' . $e->getStatusCode()) || view()->exists($view = 'errors.default')) {
+            return response()->view($view, [
+                'errors' => new ViewErrorBag(),
+                'exception' => $e,
+            ], $e->getStatusCode(), $e->getHeaders());
+        }
+
+        return parent::renderHttpException($e);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,8 +4,8 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Support\ViewErrorBag;
-use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
 {
@@ -61,7 +61,7 @@ class Handler extends ExceptionHandler
      */
     protected function renderHttpException(HttpException $e)
     {
-        if (view()->exists($view = 'errors.' . $e->getStatusCode()) || view()->exists($view = 'errors.default')) {
+        if (view()->exists($view = 'errors.'.$e->getStatusCode()) || view()->exists($view = 'errors.default')) {
             return response()->view($view, [
                 'errors' => new ViewErrorBag(),
                 'exception' => $e,


### PR DESCRIPTION
This PR changes 2 things:

1. It allows to use `default` view for all exceptions except those defined in custom views. Now it's impossible so in case you want to define one view for 404 and one for all the others cases it's impossible - you need to create views for multiple statuses and you are not even sure if you cover all of them or not.

2. Move some logic from Framework to App so it's easier to change the logic.  After the update it's easier to customize this logic because it's enough just to implement custom logic here and all uncovered cases will be handled by default framework logic.

If approved additional changes in Framework can be done to simplify code a bit after moving some logic to app. 