### PR TITLE
[5.7] use env value for redis queue name

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -60,7 +60,7 @@ return [
         'redis' => [
             'driver' => 'redis',
             'connection' => 'default',
-            'queue' => 'default',
+            'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => 90,
             'block_for' => null,
         ],


### PR DESCRIPTION
It's common to have a redis queue name when having multiple queues/applications on the same instance. Default value is the same.