### PR TITLE
Security Precaution

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -224,4 +224,27 @@ return [
 
     ],
 
+    'debug_blacklist' => [
+        '_ENV' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET'
+        ],
+        '_SERVER' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET'
+        ],
+        '_POST' => [
+            'password',
+        ],
+
 ];


### PR DESCRIPTION
Blacklisting by default the security information from debug to prevent security issues.