### PR TITLE
[6.x] Rename `encrypted` to `forceTLS` for Pusher

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -24,5 +24,5 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     broadcaster: 'pusher',
 //     key: process.env.MIX_PUSHER_APP_KEY,
 //     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
-//     encrypted: true
+//     forceTLS: true
 // });


### PR DESCRIPTION
The `encrypted` option for Pusher is deprecated and replaced with `forceTLS`.

This PR updates the example code in`bootstrap.js`.

See https://github.com/pusher/pusher-js/pull/293
