### PR TITLE
[7.x] Set a default for Memcached's persistent_id

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -55,7 +55,7 @@ return [
 
         'memcached' => [
             'driver' => 'memcached',
-            'persistent_id' => env('MEMCACHED_PERSISTENT_ID'),
+            'persistent_id' => env('MEMCACHED_PERSISTENT_ID', 1),
             'sasl' => [
                 env('MEMCACHED_USERNAME'),
                 env('MEMCACHED_PASSWORD'),


### PR DESCRIPTION
Distributed clusters like AWS Elasticache for Memcached seems to need this and the local (single node) instances work well too.