### PR TITLE
[5.7] Revert #4744

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'previous' => '« Previous',
-    'next' => 'Next »',
+    'previous' => '&laquo; Previous',
+    'next' => 'Next &raquo;',
 
 ];


### PR DESCRIPTION
#4744 adjusted the pagination translation after https://github.com/laravel/framework/commit/d3c0a369057d0b6ebf29b5f51c903b1a85e3e09b started escaping the output of  `@lang` calls. Now that `d3c0a36` got reverted, we can revert this fix.