### PR TITLE
Exclude StyleCI config from exported files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 *.css linguist-vendored
 *.scss linguist-vendored
 *.js linguist-vendored
+.styleci.yml export-ignore
 CHANGELOG.md export-ignore


### PR DESCRIPTION
I noticed that this file was being included when i ran the `laravel new` command and even though some developers will run StyleCI, the purpose of this file seems more like it ensures the repository quality rather than providing an starting point for this service.

On the other hand, this are really good defaults so i'm open minded about this, just wanted to make sure this wasn't an oversight 😃