### PR TITLE
[5.8] Update axios package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.18",
+        "axios": "^0.19",
         "bootstrap": "^4.1.0",
         "cross-env": "^5.1",
         "jquery": "^3.2",


### PR DESCRIPTION
Update axios in package.json to ^0.19 so that I don't get security vulnerability notification emails from Github when I push to my laravel project repos even though "^0.18" covers 0.19 as well

See: https://nvd.nist.gov/vuln/detail/CVE-2019-10742

This PR is similar in nature to this: https://github.com/laravel/laravel/pull/4730 (not the same vulnerability, but the justification to update)