### PR TITLE
[5.7] Bind LARAVEL_START into the container

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -49,6 +49,8 @@ $app = require_once __DIR__.'/../bootstrap/app.php';
 |
 */
 
+$app->instance('LARAVEL_START', LARAVEL_START);
+
 $kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
 
 $response = $kernel->handle(


### PR DESCRIPTION
When writing test code that covers features involving LARAVEL_START, it is impossible to not have it leak to other tests when using PHPUnit without using `isolateProcess` (https://github.com/laravel/telescope/pull/328/files#diff-1d02b08fbcaa478f6b508a29d704aad8R20). Binding the start time into the container allow the developer to rely on the container value instead of the constant and, therefore, allow value modification during PHPUnit tests.