### PR TITLE
[6.x] Update Slack default level

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -59,7 +59,7 @@ return [
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
-            'level' => 'critical',
+            'level' => 'debug',
         ],
 
         'papertrail' => [


### PR DESCRIPTION
make this consistent with all the other default levels.

it can also be really confusing when initially setting up your Slack logging, if a test doesn't come through because it doesn't meet the minimum critical level, especially if you're not familiar with this feature.