### PR TITLE
Added .htaccess to hide .env files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+<Files ~ "^.*\.([Ee][Nn][Vv])">
+ order allow,deny
+ deny from all
+ satisfy all
+</Files>


### PR DESCRIPTION
Due to poor deployment skills, lots of people exposed the root project directory to the web (example.com/public), therefore we've added a default .htaccess blocking .env file exposure (eventually accessible at example.com/.env)

Here you can find pages and pages (about 2.250 results) of exposed .env files: [DB_USERNAME filetype:env](https://www.google.it/search?q=DB_USERNAME+filetype%3Aenv)