### PR TITLE
default to using app.timezone for mysql

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,6 +53,7 @@ return [
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
+            'timezone' => '+00:00',
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),


### PR DESCRIPTION
This will set the default MySQL connection timezone to '+00:00' for any new project, to match the default `app.timezone` setting.

MySQL defaults to using `SYSTEM` (the database's *local system timezone*) for connections, which may not be the same as the config value for `app.timezone`.

For one hour once a year (when clocks skip forward) this can result in Laravel saving invalid TIMESTAMP values and database exceptions, because MySQL internally converts the connection timezone to UTC when it saves a TIMESTAMP field as a unix timestamp.

More about the error: https://stackoverflow.com/q/55084109/6038111
More about MySQL time_zone: https://stackoverflow.com/a/19075291/6038111

PS: I'm not sure if this is the correct branch to send to!