### PR TITLE
[7.x] Adds collision's phpunit adapter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,9 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
+    <listeners>
+        <listener class="NunoMaduro\Collision\Adapters\Phpunit\Listener" />
+    </listeners>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./app</directory>


### PR DESCRIPTION
This pull request adds of the **collision's phpunit adapter** to the default Laravel 7 skeleton. This adapter provides two things:

- Better console visuals on tests failures
- Always stops on failure

1. Here a simple comparasion with the default phpunit output ( on the left ) against collision ( on the right ).

<img width="1783" alt="Screenshot 2020-01-22 at 22 32 09" src="https://user-images.githubusercontent.com/5457236/72937681-e325ff00-3d69-11ea-8f9f-d35bed8fd3c9.png">

2. Things get even better on complex examples, as collision focuses on what really matters - hidden vendor frames, and others:

<img width="1779" alt="Screenshot 2020-01-22 at 22 59 33" src="https://user-images.githubusercontent.com/5457236/72938286-01402f00-3d6b-11ea-87f8-2c92301b4609.png">

Let me know what do you guys think. 👍 