### PR TITLE
adding trustedproxy config file. Supports AWS ELB.

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using ELB or similar).
+     *
+     */
+    'proxies' => env('TRUSTEDPROXY_PROXIES', null),
+
+    /*
+     * To trust one or more specific proxies that connect
+     * directly to your server, use an array of IP addresses:
+     */
+     # 'proxies' => null, // [<ip addresses>,], '*'
+     # 'proxies' => ['192.168.1.1'],
+
+    /*
+     * Or, to trust all proxies that connect
+     * directly to your server, use a "*"
+     */
+     # 'proxies' => '*',
+
+    /*
+     * Which headers to use to detect proxy related data (For, Host, Proto, Port)
+     * 
+     * Options include:
+     * 
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
+     * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancing)
+     * 
+     * @link https://symfony.com/doc/current/deployment/proxies.html
+     */
+    'headers' => env('TRUSTEDPROXY_HEADERS', 'HEADER_X_FORWARDED_ALL'),
+];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -21,24 +21,24 @@ return [
      * To trust one or more specific proxies that connect
      * directly to your server, use an array of IP addresses:
      */
-     # 'proxies' => null, // [<ip addresses>,], '*'
-     # 'proxies' => ['192.168.1.1'],
+     // 'proxies' => null, // [<ip addresses>,], '*'
+     // 'proxies' => ['192.168.1.1'],
 
     /*
      * Or, to trust all proxies that connect
      * directly to your server, use a "*"
      */
-     # 'proxies' => '*',
+     // 'proxies' => '*',
 
     /*
      * Which headers to use to detect proxy related data (For, Host, Proto, Port)
-     * 
+     *
      * Options include:
-     * 
+     *
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
      * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancing)
-     * 
+     *
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */
     'headers' => env('TRUSTEDPROXY_HEADERS', 'HEADER_X_FORWARDED_ALL'),


### PR DESCRIPTION
**PROBLEM**: Hard coded settings in the TrustProxies middleware class.
- Production: Probably you will use ELB.
- Development: Probably you are not using ELB.

**SOLUTION**: Moving settings to config file. Config file get settings from env file. Really easy to define your settings based on environments.

To configure Trusted Proxies when needed.
Change your .env if:
- you're using AWS ELB:
    - __TRUSTEDPROXY_PROXIES__="*"
    - __TRUSTEDPROXY_HEADERS__="__HEADER_X_FORWARDED_AWS_ELB__"
- IP address (or range) of your proxy
    - __TRUSTEDPROXY_PROXIES__="192.168.1.1,192.168.1.2"
    - __TRUSTEDPROXY_PROXIES__="192.168.1.0/8"
    - __TRUSTEDPROXY_HEADERS__="__HEADER_X_FORWARDED_ALL__"
    - __TRUSTEDPROXY_HEADERS__="__HEADER_FORWARDED__"

If you are using AWS ELB you can configure your Nginx like this:
```nginx
server {
    # all traffic, secure or otherwise, comes in on 80 from the ELB
    listen 80;
    server_name YOUR-DOMAIN.COM;
    root /home/USERNAME/sites/YOUR-DOMAIN/public;

    # ELB stores the protocol used between the client
    # and the load balancer in the X-Forwarded-Proto request header.
    # Check for 'https' and redirect if not
    if ($http_x_forwarded_proto != 'https') {
        return 301 https://$server_name$request_uri;
    }
    .......
}
```