### PR TITLE
web.config comment to help debug issues

### DIFF
--- a/public/web.config
+++ b/public/web.config
@@ -1,3 +1,8 @@
+<!--
+    Rewrites requires Microsoft URL Rewrite Module for IIS
+    Download https://www.microsoft.com/en-us/download/details.aspx?id=47337
+    Debug help: https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/using-failed-request-tracing-to-trace-rewrite-rules
+-->
 <configuration>
   <system.webServer>
     <rewrite>


### PR DESCRIPTION
IIS error reporting won't let you know why it errors out if the rewrite module is not installed.