### PR TITLE
[7.x] Add new SQS queue suffix option

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -55,6 +55,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
             'queue' => env('SQS_QUEUE', 'your-queue-name'),
+            'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         ],
 


### PR DESCRIPTION
As described in laravel/framework#31784, this option will allow you to define a queue name suffix.

This can be useful in case you have multiple queues in multiple environments like in Laravel Vapor for example:

```yml
environments:
    production:
        queues:
            - emails-production
            - imports-production
    staging:
        queues:
            - emails-staging
            - imports-staging
```

So if you define your `SQS_SUFFIX` as either `production` or `staging`, your code can now look like this:

```php
dispatch(new SendWelcomeEmail($user))->onQueue('emails');
dispatch(new ImportEmailsCsv($path))->onQueue('imports');
```

or even like this:

```php
class SendWelcomeEmail implements ShouldQueue
{
    /**
     * The name of the queue the job should be sent to.
     *
     * @var string|null
     */
    public $queue = 'emails';
}
```

```php
class ImportEmailsCsv implements ShouldQueue
{
    /**
     * The name of the queue the job should be sent to.
     *
     * @var string|null
     */
    public $queue = 'imports';
}
```

and the queue name will be resolved appropriately. 