### PR TITLE
[6.x] Add "none" to supported same site options in session config

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -190,7 +190,7 @@ return [
     | take place, and can be used to mitigate CSRF attacks. By default, we
     | do not enable this as other CSRF protection services are in place.
     |
-    | Supported: "lax", "strict"
+    | Supported: "lax", "strict", "none"
     |
     */
 


### PR DESCRIPTION
The cookie functionality is built on the one from Symfony, which lacked support for "same-site: none" until a coupe of months ago.

In some cases, Chrome might block cookie access for both strict and lax, so would be imported to know that "none" is supported too.

⚠️ When using same-site: none, Chrome also needs secure to be set to true. Does this need to be mentioned as well?

Symfony PR: https://github.com/symfony/symfony/pull/31475