### PR TITLE
[5.8] Add npm-run-all to simplify NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
     "private": true,
     "scripts": {
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "watch-poll": "npm run watch -- --watch-poll",
+        "development": "cross-env NODE_ENV=development run-s \"mix --progress\"",
+        "watch": "cross-env NODE_ENV=development run-s \"mix --progress --watch\"",
+        "watch-poll": "cross-env NODE_ENV=development run-s \"mix --progress --watch --watch-poll\"",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production run-s \"mix --no-progress\"",
+        "mix": "node_modules/webpack/bin/webpack.js --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
         "axios": "^0.18",
@@ -16,6 +17,7 @@
         "jquery": "^3.2",
         "laravel-mix": "^4.0.7",
         "lodash": "^4.17.5",
+        "npm-run-all": "^4.1.5",
         "popper.js": "^1.12",
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.15.2",


### PR DESCRIPTION
Including the full command for Laravel Mix can make the NPM scripts a bit difficult to comprehend especially when there are a few instances of it (along with the full paths to the webpack binary). `npm-run-all` provides a couple of useful commands to make scripts simpler to write.

In this case, I’ve added a new script called `mix` which will serve as the base command which we can use for our other tasks.

`run-s` runs a list of commands (with support for glob-patterns) sequentially.

Each script now clearly indicates which environment it’s running for, as well, which webpack options are set.

A tradeoff is that there is an extra script (`mix`), we need to define the Node environment for each script, and there’s a new dependency (which is totally useful later if people know how to use it — e.g `run-s lint mix`).

Note: we still do need to use escaped double quotes to pass flags and arguments to the scripts since apparently there are issues cross-platform if you just use unescaped single quotes.