### PR TITLE
[5.7] Update log config: 30 daily + easy overwrite channel for dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_DEBUG=true
 APP_URL=http://localhost
 
 LOG_CHANNEL=stack
+LOG_STACK=daily
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/config/logging.php
+++ b/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily'],
+            'channels' => [env('LOG_STACK', 'daily')],
         ],
 
         'single' => [
@@ -49,7 +49,7 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
-            'days' => 7,
+            'days' => 30,
         ],
 
         'slack' => [


### PR DESCRIPTION
As per request [here](https://github.com/laravel/laravel/pull/4767):

- Default max daily logs to 30
- Easily overwrite the channel for dev environment