### PR TITLE
[6.x] Remove "Package Service Providers" section from config/app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -163,10 +163,6 @@ return [
         Illuminate\View\ViewServiceProvider::class,
 
         /*
-         * Package Service Providers...
-         */
-
-        /*
          * Application Service Providers...
          */
         App\Providers\AppServiceProvider::class,


### PR DESCRIPTION
Since automatic package discovery is the norm now, I'm not sure that this section in `config/app.php` is really necessary as a placeholder anymore. Just a small tidy-up.