### PR TITLE
[6.x] Modify the way of obtaining environment variables

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,7 @@
 */
 
 $app = new Illuminate\Foundation\Application(
-    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+    Illuminate\Support\Env::get('APP_BASE_PATH') ?? dirname(__DIR__)
 );
 
 /*


### PR DESCRIPTION
In the php cli environment, `$ _ENV` is affected by `variables_order`. Some configuration files under php cli are:
```
variables_order
;   Default Value: "EGPCS"
;   Development Value: "GPCS"
;   Production Value: "GPCS"
```

If `variables_order` does not include the `E` option, you cannot get the default environment variables, see the following example:

1. `export APP_BASE_PATH=/var/www/laravel`
2. modify `php cli/php.ini`文件 `variables_order="GPCS"`
3. print result
```
var_dump($_ENV['APP_BASE_PATH']); // output NULL
echo PHP_EOL;
var_dump(getenv("APP_BASE_PATH")) // output /var/www/laravel
```
