### PR TITLE
[7.x] Add HandleCors middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/app/Http/Middleware/HandleCors.php
+++ b/app/Http/Middleware/HandleCors.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Fruitcake\Cors\HandleCors as Middleware;
+
+class HandleCors extends Middleware
+{
+    /**
+     * The paths to enable CORS on.
+     * Example: ['api/*']
+     *
+     * @var array
+     */
+    protected $paths = [];
+}

--- a/app/Http/Middleware/HandleCors.php
+++ b/app/Http/Middleware/HandleCors.php
@@ -6,11 +6,5 @@ use Fruitcake\Cors\HandleCors as Middleware;
 
 class HandleCors extends Middleware
 {
-    /**
-     * The paths to enable CORS on.
-     * Example: ['api/*']
-     *
-     * @var array
-     */
-    protected $paths = [];
+
 }

--- a/app/Http/Middleware/HandleCors.php
+++ b/app/Http/Middleware/HandleCors.php
@@ -6,5 +6,4 @@ use Fruitcake\Cors\HandleCors as Middleware;
 
 class HandleCors extends Middleware
 {
-
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "fideloper/proxy": "^4.2",
-        "fruitcake/laravel-cors": "^1@dev",
+        "fruitcake/laravel-cors": "^1.0",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "fideloper/proxy": "^4.2",
+        "fruitcake/laravel-cors": "^1@dev",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0"
     },

--- a/config/cors.php
+++ b/config/cors.php
@@ -33,27 +33,27 @@ return [
      */
     'allowed_origins' => ['*'],
 
-    /**
+    /*
      * Matches the request origin with, similar to `Request::is()`
      */
     'allowed_origins_patterns' => [],
 
-    /**
+    /*
      * Sets the Access-Control-Allow-Headers response header. `[*]` allows all headers.
      */
     'allowed_headers' => ['*'],
 
-    /**
+    /*
      * Sets the Access-Control-Expose-Headers response header.
      */
     'exposed_headers' => false,
 
-    /**
+    /*
      * Sets the Access-Control-Max-Age response header.
      */
     'max_age' => false,
 
-    /**
+    /*
      * Sets the Access-Control-Allow-Credentials header.
      */
     'supports_credentials' => false,

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,60 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laravel CORS Options
+    |--------------------------------------------------------------------------
+    |
+    | The allowed_methods and allowed_headers options are case-insensitive.
+    |
+    | You don't need to provide both allowed_origins and allowed_origins_patterns.
+    | If one of the strings passed matches, it is considered a valid origin.
+    |
+    | If array('*') is provided to allowed_methods, allowed_origins or allowed_headers
+    | all methods / origins / headers are allowed.
+    |
+    */
+
+    /*
+     * You can enable CORS for 1 or multiple paths.
+     * Example: ['api/*']
+     */
+    'paths' => [],
+
+    /*
+    * Matches the request method. `[*]` allows all methods.
+    */
+    'allowed_methods' => ['*'],
+
+    /*
+     * Matches the request origin. `[*]` allows all origins.
+     */
+    'allowed_origins' => ['*'],
+
+    /**
+     * Matches the request origin with, similar to `Request::is()`
+     */
+    'allowed_origins_patterns' => [],
+
+    /**
+     * Sets the Access-Control-Allow-Headers response header. `[*]` allows all headers.
+     */
+    'allowed_headers' => ['*'],
+
+    /**
+     * Sets the Access-Control-Expose-Headers response header.
+     */
+    'exposed_headers' => false,
+
+    /**
+     * Sets the Access-Control-Max-Age response header.
+     */
+    'max_age' => false,
+
+    /**
+     * Sets the Access-Control-Allow-Credentials header.
+     */
+    'supports_credentials' => false,
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,12 +13,7 @@ use Illuminate\Support\Facades\Route;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
-Route::any('/test', function (Request $request) {
-    $a++;
-    return $request->user();
-});
 
-
-Route::middleware('auth:api')->any('/user', function (Request $request) {
+Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,12 @@ use Illuminate\Support\Facades\Route;
 | is assigned the "api" middleware group. Enjoy building your API!
 |
 */
+Route::any('/test', function (Request $request) {
+    $a++;
+    return $request->user();
+});
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
+
+Route::middleware('auth:api')->any('/user', function (Request $request) {
     return $request->user();
 });


### PR DESCRIPTION
Based on a discussion with Taylor, I've added a HandleCors middleware similar to TrustProxies. This is using https://github.com/fruitcake/laravel-cors (formerly barryvdh/laravel-cors), which is updated with a few breaking changes to v1 (still in dev, awaiting possible feedback for this integration).

This would make it easy to implement CORS handling in Laravel, based on path matching.
An alternative approach would be route middleware, but the biggest issue is that it wouldn't match 404-routes, which would in turn lead to difficult debugging issues.

An approach could be to add a fallback route for the API middleware though, if you prefer route middleware, instead of the paths option.