### PR TITLE
[6.x] Add email verification to auth config

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -114,4 +114,18 @@ return [
 
     'password_timeout' => 10800,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Email Verification
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the amount of minutes before a link of email verification
+    | is expire. By default, the expire time is one hour.
+    |
+    */
+
+    'verification' => [
+        'expire' => 60,
+    ],
+
 ];


### PR DESCRIPTION
By default[ MustVerifyEmail trait](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Auth/MustVerifyEmail.php) use [VerifyEmai notification](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Auth/Notifications/VerifyEmail.php) where verificationUrl use auth.verification.expire config key with default 60 minutes, but in main config this parameter not defined. Many of apps prefer use day or more for this parameter without redefine another notification logic.
```php
 /**
     * Get the verification URL for the given notifiable.
     *
     * @param  mixed  $notifiable
     * @return string
     */
    protected function verificationUrl($notifiable)
    {
        return URL::temporarySignedRoute(
            'verification.verify',
            Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
            [
                'id' => $notifiable->getKey(),
                'hash' => sha1($notifiable->getEmailForVerification()),
            ]
        );
    }
```