### PR TITLE
[6.x] Fix types consistency in Redis database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -130,16 +130,16 @@ return [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
-            'port' => env('REDIS_PORT', 6379),
-            'database' => env('REDIS_DB', 0),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => env('REDIS_DB', '0'),
         ],
 
         'cache' => [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
-            'port' => env('REDIS_PORT', 6379),
-            'database' => env('REDIS_CACHE_DB', 1),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => env('REDIS_CACHE_DB', '1'),
         ],
 
     ],


### PR DESCRIPTION
This PR makes consistent types of configuration values in database configuration file. It's replacement of #5190

As @GrahamCampbell [said about database connections config](https://github.com/laravel/laravel/pull/5190#issuecomment-568814080):
> e.g. Consider the .env file:
> 
> ```
> DB_PORT=123
> ```
> 
> Then `env('DB_PORT', 3306)` will be the string "123", but if there is no variable, your code now produces an integer, which is not expected. We'd expect always a string, which is why the current implementation has the values quoted.

So I've tweaked redis config to match the same convention.