### PR TITLE
added the doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.2",
         "laravel/tinker": "^1.0"


### PR DESCRIPTION
doctrine/dbal is required for migrations. 

To reproduce the issue follow these steps
```
laravel new test
cd test
php artisan make:migration add_field_to_users_table --table=users
```
no need to setup a new database for that ;) 
`touch database/database.sqlite`
edit your .env file to use sqlite instead of mysql. 

edit the created ____add_field_to_users_table.php migration file, add a random column and drop it in down method. 
```
    public function up() {
        Schema::table('users', function (Blueprint $table) {
            $table->text('field')->unique()->nullable();
        });
    }

    public function down() {
        Schema::table('users', function (Blueprint $table) {
            $table->dropColumn('field');
        });
    }
```

The `php artisan migrate`  command runs as expected, but 
`php artisan migrate:refresh` will fail with the missing `Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'Doctrine\DBAL\Driver\PDOSqlite\Driver' not found` Exception, that is shipped with `doctrine/dbal` 