### PR TITLE
Fix session config changes

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -194,6 +194,6 @@ return [
     |
     */
 
-    'same_site' => null,
+    'same_site' => 'lax',
 
 ];

--- a/config/session.php
+++ b/config/session.php
@@ -166,7 +166,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', null),
+    'secure' => env('SESSION_SECURE_COOKIE'),
 
     /*
     |--------------------------------------------------------------------------
@@ -190,10 +190,10 @@ return [
     | take place, and can be used to mitigate CSRF attacks. By default, we
     | do not enable this as other CSRF protection services are in place.
     |
-    | Supported: "lax", "strict", "none"
+    | Supported: "lax", "strict", "none", null
     |
     */
 
-    'same_site' => 'lax',
+    'same_site' => null,
 
 ];


### PR DESCRIPTION
Hi,
Several changes reverted from #5157 (Symfony 5 update):
- Remove the null explicit default as env is null by default,
- Add null value in phpdoc as null is a totally valid value, (which is used by Symfony).
- Re-set null by default for same-site configuration, because as the phpdoc says itself "**By default, we do not enable this**", and I didn't find any clue of why this has be done, as it seems that nothing change for Laravel here in Symfony 5 update (new default for symfony Cookie, but Laravel set the value, so do not use the default see https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/HttpFoundation/Cookie.php#L91 and https://github.com/laravel/framework/blob/5c2c1df2d9d56f761e9c6352db067eb78426da62/src/Illuminate/Session/Middleware/StartSession.php#L157).

I'm doing an other PR to the upgrade guide in the doc to update that.

Thanks,
Matt'
