### PR TITLE
[5.7] Update HttpKernel to use Authenticate middleware under App namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,4 +61,20 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];
+    
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * Forces the listed middleware to always be in the given order.
+     *
+     * @var array
+     */    
+        protected $middlewarePriority = [
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\Authenticate::class,
+        \Illuminate\Session\Middleware\AuthenticateSession::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -68,7 +68,7 @@ class Kernel extends HttpKernel
      * Forces the listed middleware to always be in the given order.
      *
      * @var array
-     */    
+     */
     protected $middlewarePriority = [
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -69,7 +69,7 @@ class Kernel extends HttpKernel
      *
      * @var array
      */    
-     protected $middlewarePriority = [
+    protected $middlewarePriority = [
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \App\Http\Middleware\Authenticate::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,7 +61,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];
-    
+
     /**
      * The priority-sorted list of middleware.
      *
@@ -69,7 +69,7 @@ class Kernel extends HttpKernel
      *
      * @var array
      */    
-        protected $middlewarePriority = [
+     protected $middlewarePriority = [
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \App\Http\Middleware\Authenticate::class,


### PR DESCRIPTION
The `Authenticate` middleware is intended to be called in a specific order before applying developer-listed middleware. In 5.7, it was changed to `App\Http\Middleware\Authenticate` but the priority still lists it as living under `Illuminate\Auth\Middleware\Authenticate`.

This proposed fix moves that priority array to `App\Http\Kernel` and changes the reference to the userland class.