### PR TITLE
[7.x] Remove forceTLS option

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -24,5 +24,4 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     broadcaster: 'pusher',
 //     key: process.env.MIX_PUSHER_APP_KEY,
 //     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
-//     forceTLS: true
 // });


### PR DESCRIPTION
Looks like the [latest version of Pusher](https://github.com/pusher/pusher-js/blob/master/CHANGELOG.md#600-2020-04-27) now defaults this option to true, so I don't think the configuration is required in the boilerplate anymore.