### PR TITLE
[6.x] App Debug Bool

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => (bool) env('APP_DEBUG', false),
+    'debug' => env('APP_DEBUG', false) === true,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Ensure that app.debug is a bool using a strict compare.

This will make it more strict when an invalid string is used, such as `'test'` or `'on'` or any string that is not `'true'` or `'false'`. 

This is safer if somehow `app.debug` is deployed to an environment with an invalid string and `app.debug` should never have a value of `true`.

String values of `'true'`/`'false'` get converted to a boolean value by the `env` helper. See switch in [Illuminate\Support\Env](
https://github.com/laravel/framework/blob/6995c7c6e5e6ea2851fdbc1f8b2afc4590d9b84c/src/Illuminate/Support/Env.php#L83-L96)

Initial PR and discussion: https://github.com/laravel/laravel/pull/5254