### PR TITLE
Add .env.backup to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /storage/*.key
 /vendor
 .env
+.env.backup
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml


### PR DESCRIPTION
When running Laravel Dusk tests, the application `.env` gets renamed to `.env.backup`, and is restored when the tests are done. However, if you abort the tests, the `.env.backup` still exists. Adding it to the gitignore could help prevent it from being accidentally committed.

Edit: i just noticed this was rejected before in https://github.com/laravel/laravel/pull/4411