### PR TITLE
[5.6] Fix comment not lining up

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -21,8 +21,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | This value determines the "environment" your application is currently
-    | running in. This may determine how you prefer to configure various
-    | services your application utilizes. Set this in your ".env" file.
+    | running in. Based on this value you can enable/disable features of
+    | the app. Most common naming is "local", "testing", "production".
     |
     */
 


### PR DESCRIPTION
Currently, all docblocks are running 5-2-0 pattern. This one is not up to this standard. I went ahead and fixed that. There are also alternatives here:

```php
/*
|--------------------------------------------------------------------------
| Application Environment
|--------------------------------------------------------------------------
|
| This value determines the "environment" your application is currently
| running in. Based on this value you can enable/disable features of
| the app. Most common naming is "local", "testing", "production".
|
*/

/*
|--------------------------------------------------------------------------
| Application Environment
|--------------------------------------------------------------------------
|
| This value determines the "environment" your application is currently
| running in. Based on this value you can enable/disable features of
| the app. Recommended values are: local, testing, and production.
|
*/

/*
|--------------------------------------------------------------------------
| Application Environment
|--------------------------------------------------------------------------
|
| This value determines the "environment" your application is currently
| running in. Based on this value you can pick the features that are
| relevant to current environment. Change this in the ".env" file.
|
*/
```