### PR TITLE
Extract 2 core configurations for sessions to environment

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -70,7 +70,7 @@ return [
     |
     */
 
-    'connection' => null,
+    'connection' => env('SESSION_CONNECTION', null),
 
     /*
     |--------------------------------------------------------------------------
@@ -96,7 +96,7 @@ return [
     |
     */
 
-    'store' => null,
+    'store' => env('SESSION_CONNECTION', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -96,7 +96,7 @@ return [
     |
     */
 
-    'store' => env('SESSION_CONNECTION', null),
+    'store' => env('SESSION_STORE', null),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
In the spirit of JMac & LaravelShift I've extracted 2 session variables to the environment file. Not 'just because' but that one is able to set SESSION_DRIVER to redis, but unable to set a connection without touching the core session config file.