### PR TITLE
[5.8] Remove default example policy

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Model' => 'App\Policies\ModelPolicy',
+        //
     ];
 
     /**


### PR DESCRIPTION
Just noticed that I couldn't access Nova after upgrading to Laravel 5.8. I removed all my custom policy definitions because I'm instead relying on the automatic resolution of policies. I reset my `AuthServiceProvider.php` to match the one that ships with a new install of the framework which has the default example policy.

```
ErrorException (E_ERROR)
Class App\Policies\ModelPolicy does not exist (View: /vendor/laravel/nova/resources/views/layout.blade.php) (View: /vendor/laravel/nova/resources/views/layout.blade.php)
```