### PR TITLE
[7.x] App Debug Bool

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => (bool) env('APP_DEBUG', false),
+    'debug' => filter_var(env('APP_DEBUG', false), FILTER_VALIDATE_BOOLEAN),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Original commit https://github.com/laravel/laravel/commit/5ddbfb845439fcd5a46c23530b8774421a931760 attempts to cast `app.debug` as a bool, but using `(bool)` on a string of `'false'` results in a boolean of `true`. Instead we should be using `filter_var` with the `FILTER_VALIDATE_BOOLEAN` flag.

See documentation on [filter_var($value, FILTER_VALIDATE_BOOLEAN)](https://www.php.net/manual/en/filter.filters.validate.php) and [boolean casting](https://www.php.net/manual/en/language.types.boolean.php#language.types.boolean.casting)

```bash
$ php -a
Interactive shell

php > $debug = (bool)'false';
php > var_dump($debug);
bool(true)
```
```bash
$ php -a
Interactive shell

php > $debug = filter_var('false', FILTER_VALIDATE_BOOLEAN);
php > var_dump($debug);
bool(false)
```

Yes, the `env` helper does check for `false` strings, see switch in [Illuminate\Support\Env](
https://github.com/laravel/framework/blob/6995c7c6e5e6ea2851fdbc1f8b2afc4590d9b84c/src/Illuminate/Support/Env.php#L83-L96)

I still see this as a better way of casting/parsing `app.debug` than using `(bool)`. 

This will make it more strict when an invalid string is used, such as `test` or `foo` or any non-empty string. By using `filter_var` we will get `false` for these invalid strings. This is safer if somehow `app.debug` is deployed to an environment with an invalid string where it should never be set to `true`.