### PR TITLE
Added vue-template-compiler dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.15.2",
         "sass-loader": "^7.1.0",
-        "vue": "^2.5.17"
+        "vue": "^2.5.22",
+        "vue-template-compiler": "^2.5.22"
     }
 }


### PR DESCRIPTION
This fixes and avoids these errors:
1- `vue-template-compiler must be installed as a peer dependency`.
2- `vue and vue-template-compiler must be the same version`

I've reverted the compiled assets.