### PR TITLE
[5.7] Use semver caret operator for laravel-dump-server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "laravel/tinker": "^1.0"
     },
     "require-dev": {
-        "beyondcode/laravel-dump-server": "~1.0",
+        "beyondcode/laravel-dump-server": "^1.0",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
After the PR https://github.com/laravel/laravel/pull/4600, we are defaulting to the "Caret Version Range".