### PR TITLE
[5.7] Add "pretend" key to the mail config

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -120,4 +120,17 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Pretend
+    |--------------------------------------------------------------------------
+    |
+    | To enable pretend mode, set the pretend option to true.  When in pretend
+    | mode, messages will be written to your application's log files instead of
+    | being sent to the recipient.
+    |
+    */
+
+    'pretend' => false,
+
 ];


### PR DESCRIPTION
The docs say to "set the pretend option in the config/mail.php configuration file to true".  This PR adds a placeholder pretend option that's set to false.