### PR TITLE
Change remember_token string length in UserFactory class

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -21,6 +21,6 @@ $factory->define(User::class, function (Faker $faker) {
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-        'remember_token' => Str::random(10),
+        'remember_token' => Str::random(60),
     ];
 });


### PR DESCRIPTION
Change the remember_token string length to 60 to be consistent with the remember_token value set when the user sign in with the remember field filled.

Using the auth login form: 
remember_token = "26V8qaqpbL2I53o99vF21zuWlyeWr3dZXJlJeDUtlGasaeC0KfOubdO3Hz7x"

Using the UserFactory class:
remember_token = "Wr3dZXJlJe"