### PR TITLE
[5.8] Update to PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^2.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
**This PR needs to wait until laravel/framework has PHPUnit 8 support: https://github.com/laravel/framework/pull/27441**

Encourage people on 5.8 to use PHPUnit 8.