### PR TITLE
Remove unnecessary rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,4 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.yml]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
`indent_style` is already set for `[*]`.