### PR TITLE
[6.x] Set argon defaults to prevent password_hash(): Memory cost is outside…

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,9 +44,9 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
-        'threads' => 2,
-        'time' => 2,
+        'memory' => PASSWORD_ARGON2_DEFAULT_MEMORY_COST,
+        'threads' => PASSWORD_ARGON2_DEFAULT_THREADS,
+        'time' => PASSWORD_ARGON2_DEFAULT_TIME_COST,
     ],
 
 ];


### PR DESCRIPTION
… of allowed memory range on PHP 7.4

With the values 
````
'argon' => [
        'memory' => 1024,
        'threads' => 2,
        'time' => 2,
    ],
```
Hash::make() produces password_hash(): Memory cost is outside of allowed memory range on PHP 7.4