### PR TITLE
redirectTo expects a string returned

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,7 +17,6 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
-        
         return new JsonResponse('Unauthenticated', 401);
     }
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,5 +17,7 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
+        
+        return new JsonResponse('Unauthenticated', 401);
     }
 }


### PR DESCRIPTION
redirectTo expects a string to be returned. In the case where the request expects JSON we should return a 401 Unauthenticated response.