### PR TITLE
[5.7] Change default days to 30 for daily channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -49,7 +49,7 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => 'debug',
-            'days' => 7,
+            'days' => 30,
         ],
 
         'slack' => [


### PR DESCRIPTION
As we changed default channel to daily in https://github.com/laravel/laravel/pull/4767 I think it makes sense to keep logs for more than 7 days. In case any problem appears, you often need to take a look a bit further than just 7 days.