### PR TITLE
[6.0] Remove deprecated language line

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -13,7 +13,6 @@ return [
     |
     */
 
-    'password' => 'Passwords must be at least eight characters and match the confirmation.',
     'reset' => 'Your password has been reset!',
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',


### PR DESCRIPTION
This got removed in its related PR here: https://github.com/laravel/framework/pull/29480