### PR TITLE
Fix cache, redis and session prefixes for non-English `APP_NAME`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+APP_CODE=Laravel
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-APP_CODE=Laravel
 APP_NAME=Laravel
+APP_CODE=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/config/cache.php
+++ b/config/cache.php
@@ -98,6 +98,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_CODE', env('APP_NAME', 'laravel')), '_').'_cache'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -123,7 +123,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'predis'),
-            'prefix' => Str::slug(env('APP_NAME', 'laravel'), '_').'_database_',
+            'prefix' => Str::slug(env('APP_CODE', env('APP_NAME', 'laravel')), '_').'_database_',
         ],
 
         'default' => [

--- a/config/session.php
+++ b/config/session.php
@@ -126,7 +126,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_CODE', env('APP_NAME', 'laravel')), '_').'_session'
     ),
 
     /*


### PR DESCRIPTION
When setting non-English `APP_NAME`. The computed prefixes for cache, Redis and session would be something like `_cache`, not the `foo_cache` format. This PR try to fix this.