### PR TITLE
Update UserFactory password

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -18,7 +18,7 @@ $factory->define(App\User::class, function (Faker $faker) {
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
-        'password' => '$2y$10$wOY5GEMqZ2onAWGeNXlTd.DEgxnT.dIovWTvxfgMqvRCk1LRbjPIm', // secretpass
+        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => str_random(10),
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -18,7 +18,7 @@ $factory->define(App\User::class, function (Faker $faker) {
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
-        'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
+        'password' => '$2y$10$wOY5GEMqZ2onAWGeNXlTd.DEgxnT.dIovWTvxfgMqvRCk1LRbjPIm', // secretpass
         'remember_token' => str_random(10),
     ];
 });


### PR DESCRIPTION
The password set by the default UserFactory is `secret` which is 6 characters. This is less than the required minimum 8 character length as per new NIST standards on memorized secrets (i.e. user passwords) as stated here  laravel/framework#25957

Although this is **enforced in the next version** of laravel by #4794, I think the UserFactory default should be changed in the current version itself.

By this pr, the new default is set to `password`

---