### PR TITLE
[WIP] [6.x] Use laravel/tinker v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.2",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^2.0"
     },
     "require-dev": {
         "facade/ignition": "^1.4",


### PR DESCRIPTION
To be merged when tinker v2 is ready. This can then make it into 7.x by merging `master` -> `develop` in the usual way.