### PR TITLE
[5.6] Return the instance of \Symfony\Component\HttpFoundation\Response

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -42,7 +42,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
The render function should return the instance of \Symfony\Component\HttpFoundation\Response, an instance of \Illuminate\Http\Response given.