### PR TITLE
[6.x] Improve executeAfterLastTest logic

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -38,7 +38,7 @@ class Bootstrap implements BeforeFirstTestHook, AfterLastTestHook
     public function executeAfterLastTest(): void
     {
         array_map('unlink', glob('bootstrap/cache/*.phpunit.php'));
-        
+
         $console = $this->createApplication()->make(Kernel::class);
 
         $console->call("config:clear");

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -38,5 +38,9 @@ class Bootstrap implements BeforeFirstTestHook, AfterLastTestHook
     public function executeAfterLastTest(): void
     {
         array_map('unlink', glob('bootstrap/cache/*.phpunit.php'));
+        
+        $console = $this->createApplication()->make(Kernel::class);
+
+        $console->call("config:clear");
     }
 }


### PR DESCRIPTION
This PR solve an issue found on tests suite that does not rely upon `RefreshApplication` trait but rather `DatabaseTransaction` trait, also if you have multiple `.env` files for different environments.

Without the artisan call at the end of `executeAfterLastTest` if you try to seed the database you will end up with the database full of artifacts, the reason is that the config file cached will have values from the `.env.testing` file instead of the normal `.env` file.

This is not a breaking change and it should be fine for all supported versions of Laravel, let me know if I need to specify a different target branch.

Farewell