### PR TITLE
[7.x] Update default CORS config

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -25,9 +25,9 @@ return [
 
     'allowed_headers' => ['*'],
 
-    'exposed_headers' => false,
+    'exposed_headers' => [],
 
-    'max_age' => false,
+    'max_age' => 0,
 
     'supports_credentials' => false,
 


### PR DESCRIPTION
`exposed_headers` can be `false` or an array (not `true`). `max_age` can be false or an integer. 
There defaults make it more obvious.