### PR TITLE
Add .vapor directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/.vapor
 /vendor
 .env
 .env.backup


### PR DESCRIPTION
Could we add `.vapor` in project `.gitignore`? because some deployment failure keep this directory to commit.