### PR TITLE
Added _ide_helper.php to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+_ide_helper.php


### PR DESCRIPTION
For those like me who have to add _ide_helper.php all the time to their new project. I suggest it's added by default.