### PR TITLE
Add .phpunit.result.cache to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.phpunit.result.cache


### PR DESCRIPTION
PHPUnit version 7.3 adds a new argument `--cache-result` which allows you to do awesome things like re-run test failures using a command like:

`phpunit --cache-result --order-by=defects --stop-on-defect`

The cache file is stored as `.phpunit.result.cache`

I believe PHPUnit 8 will have caching on by default, so this file will start popping up in everyone's project quickly.