### PR TITLE
[7.x] remove empty line from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
-
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>


### PR DESCRIPTION
I'm not sure if there's a style rule for this, but it seems very out of place to be the only empty line in the whole file.