### PR TITLE
[7.x] Disable Telescope in PHPUnit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,5 +25,6 @@
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
+        <server name="TELESCOPE_ENABLED" value="false"/>
     </php>
 </phpunit>


### PR DESCRIPTION
PHPUnit throw exception when Telescope is enabled