### PR TITLE
[6.x] Add ValidateJson middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -57,6 +57,7 @@ class Kernel extends HttpKernel
         'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'json' => \App\Http\Middleware\ValidateJson::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,

--- a/app/Http/Middleware/ValidateJson.php
+++ b/app/Http/Middleware/ValidateJson.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class ValidateJson
+{
+    /**
+     * The HTTP verbs that should be validated.
+     *
+     * @var array
+     */
+    protected $methodsToParse = [
+        'DELETE',
+        'PATCH',
+        'POST',
+        'PUT',
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (!in_array($request->getMethod(), $this->methodsToParse)) {
+            return $next($request);
+        }
+
+        json_decode($request->getContent());
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new \RuntimeException(
+                'Unable to parse JSON data: '
+                . json_last_error_msg()
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ValidateJson.php
+++ b/app/Http/Middleware/ValidateJson.php
@@ -27,7 +27,7 @@ class ValidateJson
      */
     public function handle($request, Closure $next)
     {
-        if (!in_array($request->getMethod(), $this->methodsToParse)) {
+        if (! in_array($request->getMethod(), $this->methodsToParse)) {
             return $next($request);
         }
 
@@ -36,7 +36,7 @@ class ValidateJson
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \RuntimeException(
                 'Unable to parse JSON data: '
-                . json_last_error_msg()
+                .json_last_error_msg()
             );
         }
 


### PR DESCRIPTION
Every time I start a new API project, I create a simple middleware to verify JSON on incoming requests’ body.
Even considering it is simple, it is useful to inspect the payload integrity and, in case of a not valid JSON input, the middleware returns a more descriptive error (good for API consumers), saving resources by avoiding to getting deep in the application.
Considering that Laravel is used for so many JSON API projects, I think it would be good to have this out-of-the-box, by just enabling it in Kernel file.