### PR TITLE
[5.7] Changes the translation for "required_with_all" validation rule

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -97,7 +97,7 @@ return [
     'required_if'          => 'The :attribute field is required when :other is :value.',
     'required_unless'      => 'The :attribute field is required unless :other is in :values.',
     'required_with'        => 'The :attribute field is required when :values is present.',
-    'required_with_all'    => 'The :attribute field is required when :values is present.',
+    'required_with_all'    => 'The :attribute field is required when :values are present.',
     'required_without'     => 'The :attribute field is required when :values is not present.',
     'required_without_all' => 'The :attribute field is required when none of :values are present.',
     'same'                 => 'The :attribute and :other must match.',


### PR DESCRIPTION
It makes sense to use "are" in the translation of the validation rule `required_with_all` as we are referring to several items.

Also the `required_without_all` validation rule is already using "are".