### PR TITLE
[7.x] Add missing translation key pagination.goto_page used in Tailwind pagination view

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -15,5 +15,6 @@ return [
 
     'previous' => '&laquo; Previous',
     'next' => 'Next &raquo;',
+    'goto_page' => 'Go to page :page',
 
 ];


### PR DESCRIPTION
The new Tailwind pagination view uses a [`__('pagination.goto_page')` translation key](https://github.com/laravel/framework/blob/2279b73d5553c34c970128264a248f3bb57afad6/src/Illuminate/Pagination/resources/views/tailwind.blade.php#L74). This PR adds that translation to the pagination language file.

Related issue: https://github.com/laravel/framework/issues/33015