### PR TITLE
Prepare app.js for Mix 4.0 (and future)

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -18,7 +18,7 @@ window.Vue = require('vue');
  */
 
 // const files = require.context('./', true, /\.vue$/i)
-// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key)))
+// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 
 Vue.component('example-component', require('./components/ExampleComponent.vue'));
 


### PR DESCRIPTION
Since Mix 4.0 is still beta but is based on Babel7, it will now need to behave like `import`, which requires us to mention `default` to know what is `require`d.

Not sure if this is required right now, but it will be required once the switch is made. AFAIK, this is a non-breaking change for people who don't upgrade.