### PR TITLE
[6.x] Sync indentation with laravel/ui webpack files

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -12,4 +12,4 @@ const mix = require('laravel-mix');
  */
 
 mix.js('resources/js/app.js', 'public/js')
-    .sass('resources/sass/app.scss', 'public/css');
+   .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
The webpack files scaffolded by the laravel/ui's [vue](https://github.com/laravel/ui/blob/master/src/Presets/vue-stubs/webpack.mix.js#L15) and [react](https://github.com/laravel/ui/blob/master/src/Presets/react-stubs/webpack.mix.js#L15) presets have a different indentation that the [default one](https://github.com/laravel/laravel/blob/master/webpack.mix.js#L15). This change keeps them consistent and avoid unnecessary git diffs when the scaffolding happens.