### PR TITLE
Add hidden whoops editor gem

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -110,6 +110,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Editor / IDE
+    |--------------------------------------------------------------------------
+    |
+    | This value is used by whoops PrettyPageHandler to enabled the ability
+    | to open referenced files directly in your editor and IDE. This feature
+    | only works in case your php-source files are locally accessible to the
+    | machine on which the editor is installed.
+    |
+    */
+
+    'editor' => env('APP_EDITOR'),    
+    
+    /*
+    |--------------------------------------------------------------------------
     | Autoloaded Service Providers
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Whilst browsing around for a solution to enable the ->setEditor of Whoops, it turned out that this was already built into laravel and just needed to be enabled. 

Unveiling it in app.php, as it seemed intended, will help others enable this useful feature.