### PR TITLE
[5.8] Use $_SERVER instead of $_ENV for phpunit.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,11 +23,11 @@
         </whitelist>
     </filter>
     <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="MAIL_DRIVER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
+        <server name="APP_ENV" value="testing"/>
+        <server name="BCRYPT_ROUNDS" value="4"/>
+        <server name="CACHE_DRIVER" value="array"/>
+        <server name="MAIL_DRIVER" value="array"/>
+        <server name="QUEUE_CONNECTION" value="sync"/>
+        <server name="SESSION_DRIVER" value="array"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Laravel 5.8 limits dotenv to only rely on $_SERVER and not $_ENV. See https://github.com/laravel/framework/pull/27462