### PR TITLE
[5.8] Fix api middleware ordering

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,8 +38,8 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'bindings',
             'throttle:60,1',
+            'bindings',
         ],
     ];
 
@@ -76,5 +76,6 @@ class Kernel extends HttpKernel
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
         \Illuminate\Auth\Middleware\Authorize::class,
+        \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,8 +38,8 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
             'bindings',
+            'throttle:60,1',
         ],
     ];
 


### PR DESCRIPTION
This PR reorders the default API middlewares.

We can use a  [dynamic API rate limiter](https://laravel.com/docs/5.8/routing#rate-limiting), by adding an attribute on the `User` model.

However, this does not work the way it should, because the `bindings` middleware comes after the `throttle` middleware by default. This means, the `$request->user()` object is `null` in the [`resolveMaxAttempts()`](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Routing/Middleware/ThrottleRequests.php#L73-L84) method, so it's not possible to retrieve the rate limiter attribute from the user. In this case,  we get a `429` HTTP error on the second API call, even if we are authenticated.

When using the `actingAs()` method in tests, it binds the user "manually", so this problem does not occur.

By adding the `ThrottleRequests` class after the `SubstituteBindings` in the `$middlewarePriority` array, the user object (and its limiter attribute) would be available for the rate limiter. 

Of course, it's not a big deal to fix it manually for every project, but probably it would be a nice indication.


