### PR TITLE
Add default HELO configuration to mail config file

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -44,6 +44,16 @@ return [
             'timeout' => null,
         ],
 
+        'helo' => [
+            'transport' => 'smtp',
+            'host' => env('MAIL_HOST', '127.0.0.1'),
+            'port' => env('MAIL_PORT', 2525),
+            'encryption' => env('MAIL_ENCRYPTION', null),
+            'username' => env('MAIL_USERNAME', env('APP_NAME', 'helo')),
+            'password' => env('MAIL_PASSWORD', null),
+            'timeout' => null,
+        ],
+
         'ses' => [
             'transport' => 'ses',
         ],


### PR DESCRIPTION
I've just started using HELO by @mpociot / @beyondcode, and it feels like if Laravel has default connections to other external paid mail development tools, it should probably have HELO support in there too.

This config allows the `env` file to use HELO just by specifying `MAIL_MAILER=helo`.