### PR TITLE
Bump default versions of dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     },
     "devDependencies": {
         "axios": "^0.19",
-        "cross-env": "^5.1",
-        "laravel-mix": "^4.0.7",
-        "lodash": "^4.17.13",
-        "resolve-url-loader": "^2.3.1",
-        "sass": "^1.15.2",
-        "sass-loader": "^7.1.0"
+        "cross-env": "^6.0.3",
+        "laravel-mix": "^5.0.0",
+        "lodash": "^4.17.15",
+        "resolve-url-loader": "^3.1.1",
+        "sass": "^1.23.7",
+        "sass-loader": "^8.0.0"
     }
 }


### PR DESCRIPTION
- Cross env: https://github.com/kentcdodds/cross-env/releases/tag/v6.0.3
- Laravel Mix v.5: https://github.com/JeffreyWay/laravel-mix/releases/tag/v5.0.0
- Lodash: https://github.com/lodash/lodash/releases/tag/4.17.15
- Resolve URL loader: https://github.com/bholloway/resolve-url-loader/releases/tag/3.1.1
- Sass: https://github.com/sass/dart-sass/releases/tag/1.23.7
- Sass-loader v.8: https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0