### PR TITLE
Upgrade Lodash (Security Vulnerability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "cross-env": "^5.1",
         "jquery": "^3.2",
         "laravel-mix": "^2.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.5",
         "vue": "^2.5.7"
     }
 }


### PR DESCRIPTION
This PR updates Lodash to `^4.17.5` from `^4.17.4`. I recently installed a new Laravel App and I got an email from GitHub within a few hours about a severe security vulnerability with Lodash `4.17.4`:

![screen shot 2018-08-15 at 9 30 02 am](https://user-images.githubusercontent.com/17038330/44153423-d4ba56fe-a06d-11e8-86fe-b83588d7c4bb.png)


via [https://nvd.nist.gov/vuln/detail/CVE-2018-3721](https://nvd.nist.gov/vuln/detail/CVE-2018-3721):

> Lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which allows a malicious user to modify the prototype of "Object" via __proto__, causing the addition or modification of an existing property that will exist on all objects.
