### PR TITLE
[5.6] Fix pagination translation

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'previous' => '&laquo; Previous',
-    'next' => 'Next &raquo;',
+    'previous' => '« Previous',
+    'next' => 'Next »',
 
 ];


### PR DESCRIPTION
https://github.com/laravel/framework/commit/d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b broke the links of simple pagination (https://github.com/laravel/framework/issues/25430):

    {{ User::simplePaginate()->links() }}

 > &amp;laquo; Previous
 > Next &amp;raquo;