### PR TITLE
add guard-specific redirectTo() to auth middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -7,10 +7,11 @@ use Illuminate\Auth\Middleware\Authenticate as Middleware;
 class Authenticate extends Middleware
 {
     /**
-     * the guard name of current auth middleware
+     * the guard name of current auth middleware.
      * @var string
      */
     protected $guard;
+
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
@@ -28,8 +29,7 @@ class Authenticate extends Middleware
 
             if (Route::has($path)) {
                 return route($path);
-            }
-            else {
+            } else {
                 return $path;
             }
         }
@@ -46,6 +46,6 @@ class Authenticate extends Middleware
     protected function authenticate($request, array $guards)
     {
         $this->guard = empty($guards) ? $this->auth->getDefaultDriver() : $guards[0];
-        parent::authenticate($request, $guards); 
+        parent::authenticate($request, $guards);
     }
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -7,6 +7,11 @@ use Illuminate\Auth\Middleware\Authenticate as Middleware;
 class Authenticate extends Middleware
 {
     /**
+     * the guard name of current auth middleware
+     * @var string
+     */
+    protected $guard;
+    /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -15,7 +20,32 @@ class Authenticate extends Middleware
     protected function redirectTo($request)
     {
         if (! $request->expectsJson()) {
-            return route('login');
+            $config = config("auth.guards.{$this->guard}");
+            if (empty($config['path'])) {
+                throw new InvalidArgumentException("Path of auth guard [{$this->guard}] is not defined.");
+            }
+            $path = $config['path'];
+
+            if (Route::has($path)) {
+                return route($path);
+            }
+            else {
+                return $path;
+            }
         }
+    }
+
+    /**
+     * Determine if the user is logged in to any of the given guards.
+     * Save the first guard name if it exists, in case the user is not logged in to any of them.
+     * And redirectedTo() reads its path.
+     * @param  [type] $request [description]
+     * @param  array  $guards  [description]
+     * @return [type]          [description]
+     */
+    protected function authenticate($request, array $guards)
+    {
+        $this->guard = empty($guards) ? $this->auth->getDefaultDriver() : $guards[0];
+        parent::authenticate($request, $guards); 
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -33,17 +33,23 @@ return [
     |
     | Supported: "session", "token"
     |
+    | All authentication guards have a path for user to be redirected to
+    | if he/she is not authenticated.
+    | Supported: path string, route name
+    |
     */
 
     'guards' => [
         'web' => [
             'driver' => 'session',
             'provider' => 'users',
+            'path' => '/',
         ],
 
         'api' => [
             'driver' => 'token',
             'provider' => 'users',
+            //'path' => api guard doesn't have redirect path.
         ],
     ],
 


### PR DESCRIPTION
By adding {path} element to config/auth.php and corresponding changes to Middleware/Authenticate.php, every guard may have its own redirectTo path or route names.