### PR TITLE
[5.7] Make app path stream safe

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,7 @@
 */
 
 $app = new Illuminate\Foundation\Application(
-    realpath(__DIR__.'/../')
+    dirname(__DIR__)
 );
 
 /*


### PR DESCRIPTION
This PR ensures that the app base path is stream-safe instead of the [potential unexpected behavior of using `realpath()`](https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#phar-incompatible-realpath-usage).