### PR TITLE
[5.8] Prefix redis database connection by default

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -117,6 +117,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'predis'),
+            'prefix' => str_slug(env('APP_NAME', 'laravel'), '_').'_database',
         ],
 
         'default' => [

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -117,7 +119,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'predis'),
-            'prefix' => str_slug(env('APP_NAME', 'laravel'), '_').'_database',
+            'prefix' => Str::slug(env('APP_NAME', 'laravel'), '_').'_database',
         ],
 
         'default' => [


### PR DESCRIPTION
This PR prefixes the `redis` database connection by default to mitigate multiple sites on the same server potentially sharing the same queued jobs. It uses similar logic to that which is used for creating the cache prefix.