### PR TITLE
[6.x] Move Laravel Tinker to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     "require": {
         "php": "^7.2",
         "fideloper/proxy": "^4.0",
-        "laravel/framework": "^6.2",
-        "laravel/tinker": "^2.0"
+        "laravel/framework": "^6.2"
     },
     "require-dev": {
         "facade/ignition": "^1.4",
         "fzaninotto/faker": "^1.4",
+        "laravel/tinker": "^2.0",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^3.0",
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
been having a little debate on the Slack channel about where Laravel Tinker belongs in our dependencies.

I personally **never** use it in production, so for me loading it is a waste of resources (probably minimal, but still something).

I believe there's also a bit of inherent danger by using it in production. A model could be accidentally deleted, something that may be prevented by going through the normal UI modes of manipulating data.

Due to these 2 concerns I would say we should default Tinker into the dev dependencies, and put the onus on the user that wants Tinker in their production environment to move it in their `composer.json` file.