### PR TITLE
[7.x] Let developers adjust the sendmail path

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -58,7 +58,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => '/usr/sbin/sendmail -bs',
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs'),
         ],
 
         'log' => [


### PR DESCRIPTION
The sendmail path can differ between environments. So a hard coded value for this does not work well.

We, for example, test our projects on an environment that require the `-bs` flags, while our production environments require the `-ti` flags. In the current situation we have to adjust the `config/mail.php` file for every project.

It would be a lot easier when the sendmail path could be managed with an `.env` variable.