### PR TITLE
Handle JSON requests correctly in RedirectIfAuthenticated middleware

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,7 +19,9 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
+            return $request->wantsJson()
+                ? new Response('', 204)
+                : redirect(RouteServiceProvider::HOME);
         }
 
         return $next($request);


### PR DESCRIPTION
The redirect didn't satisfy the CORS policy as 'Access-Control-Allow-Origin' was missing.