### PR TITLE
[7.x] Allow configuring the timeout for the smtp driver

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -41,6 +41,7 @@ return [
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
+            'timeout' => 30, // In seconds
         ],
 
         'ses' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -41,7 +41,7 @@ return [
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
-            'timeout' => 30, // In seconds
+            'timeout' => null, // In seconds
         ],
 
         'ses' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -41,7 +41,7 @@ return [
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
-            'timeout' => null, // In seconds
+            'timeout' => null,
         ],
 
         'ses' => [


### PR DESCRIPTION
The default is the same as in `\Swift_Transport_EsmtpTransport::$params`

Complements https://github.com/laravel/framework/pull/31973