### PR TITLE
[5.8] Add Arr and Str aliases by default

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -191,6 +191,7 @@ return [
     'aliases' => [
 
         'App' => Illuminate\Support\Facades\App::class,
+        'Arr' => Illuminate\Support\Arr::class,
         'Artisan' => Illuminate\Support\Facades\Artisan::class,
         'Auth' => Illuminate\Support\Facades\Auth::class,
         'Blade' => Illuminate\Support\Facades\Blade::class,
@@ -220,6 +221,7 @@ return [
         'Schema' => Illuminate\Support\Facades\Schema::class,
         'Session' => Illuminate\Support\Facades\Session::class,
         'Storage' => Illuminate\Support\Facades\Storage::class,
+        'Str' => Illuminate\Support\Str::class,
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,


### PR DESCRIPTION
Now that array and string helpers have been removed, we should add aliases for `Arr` and `Str` to the default `config/app.php`, so that they can be easily used in views:

```blade
<h1>{{ Str::title($post->title) }}<h1>
```