### PR TITLE
[5.8] Allow for schema setting in .env for pgsql

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -71,7 +71,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'schema' => 'public',
+            'schema' => env('DB_SCHEMA', 'public'),
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
Laravel defaulted to the 'public' schema on pgsql connections and by default did not allow overriding it in the .env file. If a person uses different schemas for different environments, not allowing this in the .env file (where other environment data is defined) it made it more complicated than it needed to be. This also will make it easier for installers that only place database settings in the .env file