### PR TITLE
[6.x] Update cross-env to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "axios": "^0.19",
-        "cross-env": "^6.0",
+        "cross-env": "^7.0",
         "laravel-mix": "^5.0.1",
         "lodash": "^4.17.13",
         "resolve-url-loader": "^3.1.0",


### PR DESCRIPTION
This is not a fix for the vulnerability.
Just updating the dependency to the latest version.

@see https://yarnpkg.com/package/cross-env

Yes, I know that they recently released version 6.0 and in a short time 7.0.