### PR TITLE
introduce sqlite foreign_key_constraints config option

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,6 +37,7 @@ return [
             'driver' => 'sqlite',
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
         'mysql' => [


### PR DESCRIPTION
This enables the sqlite `foreign_key_constraints` option that was introduced with laravel/framework#26298 for all new installs.

The env variable DB_FOREIGN_KEYS was added to make it easier to handle this in testing (e.g. via phpunit.xml).