### PR TITLE
[7.x] Added graham-campbell/testbench-core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,10 @@
     },
     "require-dev": {
         "fzaninotto/faker": "^1.9",
-        "mockery/mockery": "^1.3",
+        "graham-campbell/testbench-core": "^3.2",
+        "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^4.0",
-        "phpunit/phpunit": "^8.4"
+        "phpunit/phpunit": "^8.5"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
Also bumped min versions to fix some issues. Mockery 1.3.0 has some issues with orchestra's testing stuff, which laravel uses. Was fixed in 1.3.1.