### PR TITLE
[5.7] Persist the /storage/framework/cache/data directory

### DIFF
--- a/storage/framework/cache/data/.gitignore
+++ b/storage/framework/cache/data/.gitignore
@@ -1,3 +1,2 @@
 *
-!data/
 !.gitignore


### PR DESCRIPTION
Keeps the `/storage/framework/cache/data/` directory, in order to allow the filesystem cache to function properly.

Resolves https://github.com/laravel/framework/issues/25451