### PR TITLE
[7.x] Get the home URL from the route in welcome.blade.php

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -68,7 +68,7 @@
             @if (Route::has('login'))
                 <div class="top-right links">
                     @auth
-                        <a href="{{ url('/home') }}">Home</a>
+                        <a href="{{ route('home') }}">Home</a>
                     @else
                         <a href="{{ route('login') }}">Login</a>
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -68,7 +68,7 @@
             @if (Route::has('login'))
                 <div class="top-right links">
                     @auth
-                        <a href="{{ route('home') }}">Home</a>
+                        <a href="{{ {{ Route::has('home') ? route('home') : url('/home') }} }}">Home</a>
                     @else
                         <a href="{{ route('login') }}">Login</a>
 


### PR DESCRIPTION
It seems to be a fairly common thing for the home route's URL to be updated, for example, to /dashboard. This change keeps the behaviour in line with the Register & Login routes linked from the same file so the URL can be altered more easily.