### PR TITLE
Add missing Mailgun 'endpoint' option

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return [
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
+        'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
     ],
 
     'ses' => [


### PR DESCRIPTION
Counterpart to https://github.com/laravel/framework/pull/25010

Necessary for EU users, as they use api.eu.mailgun.net instead of api.mailgun.net