### PR TITLE
Reorder phpdoc block by syntax convention

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-/* @var $factory \Illuminate\Database\Eloquent\Factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\User;
 use Illuminate\Support\Str;


### PR DESCRIPTION
Reorder the `@var` phpdoc block syntax by convention, see http://docs.phpdoc.org/references/phpdoc/tags/var.html