### PR TITLE
[5.8] Default APP_DEBUG to false in phpunit tests.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
     </filter>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <server name="APP_DEBUG" value="false"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="MAIL_DRIVER" value="array"/>


### PR DESCRIPTION
By default, the `.env.example` file has `APP_ENV=true` which is great for local development.

However, when testing our applications, we want to test as if we are in production, ie: error messages returned from the server are **not** debug-level details.

This PR sets the `APP_DEBUG=false` in the `phpunit.xml` by default so that our tests can assert expected server responses.