### PR TITLE
[5.8] Replace redirect string `/home` with a config value

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = config('auth.redirect_authenticated');
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -28,7 +28,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = config('auth.redirect_authenticated');
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,7 +25,7 @@ class ResetPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = config('auth.redirect_authenticated');
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -25,7 +25,7 @@ class VerificationController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = config('auth.redirect_authenticated');
 
     /**
      * Create a new controller instance.

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/home');
+            return redirect(config('auth.redirect_authenticated'));
         }
 
         return $next($request);

--- a/config/auth.php
+++ b/config/auth.php
@@ -100,4 +100,16 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect authenticated
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies where users are redirected after registering,
+    | logging in or trying to log in when already logged in.
+    |
+    */
+
+    'redirect_authenticated' => '/home',
+
 ];


### PR DESCRIPTION
Authentication is one of the features that can be used without modifications for most simple projects. Except the redirects after login, as the home URL is different from app to app (`/panel`, `/dashboard`, `/admin`, `/`, ...).

Going over all the files when changing the redirect is not only a nuissance - it also leads to hard-to-notice bugs. For example, consider forgetting to change it in `RedirectIfAuthenticated` middleware - it's rare that someone actually tests accessing `/login` when already logged in. It's usually discovered some time later by the users using a bookmark.

This PR is my attempt to reduce the setup time and the chance to introduce such bugs - let's replace the repeated string literal with references to a config value.