### PR TITLE
[5.7] Return 401 Unauthorised response if expects JSON

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,10 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
-            return route('login');
+        if ($request->expectsJson()) {
+            return new JsonResponse('Unauthenticated', 401);
         }
+
+        return route('login');
     }
 }


### PR DESCRIPTION
We are expecting a string to be returned here. The redirect was wrapped to prevent unexpected responses for API routes where a JSON response was requested. 

Suggest we be explicit with the JSON response instead of deferring to the exception handler