### PR TITLE
[5.8] Add underscores to cache and redis database prefixes

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -97,6 +97,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -119,7 +119,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'predis'),
-            'prefix' => Str::slug(env('APP_NAME', 'laravel'), '_').'_database',
+            'prefix' => Str::slug(env('APP_NAME', 'laravel'), '_').'_database_',
         ],
 
         'default' => [


### PR DESCRIPTION
This PR adds an additional underscore to the end of the generated cache prefix and redis database prefix.

Addresses the relevant points regarding poorly named keys, mentioned by @fitztrev @ludo237 @gerardnll in https://github.com/laravel/laravel/pull/4982.