### PR TITLE
Add DYNAMODB_ENDPOINT to the cache config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -82,6 +82,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
             'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
+            'endpoint' => env('DYNAMODB_ENDPOINT'),
         ],
 
     ],


### PR DESCRIPTION
This adds the DYNAMODB_ENDPOINT environment variable to the
dynamodb store of the cache config.

Its usage is implemented in the framework as laravel/framework#28600