### PR TITLE
[5.7] Define mix as const

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,4 +1,4 @@
-let mix = require('laravel-mix');
+const mix = require('laravel-mix');
 
 /*
  |--------------------------------------------------------------------------


### PR DESCRIPTION
`mix` isn't re-assigned (and shouldn't be) so `const` is more appropriate.