### PR TITLE
[5.7] Set hash rounds to 4 to speed up tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -16,6 +17,8 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        
+        Hash::driver('bcrypt')->setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
This improvement was originally tweeted by taylor 

https://twitter.com/taylorotwell/status/943135617466105856

And it does really make a difference.
I was really surprised that it's not included by default in 5.7
So there it is, enjoy the speed.