### PR TITLE
Add Redis to list of drivers that support SESSION_STORE

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -92,9 +92,9 @@ return [
     | Session Cache Store
     |--------------------------------------------------------------------------
     |
-    | When using the "apc", "memcached", or "dynamodb" session drivers you may
-    | list a cache store that should be used for these sessions. This value
-    | must match with one of the application's configured cache "stores".
+    | When using the "apc", "dynamodb", "memcached", or "redis" session drivers
+    | you may list a cache store that should be used for these sessions. This
+    | value must match with one of the application's configured cache "stores".
     |
     */
 


### PR DESCRIPTION
This was always true as far as I can tell, it just didn't make it into the initial description.  Hoping to save someone a bit of time digging through the source to confirm.