### PR TITLE
[5.8] Change password min length to 8

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -51,7 +51,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
-            'password' => 'required|string|min:6|confirmed',
+            'password' => 'required|string|min:8|confirmed',
         ]);
     }
 

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'password' => 'Passwords must be at least six characters and match the confirmation.',
+    'password' => 'Passwords must be at least eight characters and match the confirmation.',
     'reset' => 'Your password has been reset!',
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',


### PR DESCRIPTION
This PR is a dependent of laravel/framework#9999999.

Changes to the default password validation rule must be made in framework and laravel repositories, since they're defined and stipulated in both. Please refer to the PR in framework for more information.