### PR TITLE
[6.x] Default email from name to app name

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -57,7 +57,7 @@ return [
 
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'name' => env('MAIL_FROM_NAME', env('APP_NAME', 'Example')),
     ],
 
     /*


### PR DESCRIPTION
I continually forget to set `MAIL_FROM_NAME` and IMHO it makes more sense to default to the app name vs. “Example”