### PR TITLE
[5.7] test bootstrap

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+//$app = require __DIR__.'/../bootstrap/app.php';
+//
+//$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+//
+//if (! file_exists(__DIR__.'/../.env.testing')) {
+//    throw new Exception('Create a .env.testing file to separate development and testing environments!');
+//}
+//
+//Artisan::call('migrate:refresh');


### PR DESCRIPTION
This is something I do in almost all of my laravel projects:

1. Create a custom bootstrap for my tests.
2. In that bootstrap create a laravel application and clean up the application state, e.g. refresh the database and clean the cache.
3. Make sure my tests are running in a separate environment, so the state of my manual-testing/development database does not affect the tests, and the tests does not drop my development data.

I am not sure if laravel and phpunit have alternative approach for this, so probably others would like to do the same. This PR adds the bootstrap file, while doing nothing by default, it has some commented codes that might be handy.
