### PR TITLE
[5.8] Add default guard to guest middleware

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -17,6 +17,10 @@ class RedirectIfAuthenticated
      */
     public function handle($request, Closure $next, ...$guards)
     {
+        if (empty($guards)) {
+            $guards = [null];
+        }
+
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
                 return redirect('/home');


### PR DESCRIPTION
Keep backward compatibility

Original PR
https://github.com/laravel/laravel/pull/4904

The code is very similar to `Authenticate` middleware

https://github.com/laravel/framework/blob/8107fe1d3769fdef35a8ccb85d9ff0d942380394/src/Illuminate/Auth/Middleware/Authenticate.php#L55-L59

ping @tomhorvat 
@laurencei 

After merging this PR, the
https://github.com/laravel/laravel/pull/4947
is not required