### PR TITLE
upgrade trustedproxy package to 4.1 and adding config

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,14 +10,14 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array
+     * @var null|string|array
      */
     protected $proxies;
 
     /**
      * The headers that should be used to detect proxies.
      *
-     * @var int
+     * @var null|string|int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers;
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1.3",
-        "fideloper/proxy": "^4.0",
+        "fideloper/proxy": "^4.1",
         "laravel/framework": "5.7.*",
         "laravel/tinker": "^1.0"
     },

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using ELB or similar).
+     *
+     */
+    'proxies' => env('TRUSTEDPROXY_PROXIES', null), // [<ip addresses>,], '*', '<ip addresses>,'
+
+    /*
+     * To trust one or more specific proxies that connect
+     * directly to your server, use an array or a string separated by comma of IP addresses:
+     */
+    // 'proxies' => ['192.168.1.1'],
+    // 'proxies' => '192.168.1.1, 192.168.1.2',
+
+    /*
+     * Or, to trust all proxies that connect
+     * directly to your server, use a "*"
+     */
+    // 'proxies' => '*',
+
+    /*
+     * Which headers to use to detect proxy related data (For, Host, Proto, Port)
+     * 
+     * Options include:
+     * 
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
+     * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancer)
+     *
+     * - 'HEADER_X_FORWARDED_ALL' (use all x-forwarded-* headers to establish trust)
+     * - 'HEADER_FORWARDED' (use the FORWARDED header to establish trust)
+     * - 'HEADER_X_FORWARDED_AWS_ELB' (If you are using AWS Elastic Load Balancer)
+     * 
+     * @link https://symfony.com/doc/current/deployment/proxies.html
+     */
+    'headers' => env('TRUSTEDPROXY_HEADERS', 'HEADER_X_FORWARDED_ALL'),
+
+];


### PR DESCRIPTION
@fideloper will release [4.1](https://github.com/fideloper/TrustedProxy/releases) after this PR has been submitted. See [fideloper/TrustedProxy/pull/117 ](https://github.com/fideloper/TrustedProxy/pull/117).

**PROBLEM**: Hard coded settings in the TrustProxies middleware class.
- Production: Probably you will use ELB.
- Development: Probably you are not using ELB.

**SOLUTION**: Moving settings to config file. Config file get settings from env file. Really easy to define your settings based on environments.

Features:
1. Accept IPs separated by comma.
    - You can add this config to the .env file:
```config
TRUSTEDPROXY_PROXIES='192.168.1.1, 192.168.1.2'
# More options
TRUSTEDPROXY_PROXIES='*'
```

2. Accept headers as a string.
    - You can add this config to the .env file:
```config
TRUSTEDPROXY_HEADERS="HEADER_X_FORWARDED_ALL"
# More options
TRUSTEDPROXY_HEADERS="HEADER_FORWARDED"
TRUSTEDPROXY_HEADERS="HEADER_X_FORWARDED_AWS_ELB"
```

3. Added support for AWS ELB.

**Maybe you want to add this to the laravel documentation.**
If you are using AWS ELB with HTTPS you can configure your Nginx like this:
```nginx
server {
    # all traffic, secure or otherwise, comes in on 80 from the ELB
    listen 80;
    .......

    # ELB stores the protocol used between the client
    # and the load balancer in the X-Forwarded-Proto request header.
    # Check for 'https' and redirect if not
    if ($http_x_forwarded_proto != 'https') {
        return 301 https://$server_name$request_uri;
    }
    .......
}
```

Thanks.

