### PR TITLE
[5.6] Enable and configure browserSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "devDependencies": {
         "axios": "^0.18",
         "bootstrap": "^4.0.0",
-        "popper.js": "^1.12",
+        "browser-sync": "^2.26.0",
+        "browser-sync-webpack-plugin": "^2.2.2",
         "cross-env": "^5.1",
         "jquery": "^3.2",
         "laravel-mix": "^2.0",
         "lodash": "^4.17.5",
+        "popper.js": "^1.12",
         "vue": "^2.5.7"
     }
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,3 +13,42 @@ let mix = require('laravel-mix');
 
 mix.js('resources/assets/js/app.js', 'public/js')
    .sass('resources/assets/sass/app.scss', 'public/css');
+
+
+/*
+|-----------------------------------------------------------------------
+| BrowserSync
+|-----------------------------------------------------------------------
+|
+| BrowserSync refreshes the browser if file changes (js, sass, blade.php) are
+| detected.
+|
+| For more information: https://browsersync.io/docs
+*/
+mix.browserSync({
+  /*
+   * Specify the URL that addresses your server.
+   * This can also be an IP or your homestead environment.
+   */
+  proxy: 'http://localhost:8000',
+
+  /*
+   * Host name for external use. Here you can also specify a domain, that you have
+   * edited in your local hosts file. Most of the time this can be untouched.
+   */
+  host: 'localhost',
+
+  /*
+   * Open the browser. You can set this to false if you are using a vagrant development
+   * environment like homestead.
+   */
+  open: true,
+
+  /*
+   * Use polling if your are using the homestead environment or an equivalent
+   * vagrant development environment.
+   */
+  watchOptions: {
+    usePolling: false
+  }
+});


### PR DESCRIPTION
# Enable and configure BrowserSync

This PR integrates the dependencies required for browserSync and configures browserSync in webpack.mix.js. 

## Benefits
* Frontend development is facilitated
* Developers can test and view frontend changes in different browsers in sync.

## Usage/testing
1. In a terminal run `php artisan serve`
2. In a second terminal run `npm run watch`
3. Open your browser(s) at http://localhost:3000 (URL and port are also displayed in the second terminal
4. Change e.g. a template, JS file or SCSS/CSS file.
5. After the watch process rebuilds the assets a browser reload should be triggered.

## More information
* https://www.browsersync.io/
* https://github.com/Va1/browser-sync-webpack-plugin