### PR TITLE
[7.x] Update typehint to be nullable

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array|string
+     * @var array|string|null
      */
     protected $proxies;
 


### PR DESCRIPTION
By default, this property is null. Therefore, it should be marked as nullable. Now the property declaration is the same as the parents, should we consider just removing it altogether in a future PR?

I ran into this when running some static analysis with https://github.com/psalm/psalm-plugin-laravel