### PR TITLE
Add `vue-template-compiler` in `package.json` by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.15.2",
         "sass-loader": "^7.1.0",
-        "vue": "^2.5.17"
+        "vue": "^2.5.21",
+        "vue-template-compiler": "^2.5.21"
     }
 }


### PR DESCRIPTION
For a new Laravel application, after the very first `npm run prod`, `vue-template-compiler` would be added to `package.json` automatically by the Laravel Mix.

In the [recent PR](https://github.com/laravel/laravel/pull/4882), Jeffrey added SASS dependencies into the `package.json` to skip this auto-download step, because Laravel goes with SASS boilerplate by default.

But here we can see a similar situation. Laravel app goes with Vue.js boilerplate, so why don't we add `vue-template-compiler` as well?