### PR TITLE
[6.x] Comment out sqlite.url config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
 
         'sqlite' => [
             'driver' => 'sqlite',
-            'url' => env('DATABASE_URL'),
+            //'url' => env('DATABASE_URL'),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),


### PR DESCRIPTION

```sh
laravel new sqlite --auth
#edit .env
touch database/database.sqlite
php artisan migrate
```

```
   InvalidArgumentException  : The database configuration URL is malformed.

  at vendor/laravel/framework/src/Illuminate/Support/ConfigurationUrlParser.php:135
    131|
    132|         $parsedUrl = parse_url($url);
    133|
    134|         if ($parsedUrl === false) {
  > 135|             throw new InvalidArgumentException('The database configuration URL is malformed.');
    136|         }
    137|
    138|         return $this->parseStringsToNativeTypes(
    139|             array_map('rawurldecode', $parsedUrl)
```

Disable as default.