### PR TITLE
[6.x] Remove redundant default attributes from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+         colors="true">
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>


### PR DESCRIPTION
PR https://github.com/laravel/laravel/pull/5139 added the xml schema to `phpunit.xml`. Because of this, IDEs like PhpStorm now show which attributes are redundant:
![image](https://user-images.githubusercontent.com/7202674/75116588-3f7e8600-566a-11ea-9271-b2d5add3bf33.png)

All the gray attributes in the screenshot above are setting the same value as the default value. They can be removed.

The `suffix="Test.php"` is also a redundant default, but I think this is useful in reminding people their test classes should end with `Test.php`