### PR TITLE
[5.7] Fix running mix tasks error

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,6 +1,5 @@
 
 window._ = require('lodash');
-window.Popper = require('popper.js').default;
 
 /**
  * We'll load jQuery and the Bootstrap jQuery plugin which provides support
@@ -9,6 +8,7 @@ window.Popper = require('popper.js').default;
  */
 
 try {
+    window.Popper = require('popper.js').default;
     window.$ = window.jQuery = require('jquery');
 
     require('bootstrap');


### PR DESCRIPTION
Before this PR, running `php artisan preset none` and then running all Mix tasks `npm run production` would output an error:

`ERROR in ./resources/js/bootstrap.js`
`Module not found: Error: Can't resolve 'popper.js'`

This PR turns it into a warning keeping the same behaviour as when `bootstrap` and `jquery` modules are missing:

`WARNING in ./resources/js/bootstrap.js`
`Module not found: Error: Can't resolve 'popper.js'`