### PR TITLE
[7.x] Bumps nunomaduro/collision dependency to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
-        "nunomaduro/collision": "^3.0",
+        "nunomaduro/collision": "^4.0",
         "phpunit/phpunit": "^8.0"
     },
     "config": {


### PR DESCRIPTION
This pull request adds the next major version of Collision: `v4.0`.

Note that this version is not tagged yet, as discussed with @taylorotwell, I am waiting that my development dependencies to support Laravel 7 / Symfony 5 and I am also working in a redesign of the console exceptions.

Meanwhile, this is working using the composer branch alias feature proxying `^4.0` to `dev-next`.