### PR TITLE
[7.x] App Debug

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => (bool) env('APP_DEBUG', false),
+    'debug' => env('APP_DEBUG', false) === true,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Comparing the value to `true` fixes possible issues with casting non-empty strings. For example, `(bool)'off'` will equal `true`.

```
APP_DEBUG=off
# OR
APP_DEBUG=false
```
The above `.env` example results in `config('app.debug')` equal to`false`.
```
APP_DEBUG=true
```
The above `.env` example results in `config('app.debug')` equal to `true`.