### PR TITLE
[6.0] Add PHPUnit bootstrap file to allow execution of console commands before a test run

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
@@ -29,5 +29,10 @@
         <server name="MAIL_DRIVER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
+        <server name="APP_CONFIG_CACHE" value="bootstrap/cache/config.phpunit.php"/>
+        <server name="APP_SERVICES_CACHE" value="bootstrap/cache/services.phpunit.php"/>
+        <server name="APP_PACKAGES_CACHE" value="bootstrap/cache/packages.phpunit.php"/>
+        <server name="APP_ROUTES_CACHE" value="bootstrap/cache/routes.phpunit.php"/>
+        <server name="APP_EVENTS_CACHE" value="bootstrap/cache/events.phpunit.php"/>
     </php>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Contracts\Console\Kernel;
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+/*
+|--------------------------------------------------------------------------
+| Bootstrap the testing environment
+|--------------------------------------------------------------------------
+|
+| You have the option to specify console commands that will execute before your
+| test suite is run. Caching config, routes, & events may improve performance
+| and bring your testing environment closer to production.
+|
+*/
+
+$commands = [
+    'config:cache',
+    'event:cache',
+    // 'route:cache',
+];
+
+$app = require __DIR__.'/../bootstrap/app.php';
+
+$console = tap($app->make(Kernel::class))->bootstrap();
+
+foreach ($commands as $command) {
+    $console->call($command);
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,4 +28,3 @@ $console = tap($app->make(Kernel::class))->bootstrap();
 foreach ($commands as $command) {
     $console->call($command);
 }
-


### PR DESCRIPTION
This PR introduces a PHPUnit  ~~watcher~~ bootstrap file that caches the config before the test suite runs for the first time, which in [my benchmarks](https://timacdonald.me/the-case-laravel-testcase/) reduces the boot time of the Kernel during a test run by ~50% without any additional work by the developer.

This will only really have an impact on a larger test suite, but personally I think it is a worthwhile thing to consider.

The benchmark test suite ended up with the following durations:

- Without caching: 9.15s
- With caching: 4.2s

Caching the config before a test run is good for a couple of reasons:

1. It's faster.
2. It is closer reflects what you use in production.

If, for example, you cache your routes in production but try deploy a sneaky closure route, your app is gonna blow up when you go to cache the routes during production. Having this in place will help you catch that kind of thing during testing, either locally or during CI. (you could catch this in CI if you are already calling this command before running the tests).

The PHPUnit ~~listener~~ bootstrap file will cache the config for the test environment before a test is run. Because it is in "User land" it is 100% opt-in. If you don't want it, don't use it. One handy thing about running the cache command in a ~~PHPUnit listener~~ bootstrap file (as opposed to say in a composer script) is that it will already have the environment variables from the phpunit.xml file loaded, so we don't need to read those ourselves.

## Notes

- As this doesn't require any changes to the framework, it is totally possible to just package up, which I'm more than happy to do.

- The watcher could be kept in core with just the `phpunit.xml` changes made here.

- it is possible we could see similar results by caching routes and events, but I haven’t tested this yet. I plan to extend the benchmark repo I setup to also have some feature (http) tests so we can see what kind of impact that might have on a test suite as well.

This PR is a simpler approach to my first run at this: https://github.com/laravel/framework/pull/28998