### PR TITLE
[^5.6] Printing blade directive from database in laravel

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'previous' => '« Previous',
-    'next' => 'Next »',
+    'previous' => '&laquo; Previous',
+    'next' => 'Next &raquo;',
 
 ];


### PR DESCRIPTION
It would be great to return blade directives inside another directive (data stored in database)

# Example + Code

`{{$category->title}}` shows category title but it also stored in another table in database like `category {{$category->title}} has 45 posts and etc.` (some additional texts) then I get this in my blade:

`{!!$myCustom!!}` so this `myCustom` has to print something like:

```
category LARAVEL has 45 posts and etc.
```

but what I get currently is:

```
category {{$category->title}} has 45 posts and etc.
```

The title part won't print.




### reason I suggest/ ask for this ability

If you check [this plugin](https://www.mageworx.com/magento-seo-meta-templates-extension.html) of Magento you'll see the reason. This type of functionality can save lots of time for taking care of websites SEO also can be used for lot's of other purposes.