### PR TITLE
[6.x] Update cross-env and resolve-url-loader to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     },
     "devDependencies": {
         "axios": "^0.19",
-        "cross-env": "^5.1",
+        "cross-env": "^6.0",
         "laravel-mix": "^5.0.1",
         "lodash": "^4.17.13",
-        "resolve-url-loader": "^2.3.1",
+        "resolve-url-loader": "^3.1.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0"
     }


### PR DESCRIPTION
This is not a fix for the vulnerability.
Just updating the dependencies to the latest version.