### PR TITLE
[6.x] Use `assertOk()` instead of `assertStatus(200)`

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,6 +16,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
Asserting that a response has a 200 status code is a too common task.

`assertOk()` was created in order to make such a task simpler and easier for newcomers, so it would be nice to have this assertion 'enabled' by default.