### PR TITLE
Update composer.json to remove license MIT

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "framework",
         "laravel"
     ],
-    "license": "MIT",
     "require": {
         "php": "^7.2",
         "fideloper/proxy": "^4.0",


### PR DESCRIPTION
Because the skeleton app isn't licensed according to earlier PR requests and reactions from @taylorotwell the license needs to be removed from composer.json. The framework composer.json has the MIT license tag applied to it so the license will apply to the framework only. This way the skeleton app can be used in proprietary projects.