### PR TITLE
[5.7] Adding faker_locale default config value.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -92,7 +92,7 @@ return [
     */
 
     'fallback_locale' => 'en',
-    
+
     /*
     |--------------------------------------------------------------------------
     | Faker Locale Configuration

--- a/config/app.php
+++ b/config/app.php
@@ -92,6 +92,19 @@ return [
     */
 
     'fallback_locale' => 'en',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Faker Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The locale set here will be used by the Faker PHP library when it will
+    | generate localized random data for testing such as a postal address
+    | or a telephone number. This is the default locale we are setting.
+    |
+    */
+
+    'faker_locale' => 'en_US',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
As per [that PR](https://github.com/laravel/framework/pull/17895) and [the documentation](https://laravel.com/docs/5.6/database-testing#writing-factories), I wanted to make sure this was present in the `app/config.php` out of the box.

It's a great thing and I'm sure people will be happy to use it rather than overriding the singleton registration.