### PR TITLE
[6.x] Add the AWS_SESSION_TOKEN variable for the S3 config

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,6 +59,7 @@ return [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'token' => env('AWS_SESSION_TOKEN'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),


### PR DESCRIPTION
In some cases, the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables are not enough to authenticate to the AWS API. The `AWS_SESSION_TOKEN` must be provided as well.

The `AWS_SESSION_TOKEN` is part of the "Temporary Security Credentials" authentication mechanism. See the [AWS Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).

One of those cases is when Laravel runs on AWS Lambda. In that case the `AWS_SESSION_TOKEN` variable is populated ([source](https://docs.aws.amazon.com/lambda/latest/dg/lambda-environment-variables.html)).

With the default Laravel installation, when listing files in the `s3` drive, I get:

> Aws\S3\Exception\S3Exception
> Error executing "ListObjects" on "https://redacted.s3.amazonaws.com/?prefix=&delimiter=%2F&encoding-type=url"; AWS HTTP error: Client error: `GET https://redacted.s3.amazonaws.com/?prefix=&delimiter=%2F&encoding-type=url` resulted in a `403 Forbidden` response:
> `<?xml version="1.0" encoding="UTF-8"?> <Error><Code>InvalidAccessKeyId</Code><Message>The AWS Access Key Id you provided does not exist in our records.</Message><AWSAccessKeyId>redacted</AWSAccessKeyId><RequestId>redacted</RequestId><HostId>redacted</HostId></Error>`

By adding the `token` line to the configuration, the API call succeeds and my application works as expected.

I expect that adding the line will not cause any regression in cases where the `AWS_SESSION_TOKEN` is not define: the `token` option will remain empty.