### PR TITLE
Update docblocks to match parent class

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -30,7 +30,9 @@ class Handler extends ExceptionHandler
      * Report or log an exception.
      *
      * @param  \Exception  $exception
-     * @return void
+     * @return mixed
+     *
+     * @throws \Exception
      */
     public function report(Exception $exception)
     {
@@ -42,7 +44,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
While testing [Larastan](https://github.com/nunomaduro/larastan) warned that `render()` had the wrong return type based on the docblock. I also updated the docblock for `report()`