### PR TITLE
[5.8] Add beanstalk queue block_for config key

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -46,6 +46,7 @@ return [
             'host' => 'localhost',
             'queue' => 'default',
             'retry_after' => 90,
+            'block_for' => 0,
         ],
 
         'sqs' => [


### PR DESCRIPTION
This functionality was added in laravel/framework 9aa1706.