### PR TITLE
[5.9] Move TrustProxies to highest priority - fixes maintenance mode ip whitelist if behind proxy e.g. Cloudflare

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,11 +14,11 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-        \App\Http\Middleware\TrustProxies::class,
     ];
 
     /**


### PR DESCRIPTION
Noticed this when trying to do `php artisan down --allow=<ip>` if your behind Cloudflare / some other proxy it won't allow you to access site - this is because `TrustProxies` only kicks in *after* maintenance mode middleware.

It also makes sense to me to whitelist a request straight away as the first thing in the app before firing any subsequent middlewares.