### PR TITLE
Laravel 5-6 – Remove Public from URL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{REQUEST_URI} !^/public/
+RewriteRule ^(.*)$ /public/$1 [L,QSA]


### PR DESCRIPTION
# DON'T!

**YOU REALLY SHOULD NOT** rename `server.php` in your Laravel root folder to `index.php`
and copy the `.htaccess` file from the `/public` directory to your Laravel root folder!!!

This way everyone can access some of your files (`.env` for example). Try it yourself. You don't want that!

----

# DO

Instead, you should create an `.htaccess` file in your root like this:

    RewriteEngine On
    RewriteCond %{REQUEST_URI} !^/public/
    RewriteRule ^(.*)$ /public/$1 [L,QSA]

This will silently rewrite all your base URIs to the `/public` folder. Even all [Headers][1], for example [the HTTP Authorization Header][2], and all optional URI parameters will silently be passed on to the `/public` folder as well.

That's all!


  [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
  [2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization