### PR TITLE
[5.7] Remove lodash dependency when auto registering Vue components

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -22,7 +22,7 @@ Vue.component('example-component', require('./components/ExampleComponent.vue'))
 // const files = require.context('./', true, /\.vue$/i)
 
 // files.keys().map(key => {
-//     return Vue.component(_.last(key.split('/')).split('.')[0], files(key))
+//     return Vue.component(key.split('/').pop().split('.')[0], files(key))
 // })
 
 /**


### PR DESCRIPTION
Love this new addition, but don't often use the full Lodash library. By using `pop()` instead of `_.last()`, everything will continue to work without Lodash being pulled in from `bootstrap.js`.