### PR TITLE
Update AppServiceProvider.php

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
When Trying To Run The Migration Just After The Installation If Length Of Any Column In the Schema That Gives An Error To Define The String Length This Helps When String Length Is Not Define In Any Of The Migration. Set The Default String Length As 191.