### PR TITLE
[5.8] Do not use config from the cache when running tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <server name="MAIL_DRIVER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
+        <env name="APP_CONFIG_CACHE" value="/storage"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Set the APP_CONFIG_CACHE to a path different then the one used by the framework so that it cannot find a cached configuration.

I know that typically in development config is not cached, and i do not cache it on purpose but this is my use case.

# Use case
I have two different databases in developement.
1- An empty one for automated tests.
2- Another one with information for manual browser testing and demo purposes.

When using the application in the browser, i have a settings module that will cache the application configuration by calling whenever the application settings are updated.

```php
Artisan::call('config:cache');
```

When i run my automated tests they fail because they will be running on the second database and not the one for the automated tests, because the configuration is cached (database name is cached as well).