### PR TITLE
Redirect duplicate URLs containing index.php

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -13,9 +13,12 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
+    
+    # Redirect Accessing index.php Directly...
+    RewriteRule ^index\.php/?(.*)$ /$1 [L,R=301]    
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^ index.php [L]
+    RewriteRule ^ index.php [END]
 </IfModule>


### PR DESCRIPTION
This change will prevent duplicate website URLs and redirect routes such as the following:

https://laravel.com/index.php/docs/5.8 -> https://laravel.com/docs/5.8
https://laravel.com/index.php -> https://laravel.com/