### PR TITLE
Fix for too long key error

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email', 191)->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
+            $table->string('email', 191)->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });


### PR DESCRIPTION
When using MariaDB or MySQL below v. 5.7.7, there is an inconvenient error stating:
[Illuminate\Database\QueryException]
SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes (SQL: alter table users add unique users_email_unique(email))

There are many great solutions for this issue, being one of them well-explained in:
https://laravel-news.com/laravel-5-4-key-too-long-error

However, I believe the best solution would be not having to deal with an error at all. Furthermore, you won't affect any other schema setting an undesired default length to them.