### PR TITLE
[5.8] Update SQS queue configuration to use a url instead of prefix

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -52,7 +52,7 @@ return [
             'driver' => 'sqs',
             'key' => env('SQS_KEY', 'your-public-key'),
             'secret' => env('SQS_SECRET', 'your-secret-key'),
-            'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
+            'url' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id/sqs-queue-name'),
             'queue' => env('SQS_QUEUE', 'your-queue-name'),
             'region' => env('SQS_REGION', 'us-east-1'),
         ],


### PR DESCRIPTION
As per this [PR over in laravel/framework](https://github.com/laravel/framework/pull/27086) the default Amazon SQS configuration needs a full url, rather than a prefix.