### PR TITLE
[6.x] Add hrtime for newer versions of PHP

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,7 +7,7 @@
  * @author   Taylor Otwell <taylor@laravel.com>
  */
 
-define('LARAVEL_START', microtime(true));
+define('LARAVEL_START', function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true));
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
`hrtime` was introduced in PHP 7.3 (https://www.php.net/manual/en/book.hrtime.php) to provide high resolution time.

Although it's a minor change, but it tries to give us the most accurate time since it uses the best possible APIs on different platforms which brings resolution up to nanoseconds.

