### PR TITLE
Ignore SQLite journals

### DIFF
--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite
+*.sqlite-journal


### PR DESCRIPTION
When SQLite is being used, journals appear as temporary files. However if the process that is using SQLite is terminated (Interrupting Dusk tests for example) before SQLite properly cleans after itself, you are left with said journal, which shouldn't be commited obvs.