### PR TITLE
Additional Config Options Documentation

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your Application default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your Auth default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your broadcasting default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your cache default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 use Illuminate\Support\Str;
 
 return [

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your database default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your filesystem default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/hashing.php
+++ b/config/hashing.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your hashing default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your logging default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your mail default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your queue default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/services.php
+++ b/config/services.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your services default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*

--- a/config/session.php
+++ b/config/session.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your session default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 use Illuminate\Support\Str;
 
 return [

--- a/config/view.php
+++ b/config/view.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| Config Option Precedence
+|--------------------------------------------------------------------------
+|
+| You can define your view default config options here. Please note 
+| that *.env files have higher precedence and will override any values 
+| defined here. 
+|
+*/
+
 return [
 
     /*


### PR DESCRIPTION
It was not clear to me that .env files had higher precedence over application config files. While it makes total sense, now that I know it lead to unexpected behavior. So I added simple comment blocks to each config file to make this behavior clear in the source.