### PR TITLE
[7.x] Adds `.travis.yml` asserting skeleton works with lowest dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+.travis.yml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: bionic
+language: php
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.2
+    - php: 7.2
+      env: SETUP=lowest
+    - php: 7.3
+    - php: 7.3
+      env: SETUP=lowest
+    - php: 7.4
+    - php: 7.4
+      env: SETUP=lowest
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - if [[ $SETUP = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
+  - if [[ $SETUP = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
+
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
**Note:** The `.travis.yml` is marked as non-exportable on `.gitattributes` just like the `.CHANGELOG.md` file.

This pull request adds `.travis.yml` into the Laravel skeleton. The goal is firing automatically CI jobs that **asserts that the current skeleton works with the lowest dependencies specified in `composer.json`**.

Here is an example here this may have been useful:

1. Pull request with a feature: https://github.com/laravel/laravel/commit/bc82317a02e96105ad9f3cc0616d491cb5585c62
2. Pull request made to fix the required dependencies of that feature: https://github.com/laravel/laravel/commit/bb969c61d41ec479adbe4a6da797831002b75092

With CI testing, the very first pull request would have failed.

Note that, if this pull request gets merged, @taylorotwell may have to activate this repository on Travis.