### PR TITLE
[5.8] use bigIncrements by default

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();


### PR DESCRIPTION
All new generated migrations will be using `bigIncrements`
see https://github.com/laravel/framework/pull/26472

https://github.com/laravel/framework/blob/8107fe1d3769fdef35a8ccb85d9ff0d942380394/src/Illuminate/Database/Migrations/stubs/create.stub#L17