### PR TITLE
Removing unnecessary use from User Model

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -2,7 +2,6 @@
 
 namespace App;
 
-use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;


### PR DESCRIPTION
The base class Illuminate\Foundation\Auth\User already uses the MustVerifyEmail trait.