### PR TITLE
Auto register Vue components

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,7 +15,11 @@ window.Vue = require('vue');
  * or customize the JavaScript scaffolding to fit your unique needs.
  */
 
-Vue.component('example-component', require('./components/ExampleComponent.vue'));
+const files = require.context('./', true, /\.vue$/i)
+files.keys().map(key => {
+    const name = _.last(key.split('/')).split('.')[0]
+    return Vue.component(name, files(key))
+})
 
 const app = new Vue({
     el: '#app'


### PR DESCRIPTION
Not sure if this is too magical, but Webpack has a feature called [require.context](https://webpack.js.org/guides/dependency-management/#require-context), which allows you to traverse a directory. Using this, we can automatically register all the Vue components in the `/js` directory. This happens at build time, so there is no performance implications.

Note, this will register Vue components in sub folders as well, so it's the developer's responsibility to avoid naming collisions, since the folder name isn't included in the component name (although it could be added if they wanted). I don't see this as an issue, in fact I like it since it allows organization of Vue files into folders, but it's good to be aware of.

Examples:

- `/js/components/ExampleComponent.vue` becomes `<example-component></example-component>`
- `/js/components/Autocomplete.vue` becomes `<autocomplete></autocomplete>`
- `/js/pages/CreateUser.vue` becomes `<create-user></create-user>`
- `/js/Layout.vue` becomes `<layout></layout>`