### PR TITLE
[5.8] Remove underscore from cache prefix

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -97,6 +97,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
 
 ];


### PR DESCRIPTION
This PR removes the underscore from the cache prefix, as cache prefixes automatically have a colon appended to them.

This change came from discussion here: https://github.com/laravel/laravel/pull/4986.