### PR TITLE
[5.7] opt: follow PSR12 coding standard

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -35,7 +35,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/config/cache.php
+++ b/config/cache.php
@@ -88,6 +88,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache'),
 
 ];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -51,7 +51,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
         ],
 

--- a/config/session.php
+++ b/config/session.php
@@ -126,7 +126,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
     ),
 
     /*

--- a/public/index.php
+++ b/public/index.php
@@ -21,7 +21,7 @@ define('LARAVEL_START', microtime(true));
 |
 */
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
@@ -35,7 +35,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 */
 
-$app = require_once __DIR__.'/../bootstrap/app.php';
+$app = require_once __DIR__ . '/../bootstrap/app.php';
 
 /*
 |--------------------------------------------------------------------------

--- a/server.php
+++ b/server.php
@@ -14,8 +14,8 @@ $uri = urldecode(
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ($uri !== '/' && file_exists(__DIR__.'/public'.$uri)) {
+if ($uri !== '/' && file_exists(__DIR__ . '/public' . $uri)) {
     return false;
 }
 
-require_once __DIR__.'/public/index.php';
+require_once __DIR__ . '/public/index.php';

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,7 +13,7 @@ trait CreatesApplication
      */
     public function createApplication()
     {
-        $app = require __DIR__.'/../bootstrap/app.php';
+        $app = require __DIR__ . '/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
 


### PR DESCRIPTION
Laravel is following ["PSR-2 Coding Style Guide"](https://www.php-fig.org/psr/psr-2/).

Now ["PSR-12 Extended Coding Style Guide"](https://www.php-fig.org/psr/#draft) is in draft, and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) has supported it.

There are some small errors when checked by PSR12.

```
./vendor/bin/phpcs --version
PHP_CodeSniffer version 3.4.0 (stable) by Squiz (http://www.squiz.net)
./vendor/bin/phpcs --standard=what
The installed coding standards are PEAR, MySource, PSR1, PSR2, PSR12, Squiz and Zend

./vendor/bin/phpcs --standard=PSR12 app/

FILE: /home/ubuntu/code/stonecutter/laravel/app/Console/Kernel.php
-----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
-----------------------------------------------------------------------
 38 | ERROR | [x] Expected at least 1 space before "."; 0 found
 38 | ERROR | [x] Expected at least 1 space after "."; 0 found
-----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-----------------------------------------------------------------------
```