### PR TITLE
[6.0] Use phpredis as default Redis client

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -119,10 +119,10 @@ return [
 
     'redis' => [
 
-        'client' => env('REDIS_CLIENT', 'predis'),
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
-            'cluster' => env('REDIS_CLUSTER', 'predis'),
+            'cluster' => env('REDIS_CLUSTER', 'phpredis'),
             'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
         ],
 

--- a/config/database.php
+++ b/config/database.php
@@ -122,7 +122,7 @@ return [
         'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
-            'cluster' => env('REDIS_CLUSTER', 'phpredis'),
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
             'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
         ],
 


### PR DESCRIPTION
Follow up for https://github.com/laravel/framework/pull/29688

It's best that we already start using `phpredis` as a default to discourage usage of Predis.

I'm not sure where `REDIS_CLUSTER` is set? Probably a native Redis option?