### PR TITLE
[5.8] Fix type hint for case of trusting all proxies (string)

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array
+     * @var array|string
      */
     protected $proxies;
 


### PR DESCRIPTION
Trusted proxies example from the docs:

```
/**
 * The trusted proxies for this application.
 *
 * @var array
 */
protected $proxies = '*';
```