### PR TITLE
Revert validation syntax change

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -49,9 +49,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:6', 'confirmed'],
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:6|confirmed',
         ]);
     }
 


### PR DESCRIPTION
https://github.com/laravel/laravel/pull/4820 was merged earlier today without any discussion. I don't think the change is a good idea, so i've opened up this PR to start a discussion (and hopefully revert the change)

The old syntax is shorter, cleaner, and is used in all the [validation docs](https://laravel.com/docs/5.7/validation#custom-validation-rules) examples that don't use a closure or custom rule. The validation in the `RegisterController` doesn't use any custom rules, so there is no reason to write the rules as an array.