### PR TITLE
Localize responses

### DIFF
--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -15,5 +15,9 @@ return [
 
     'failed' => 'These credentials do not match our records.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+    
+    'responses' => [
+        'Unauthenticated' => 'Unauthenticated.',
+    ],
 
 ];


### PR DESCRIPTION
Related to: https://github.com/laravel/framework/compare/5.6...dmcbrn:patch-1

---details---

When creating an API I'm getting untranslated responses. This PR (in combination with the one mentioned above) will extract the 'Unauthenticated' text to language files making it easy to translate it.