### PR TITLE
Fix bad font size render on link

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -51,7 +51,7 @@
             .links > a {
                 color: #636b6f;
                 padding: 0 25px;
-                font-size: 12px;
+                font-size: 13px;
                 font-weight: 600;
                 letter-spacing: .1rem;
                 text-decoration: none;


### PR DESCRIPTION
With Nunito, the 12px size with uppercase hase bad render (FF & Chrome).

![annotation 1](https://user-images.githubusercontent.com/1703605/47049905-e9a8ec80-d19e-11e8-997d-4e240260b08b.png)

![annotation](https://user-images.githubusercontent.com/1703605/47049870-d007a500-d19e-11e8-8a32-cf618ce6e4d4.png)



