### PR TITLE
Added sqlite:memory connection to use in phpunit

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -43,6 +43,12 @@ return [
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],
 
+        'sqlite:memory' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DATABASE_URL'),


### PR DESCRIPTION
With this connection, we may only use `<server name="DB_CONNECTION" value="sqlite:memory"/>` for testing on memory.
