### PR TITLE
[5.7] Added property on verification controller to allow users to skip being logged in

### DIFF
--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -28,13 +28,23 @@ class VerificationController extends Controller
     protected $redirectTo = '/home';
 
     /**
+     * Users must be logged in to verify
+     *
+     * @var boolean
+     */
+    protected $forceAuth = true;
+
+    /**
      * Create a new controller instance.
      *
      * @return void
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        if ($this->forceAuth) {
+            $this->middleware('auth');
+        }
+
         $this->middleware('signed')->only('verify');
         $this->middleware('throttle:6,1')->only('verify', 'resend');
     }

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -28,9 +28,9 @@ class VerificationController extends Controller
     protected $redirectTo = '/home';
 
     /**
-     * Users must be logged in to verify
+     * Users must be logged in to verify.
      *
-     * @var boolean
+     * @var bool
      */
     protected $forceAuth = true;
 


### PR DESCRIPTION
I opened a PR on the framework side [HERE](https://github.com/laravel/framework/pull/27126). This feature will allow developers to specify whether or not they want the users to be logged in to be able to verify emails.