### PR TITLE
[6.x] Security fix: Waiting before retrying password reset

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -97,6 +97,7 @@ return [
             'provider' => 'users',
             'table' => 'password_resets',
             'expire' => 60,
+            'timeout' => 60,
         ],
     ],
 

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -17,5 +17,6 @@ return [
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
     'user' => "We can't find a user with that e-mail address.",
+    'timeout' => 'Please wait before retrying.',
 
 ];


### PR DESCRIPTION
Hello!
An attacker can use the password recovery function to spam the user's mailbox and / or overload the mail server.
This can be avoided by delaying the next attempt to use the password recovery function.
Also changes to laravel/framework are submited.
Thanks!
