### PR TITLE
[5.8] Remove unnecessary X-CSRF-TOKEN header from our Axios instance

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -24,20 +24,6 @@ window.axios = require('axios');
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**
- * Next we will register the CSRF Token as a common header with Axios so that
- * all outgoing HTTP requests automatically have it attached. This is just
- * a simple convenience so we don't have to attach every token manually.
- */
-
-let token = document.head.querySelector('meta[name="csrf-token"]');
-
-if (token) {
-    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
-} else {
-    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
-}
-
-/**
  * Echo exposes an expressive API for subscribing to channels and listening
  * for events that are broadcast by Laravel. Echo and event broadcasting
  * allows your team to easily build robust real-time web applications.


### PR DESCRIPTION
In `bootstrap.js` we currently add a `X-CSRF-TOKEN` HTTP header (note the 'C') to the Axios instance that we instantiate, using the value of a `<meta>` tag added by the auth scaffolding. This is not necessary because [Axios already has similar functionality](https://github.com/axios/axios/blob/master/dist/axios.js#L1077) enabled by default where it will add a `X-XSRF-TOKEN` HTTP header (note the second 'X') using the value of the `XSRF-TOKEN` cookie.

On a current installation of Laravel, our Axios instance requests have both the `X-CSRF-TOKEN` and the `X-XSRF-TOKEN` HTTP headers. The only difference is the `X-CSRF-TOKEN` value is unencrypted, while the `X-XSRF-TOKEN` value is encrypted.

I believe we can safely remove the `X-CSRF-TOKEN` HTTP header configuration from `bootstrap.js` because Laravel already verifies requests using the `X-XSRF-TOKEN` HTTP header in the [`VerifyCsrfToken` middleware](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L152). The same is also now true for [Passport >=7.4 `TokenGuard`](https://github.com/laravel/passport/blob/7.0/src/Guards/TokenGuard.php#L272) for users [consuming their API with JavaScript](https://laravel.com/docs/5.8/passport#consuming-your-api-with-javascript).

I have verified that this works on a fresh Laravel 5.8 installation for Axios POST requests going through our `web` middleware group, as well as requests going through the `auth:api` middleware when Passport is configured as linked above.

I have submitted a draft PR at https://github.com/laravel/docs/pull/5382 to update the docs if this is accepted.