### PR TITLE
[5.8] throttle the verification request first

### DIFF
--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -35,7 +35,7 @@ class VerificationController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
-        $this->middleware('signed')->only('verify');
         $this->middleware('throttle:6,1')->only('verify', 'resend');
+        $this->middleware('signed')->only('verify');
     }
 }


### PR DESCRIPTION
With the current order, the `throttle` middleware is never executed