### PR TITLE
Adding papertrail log channel option

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -76,6 +76,15 @@ return [
             'driver' => 'errorlog',
             'level' => 'debug',
         ],
+
+        'papertrail' => [
+            'driver'  => 'monolog',
+            'handler' => Monolog\Handler\SyslogUdpHandler::class,
+            'handler_with' => [
+                'host' => env('PAPERTRAIL_URL'),
+                'port' => env('PAPERTRAIL_PORT'),
+            ],
+        ],
     ],
 
 ];


### PR DESCRIPTION
Since Papertrail is one major log management service and its configuration can be hard to newcomers i think its fair to let it out of the box to plug it.