### PR TITLE
Revert "[6.x] According to PHP Bug 78516 Argon2 requires at least 8KB"

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,7 +44,7 @@ return [
     */
 
     'argon' => [
-        'memory' => 8192,
+        'memory' => 1024,
         'threads' => 2,
         'time' => 2,
     ],


### PR DESCRIPTION
Reverts laravel/laravel#5097. ~Laravel's hash manager should select the correct value to pass to PHP. The intended default is 1MB, across any PHP version.~ The bug will be fixed before PHP 7.4 is released.