### PR TITLE
[5.7] Remove unnecessary link type on "welcome" view

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,7 +7,7 @@
         <title>Laravel</title>
 
         <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
 
         <!-- Styles -->
         <style>


### PR DESCRIPTION
Remove the link MIME type "text/css" definition since its use is unnecessary according to the HTML5 specs: https://html.spec.whatwg.org/multipage/semantics.html#the-link-element.