### PR TITLE
[6.x] Bump fzaninotto/faker version to support PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "facade/ignition": "^1.4",
-        "fzaninotto/faker": "^1.4",
+        "fzaninotto/faker": "^1.9.1",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^3.0",
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
Bumping `fzaninotto/faker` version to support PHP 7.4, especially when running composer with `--prefer-lowest` flag.

PRs related to version `^1.9.1`: 

* https://github.com/fzaninotto/Faker/pull/1748
* https://github.com/fzaninotto/Faker/pull/1843