### PR TITLE
[6.x] Should default to 'default' to work with Horizon

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -122,7 +122,7 @@ return [
         'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
-            'cluster' => env('REDIS_CLUSTER', 'redis'),
+            'cluster' => env('REDIS_CLUSTER', 'default'),
             'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
         ],
 


### PR DESCRIPTION
When adding Horizon to a new Laravel project it will throw an Exception during composer require on Horizon.php line 100.
Since the Laravel framework defaults to 'redis' for cluster name and Horizon uses that very cluster name variable. It won't find database.redis.redis and throw an Exception ("Redis connection [] has not been configured.") because it tries to look up database.redis.redis (while it's actually database.redis.default)

Can be solved either by changing this line here. Or change the example .env file to include REDIS_CLUSTER=default