### PR TITLE
Security Precaution

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -224,4 +224,28 @@ return [
 
     ],
 
+    'debug_blacklist' => [
+        '_ENV' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET'
+        ],
+        '_SERVER' => [
+            'APP_KEY',
+            'DB_PASSWORD',
+            'REDIS_PASSWORD',
+            'MAIL_USERNAME',
+            'MAIL_PASSWORD',
+            'PUSHER_APP_KEY',
+            'PUSHER_APP_SECRET'
+        ],
+        '_POST' => [
+            'password',
+        ],
+    ],
+
 ];


### PR DESCRIPTION
Enable by default important security config in debug blacklist to prevent security issues.