### PR TITLE
FindOrFail method doesn't through the passed ids while working with many-to-many relationship.

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'previous' => '« Previous',
-    'next' => 'Next »',
+    'previous' => '&laquo; Previous',
+    'next' => 'Next &raquo;',
 
 ];


### PR DESCRIPTION
Eloquent Builder throws  ModelNotFound Exception in case of giving an id that doesn't exist, and within the thrown exception, there is an array  of ids containing of the passed id.

This doesn't happen with relationships such as BelongsToMany ( I haven't tested the rest )

Steps To Reproduce : 

I think you guys forgot to set the id here in Illuminate\Database\Eloquent\Relations\BelongsToMany

```php
    public function findOrFail($id, $columns = ['*'])
    {
        $result = $this->find($id, $columns);

        if (is_array($id)) {
            if (count($result) === count(array_unique($id))) {
                return $result;
            }
        } elseif (! is_null($result)) {
            return $result;
        }
        // set ID Here.
        throw (new ModelNotFoundException)->setModel(get_class($this->related) , $id);
    }


```