### PR TITLE
[5.8] Remove homestead from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,5 @@
 .env
 .env.backup
 .phpunit.result.cache
-Homestead.json
-Homestead.yaml
 npm-debug.log
 yarn-error.log


### PR DESCRIPTION
accroding to this commit [use generic default db config](https://github.com/laravel/laravel/commit/6f3d68f67f3dab0e0d853719696ede8dfd9cc4e1) i think remove homestead from gitignore is goodchange