### PR TITLE
Improved comments about 'expire_on_close' and 'lifetime' session config

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -24,8 +24,9 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may specify the number of minutes that you wish the session
-    | to be allowed to remain idle before it expires. If you want them
-    | to immediately expire on the browser closing, set that option.
+    | to be allowed to remain idle before it expires. If instead you want 
+    | sessions to expire immediately when the browser closes, set that option,
+    | in which case the 'lifetime' option will be ignored.
     |
     */
 


### PR DESCRIPTION
Improving the instructions (in the comments) since many people (e.g. https://github.com/laravel/framework/issues/9321 and throughout StackOverflow) have been confused about the interaction between the 'expire_on_close' and 'lifetime' session config values. The Principle of Least Surprise applies here (see https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

I _assume_ my new comments are correct based on @GrahamCampbell closing [this issue](https://github.com/laravel/framework/issues/9321#event-335017510), but please see if you'd word them differently.