### PR TITLE
[5.7] Date mutator for 'email_verified_at' attribute on User model stub (with explanation)

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -27,4 +27,13 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'email_verified_at',
+    ];
 }


### PR DESCRIPTION
The default included migration for the users table includes a timestamp field for 'email_verified_at'.
However, it might be a convience if the User model (stub) interpretes this field as a Carbon instance instead of a plain date/time string.
It also serves as a nice way to show the date mutator feature on models for someone new to Laravel