### PR TITLE
[6.x] Fixes required version of the framework within `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.2",
         "fideloper/proxy": "^4.0",
-        "laravel/framework": "^6.0",
+        "laravel/framework": "^6.2",
         "laravel/tinker": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
After https://github.com/laravel/laravel/pull/5129, the current application boilerplate within `laravel/laravel` does not work with the previous version of Laravel 6. Giving the error:

`Illuminate\Contracts\Container\BindingResolutionException Target class [Illuminate\Auth\Middleware\RequirePassword] does not exist.`

This pull request addresses that exact same issue, specifying that the current boilerplate only works with newer versions of the Framework.

> Note: Probably nobody will ever face this problem, just making my first contribution of the day. 🤗