### PR TITLE
[5.8] Update deprecated pusher option

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,7 +37,7 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'encrypted' => true,
+                'useTLS' => true,
             ],
         ],
 


### PR DESCRIPTION
I was looking at source code pusher php library:

https://github.com/pusher/pusher-http-php/blob/60148190da064d662caeceee9a920592b5aae78e/src/Pusher.php#L107-L113

Seems both options are supported, but they are saying `encrypted` is deprecated.

Also, Laravel documentation is showing the `useTLS` instead of `encrypted`:

https://laravel.com/docs/5.8/broadcasting