### PR TITLE
[5.7] Set logs to daily by default

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily'],
         ],
 
         'single' => [


### PR DESCRIPTION
*Why consider this?*

Daily logging makes an application more "production ready" out of the box. I know developers are considered to set this config, but for many new or inexperienced devs this isn't common knowledge.

Sticking to daily by default makes more sense to me:
- Way easier of getting an overview of what happened in a chronological order.
- No chance of consuming lots of disk space by huge logs.

I understand this is also partly a personal preference, so I'd welcome any feedback or constructive criticism why this should remain as is or changed to something different.