### PR TITLE
[7.x] Adds support to PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "fzaninotto/faker": "^1.9",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^4.1",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5|^9.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This pull request adds support to PHPUnit 9. We can't drop the support PHPUnit 8 as PHPUnit 9 don't support php 7.2.