### PR TITLE
Fixed "Specified key was too long error" Bug

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -14,6 +15,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+        Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
Fixed Laravel 5.4: Specified key was too long error Bug in Laravel Which was not fixed yet.
https://laravel-news.com/laravel-5-4-key-too-long-error