### PR TITLE
Change order of boot and register methods in service providers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,21 +7,21 @@ use Illuminate\Support\ServiceProvider;
 class AppServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
      * Register any application services.
      *
      * @return void
      */
     public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
     {
         //
     }


### PR DESCRIPTION
This PR changes the order of the `boot` and `register` methods in service providers from alphabetic to the order in which they are used by the framework. This small change might make service providers slightly easier to understand, putting the method that runs first at the top, and the method that runs last at the bottom.

If this PR is accepted i'll also create a PR to change the stub used by the `artisan make:provider` command.



