### PR TITLE
[5.8] Argon2 requires at least 8KB

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,7 +44,7 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
+        'memory' => 8192,
         'threads' => 2,
         'time' => 2,
     ],


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=78516
Argon2 requires at least 8KB
On PHP 7.4 memory 1024 will throw:
password_hash(): Memory cost is outside of allowed memory range