### PR TITLE
[6.x] Rename Redis alias to RedisManager

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -214,7 +214,7 @@ return [
         'Password' => Illuminate\Support\Facades\Password::class,
         'Queue' => Illuminate\Support\Facades\Queue::class,
         'Redirect' => Illuminate\Support\Facades\Redirect::class,
-        'Redis' => Illuminate\Support\Facades\Redis::class,
+        'RedisManager' => Illuminate\Support\Facades\Redis::class,
         'Request' => Illuminate\Support\Facades\Request::class,
         'Response' => Illuminate\Support\Facades\Response::class,
         'Route' => Illuminate\Support\Facades\Route::class,


### PR DESCRIPTION
Laravel 6 switched to PhpRedis as the default driver instead of Predis (#5085). The documentation recommends that if you're using PhpRedis, you should rename the `Redis` alias to `RedisManager`.

> If you plan to use PhpRedis extension along with the `Redis` Facade alias, you should rename it to something else, like `RedisManager`, to avoid a collision with the Redis class. You can do that in the aliases section of your `app.php` config file.

It would then seem logical that the default alias should match this recommendation...which is what this PR changes.