### PR TITLE
[7.x][6.x] Remove class constant visibility

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,7 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    const HOME = '/home';
 
     /**
      * Define your route model bindings, pattern filters, etc.


### PR DESCRIPTION
Class constant visibility can be used in PHP 7.1 only.
Laravel 7: PHP >= 7.2.5
Laravel 6: PHP >= 7.2.0