### PR TITLE
Change Laravel Mix to version 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "bootstrap": "^4.0.0",
         "cross-env": "^5.1",
         "jquery": "^3.2",
-        "laravel-mix": "^2.0",
+        "laravel-mix": "^4.0",
         "lodash": "^4.17.5",
         "popper.js": "^1.12",
         "vue": "^2.5.17"


### PR DESCRIPTION
Changes Laravel Mix from the old 2.0 to the new 4.0 version. It is backwards compatible, so no need to change config file. 