### PR TITLE
[6.x] Allowing optional use of yml/yaml file extensions in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
The YAML docs generally recommends using .yaml as the preferred extension for YAML files - https://yaml.org/faq.html.

I've tweaked the .editorconfig to set both yaml and yml files to have the same indentation. Without this, *.yaml files default to 4 spaces.