### PR TITLE
[7.x] add new `check_compiled` option

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -43,6 +43,6 @@ return [
      | and precompiling your views we can skip this check to save time.
      |
      */
-    'check_compiled' => env('APP_ENV') !== 'production',
+    'expires' => env('APP_ENV') !== 'production',
 
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -33,4 +33,16 @@ return [
         realpath(storage_path('framework/views'))
     ),
 
+    /*
+     |--------------------------------------------------------------------------
+     | Check Compiled Views
+     |--------------------------------------------------------------------------
+     |
+     | On every request the framework will check to see if a view has expired
+     | to determine if it needs to be recompiled. If you are in production
+     | and precompiling your views we can skip this check to save time.
+     |
+     */
+    'check_compiled' => env('APP_ENV') !== 'production',
+
 ];


### PR DESCRIPTION
this adds the option for https://github.com/laravel/framework/pull/31206

I am setting the default to check for expired files in non-production environments, and **not** check in production environments, to provide an example for what most people will probably use.  The only danger to this is you **must** run `php artisan view:cache` in deployment.

If you feel the risk it too great to automatically tie this to the environment, we can set the default value as `true`.