### PR TITLE
[5.8] Add missing @throws phpdoc

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -31,6 +31,8 @@ class Handler extends ExceptionHandler
      *
      * @param  \Exception  $exception
      * @return void
+     *
+     * @throws \Exception
      */
     public function report(Exception $exception)
     {


### PR DESCRIPTION
`parent::report()` may [throw an exception](https://github.com/laravel/framework/blob/5d2587bd32a088ff88ad701bce2423191c62edc9/src/Illuminate/Foundation/Exceptions/Handler.php#L109).