### PR TITLE
Autogenerate key for tests

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Artisan;
 
 trait CreatesApplication
 {
@@ -16,6 +17,8 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        
+        Artisan::call('key:generate');
 
         return $app;
     }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,7 +17,7 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
-        
+
         Artisan::call('key:generate');
 
         return $app;


### PR DESCRIPTION
nunomaduro/collision:4.1.3  and later no longer generates `app.key`