### PR TITLE
[6.x] Allow configurable emergency logger

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -95,6 +95,10 @@ return [
             'driver' => 'monolog',
             'handler' => NullHandler::class,
         ],
+
+        'emergency' => [
+            'path' => storage_path('logs/laravel.log'),
+        ],
     ],
 
 ];


### PR DESCRIPTION
This adds a default emergency logger path to the logging config file.

---

Goes hand-in-hand with laravel/framework#30873.