### PR TITLE
Flash status message into verified view session

### DIFF
--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -26,8 +26,12 @@ class VerificationController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
-
+    protected function redirectTo()
+    {
+        session()->flash('status', 'Email Verified.');
+        return RouteServiceProvider::HOME;
+    }
+    
     /**
      * Create a new controller instance.
      *


### PR DESCRIPTION
When a new user receives the "Verify Email Address" email and clicks on the included link they should be redirected to the default HOME route with a message injected into the session to display to the user for the HOME view to render. This lets the user confirm the Verify Email Address link worked correctly.