### PR TITLE
[5.7] Update config/cache.php slug generation to conform to config/session.php

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -88,6 +86,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', str_slug(env('APP_NAME', 'laravel'), '_').'_cache'),
 
 ];


### PR DESCRIPTION
The `config/session.php` file generates a slug with the `str_slug()` helper. This PR makes `config/cache.php` generate a slug in the same manner. :)