### PR TITLE
[5.8] upgrade the collision dependency from v2 to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
-        "nunomaduro/collision": "^2.0",
+        "nunomaduro/collision": "^3.0",
         "phpunit/phpunit": "^7.5"
     },
     "config": {


### PR DESCRIPTION
This PR upgrades the collision dependency from v2 to v3 as mentioned here: https://twitter.com/enunomaduro/status/1103775614849482753