### PR TITLE
[6.x] update Laravel Mix to new version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "devDependencies": {
         "axios": "^0.19",
         "cross-env": "^5.1",
-        "laravel-mix": "^4.0.7",
+        "laravel-mix": "^5.0.0",
         "lodash": "^4.17.13",
-        "resolve-url-loader": "^2.3.1",
+        "resolve-url-loader": "^3.1.0",
         "sass": "^1.15.2",
-        "sass-loader": "^7.1.0"
+        "sass-loader": "^8.0.0"
     }
 }


### PR DESCRIPTION
and update the other shared dependencies with Mix.

I've personally updated these 3 dependencies in some projects and run into no issues, but maybe @JeffreyWay could weigh in here with any potential concerns.

also, since this is `laravel/laravel` it won't affect existing projects, so we should be good to update this for new projects.