### PR TITLE
[6.x] Do not check, if the request expects Json response in Authenticate.php

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,6 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
-            return route('login');
-        }
+        return route('login');
     }
 }


### PR DESCRIPTION
It doesn't make sense to check for Json expectation at this point.

Exception handler does it here:
https://github.com/laravel/framework/blob/a0e7e4c7c883327496816164d5db88af66d5a722/src/Illuminate/Foundation/Exceptions/Handler.php#L225

If we didn't unconditionally return a route here, and expectsJson would fail for some reason at the Exception Handler then 'login' route would be returned (and exception thrown, if it doesn't exist; which it probably deosn't otherwise we wouldn't even specify our own route here).
Documentation already properly shows an example where no condition is included.