### PR TITLE
Added "MAIL_THEME"

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -113,7 +113,7 @@ return [
     */
 
     'markdown' => [
-        'theme' => 'default',
+        'theme' => env('MAIL_THEME', 'default'),
 
         'paths' => [
             resource_path('views/vendor/mail'),


### PR DESCRIPTION
The "MAIL_THEME" env setting would allow easier on-the-fly customization of the mailable theme that is used in sending emails (especially if the config files are cached).