### PR TITLE
Use the word "email" instead of "e-mail" consistently

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -8,7 +8,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Laravel supports both SMTP and PHP's "mail" function as drivers for the
-    | sending of e-mail. You may specify which one you're using throughout
+    | sending of email. You may specify which one you're using throughout
     | your application here. By default, Laravel is setup for SMTP mail.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses",
@@ -36,9 +36,9 @@ return [
     | SMTP Host Port
     |--------------------------------------------------------------------------
     |
-    | This is the SMTP port used by your application to deliver e-mails to
+    | This is the SMTP port used by your application to deliver emails to
     | users of the application. Like the host we have set this value to
-    | stay compatible with the Mailgun e-mail application by default.
+    | stay compatible with the Mailgun email application by default.
     |
     */
 
@@ -49,9 +49,9 @@ return [
     | Global "From" Address
     |--------------------------------------------------------------------------
     |
-    | You may wish for all e-mails sent by your application to be sent from
+    | You may wish for all emails sent by your application to be sent from
     | the same address. Here, you may specify a name and address that is
-    | used globally for all e-mails that are sent by your application.
+    | used globally for all emails that are sent by your application.
     |
     */
 
@@ -62,11 +62,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | E-Mail Encryption Protocol
+    | Email Encryption Protocol
     |--------------------------------------------------------------------------
     |
     | Here you may specify the encryption protocol that should be used when
-    | the application send e-mail messages. A sensible default using the
+    | the application send email messages. A sensible default using the
     | transport layer security protocol should provide great security.
     |
     */
@@ -93,7 +93,7 @@ return [
     | Sendmail System Path
     |--------------------------------------------------------------------------
     |
-    | When using the "sendmail" driver to send e-mails, we will need to know
+    | When using the "sendmail" driver to send emails, we will need to know
     | the path to where Sendmail lives on this server. A default path has
     | been provided here, which will work well on most of your systems.
     |

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 
 ## Security Vulnerabilities
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability within Laravel, please send an email to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
 
 ## License
 

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -14,8 +14,8 @@ return [
     */
 
     'reset' => 'Your password has been reset!',
-    'sent' => 'We have e-mailed your password reset link!',
+    'sent' => 'We have emailed your password reset link!',
     'token' => 'This password reset token is invalid.',
-    'user' => "We can't find a user with that e-mail address.",
+    'user' => "We can't find a user with that email address.",
 
 ];

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -140,7 +140,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The following language lines are used to swap our attribute placeholder
-    | with something more reader friendly such as "E-Mail Address" instead
+    | with something more reader friendly such as "Email Address" instead
     | of "email". This simply helps us make our message more expressive.
     |
     */


### PR DESCRIPTION
Nowadays, in English, "email" is used more often compared to "e-mail". Several places in Laravel were already using the word "email"; this makes spelling consistent across the framework.