### PR TITLE
[6.0] Current working directory set to project root in bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,8 @@ use Illuminate\Contracts\Console\Kernel;
 
 require_once __DIR__.'/../vendor/autoload.php';
 
+chdir(__DIR__.'/../');
+
 /*
 |--------------------------------------------------------------------------
 | Bootstrap The Test Environment


### PR DESCRIPTION
As `APP_CONFIG_CACHE`, `APP_SERVICES_CACHE`, `APP_PACKAGES_CACHE`, `APP_ROUTES_CACHE` and `APP_EVENTS_CACHE` are defined as relative paths from project root in `phpunit.xml`, this PR updates current working directory with project root during test bootstrap.
Without this, it is not possible to launch tests from another location than project root and it is not possible anymore to launch a single test class from (at least) PHPStorm.
See discussion in #5050 