### PR TITLE
[6.x] Specifying the minimum version of nodejs to require `cross-env`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
         "prod": "npm run production",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
+    "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+    },
     "devDependencies": {
         "axios": "^0.19",
         "cross-env": "^7.0",


### PR DESCRIPTION
`cross-env` version update merged: #5216 
This PR contains an indication of the [minimum version](https://github.com/kentcdodds/cross-env/blob/master/package.json#L10-L14) of nodejs required for `cross-env` to work (also see https://github.com/laravel/laravel/pull/5212#issuecomment-578822212).