### PR TITLE
[5.8] Fixed lodash version (CVE-2019-10744)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "cross-env": "^5.1",
         "jquery": "^3.2",
         "laravel-mix": "^4.0.7",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.13",
         "popper.js": "^1.12",
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.15.2",


### PR DESCRIPTION
Hello!

lodash in package.json - 4.17.5, but [CVE-2019-10744](https://github.com/lodash/lodash/pull/4336) affected versions (<4.17.13) of lodash are vulnerable to Prototype Pollution