### PR TITLE
[6.x] Add redirect from /index.php to /

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,4 +18,8 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+    
+    # Handle Redirect index.php...
+    RewriteCond %{THE_REQUEST} ^GET.*index\.php [NC]
+    RewriteRule (.*?)index\.php/*(.*) /$1$2 [R=301,NE,L]
 </IfModule>


### PR DESCRIPTION
I noticed index.php showing up in Google Analytics for a project i am working on. 

The project is a news portal currently in production and used by hundreds of users every day.
Index.php links are showing up every day in our Google Analytics and the laravel project doesn't seem to be able to rewrite them.

I used the proposed solution and is looking to work great.

Our setup is a Linux/Apache server.