### PR TITLE
Added nginx.conf to hide .env files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,5 @@
+# nginx configuration
+
+location ~ ^.*\.([Ee][Nn][Vv]) {
+  deny all;
+}


### PR DESCRIPTION
Due to poor deployment skills, lots of people exposed the root project directory to the web (example.com/public), therefore we've added a default nginx.conf blocking .env file exposure (eventually accessible at example.com/.env)

Here you can find pages and pages (about 2.250 results) of exposed .env files: [DB_USERNAME filetype:env](https://www.google.it/search?q=DB_USERNAME+filetype%3Aenv)
