### PR TITLE
[5.8] Create EnsureEmailIsVerified.php in App / Http / Middleware /

### DIFF
--- a/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,101 @@
+<?php
+
+
+
+namespace App\Http\Middleware;
+
+
+
+use Closure;
+
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified as Middleware;
+
+use Illuminate\Support\Facades\Auth;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+// use Illuminate\Support\Facades\Redirect;
+
+
+
+class EnsureEmailIsVerified extends Middleware
+
+{
+
+    protected $guard;
+
+    /**
+
+     * Handle an incoming request.
+
+     *
+
+     * @param  \Illuminate\Http\Request  $request
+
+     * @param  \Closure  $next
+
+     * @return mixed
+
+     */
+
+    public function handle($request, Closure $next, $guard = null)
+
+    {
+
+        switch ($guard) {
+
+            // case 'admin':
+
+            //     $this->guard = $guard;
+
+            //     $link = "admin.verification.notice";
+
+            //     break;
+
+
+
+            // case 'writer':
+
+            //     $this->guard = $guard;
+
+            //     $link = "writer.verification.notice";
+
+            //     break;    
+
+            
+
+            default:
+
+                $this->guard = Auth::getDefaultDriver();
+
+                $link = "verification.notice";
+
+                break;
+
+        }
+
+
+
+        if (! $request->user($this->guard) ||
+
+            ($request->user($this->guard) instanceof MustVerifyEmail &&
+
+            ! $request->user($this->guard)->hasVerifiedEmail())) {
+
+
+
+            return $request->expectsJson()
+
+                    ? abort(403, 'Your email address is not verified.')
+
+                    : Redirect::route($link);
+
+        }
+
+
+
+        return $next($request);
+
+    }
+
+}


### PR DESCRIPTION
This file will be helpful for multi-guard-authentication Email Verification to send different type verification email to different guard's user as well as redirect to different path as per guard. 

> Also need change in **kernel.php** 


```
namespace App\Http;

protected $routeMiddleware = [
            [ … ]
        // 'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
        'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
        
    ];


```

> In **VerificationController.php** for 'Admin' guard have to add guard name like **$this->middleware('auth:admin');**


```
<?php
class VerificationController extends Controller
{


[ ….. ]
public function __construct()
    {
        $this->middleware('auth:admin');
        $this->middleware('signed')->only('verify');
        $this->middleware('throttle:6,1')->only('verify', 'resend');
    }
}

```

