### PR TITLE
[6.x] Fix default disks public url for php artisan serve

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -51,7 +51,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => '/storage',
             'visibility' => 'public',
         ],
 


### PR DESCRIPTION
By default `config/filesystems.php`, `\Storage::disk('public')->url('')` returns `APP_URL/storage/` for public disk access.

Default `APP_URL` has no port number. So if developers work app on `php artisan
serve` (`http://localhost:8000/`), it returns
`http://localhost/storage/` without port number. And link of resource is
dead link.

I realized that it cannot use kind of url helper functions (url, asset..) in config file for Laravel life cycle.

So I simply removed `env('APP_URL').` for fixing this default dead link.