### PR TITLE
[6.x] Alias for Unit Example TestCase

### DIFF
--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,9 +2,8 @@
 
 namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class ExampleTest extends BaseTestCase
+class ExampleTest extends PHPUnit\Framework\TestCase
 {
     /**
      * A basic test example.

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class ExampleTest extends TestCase
+class ExampleTest extends BaseTestCase
 {
     /**
      * A basic test example.

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit;
 
 
-class ExampleTest extends PHPUnit\Framework\TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * A basic test example.

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-
 class ExampleTest extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
Adding an alias for PHPUnit/Framework/TestCase to make it clear that the TestCase being used isn't the Framework provided TestCase to remove ambiguity for users where IDE's collapse use statements, on the back of the changes made in PR #5169