### PR TITLE
[5.7] Don't redirect for api calls

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,6 +14,8 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        return route('login');
+        if (! $request->expectsJson()) {
+            return route('login');
+        }
     }
 }


### PR DESCRIPTION
When calling api routes the Authenticate middleware attempts to redirect you to the login page. If you expect JSON back or don't have auth routes then you don't want this to happen. By re-using the logic from Laravel's exception handler on which format to output we can also determine wether to redirect the user to the login page or give them a JSON error response.