### PR TITLE
[6.x] Add 'null' logging channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -72,7 +72,7 @@ return [
             ],
         ],
 
-        'none' => [
+        'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,
         ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -72,11 +72,6 @@ return [
             ],
         ],
 
-        'null' => [
-            'driver' => 'monolog',
-            'handler' => NullHandler::class,
-        ],
-
         'stderr' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,
@@ -94,6 +89,11 @@ return [
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => 'debug',
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
         ],
     ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -71,7 +71,7 @@ return [
                 'port' => env('PAPERTRAIL_PORT'),
             ],
         ],
-        
+
         'none' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 
@@ -69,6 +70,11 @@ return [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
             ],
+        ],
+        
+        'none' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
         ],
 
         'stderr' => [


### PR DESCRIPTION
As proposed on https://github.com/laravel/ideas/issues/1806, this implementation ads a 'none' logging channel which outputs logs to nowhere by using Monolog's 'NullHandler' class.