### PR TITLE
[7.x] Update redirectTo return type for the Authenticate middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,7 +10,7 @@ class Authenticate extends Middleware
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string|null
+     * @return string|void
      */
     protected function redirectTo($request)
     {


### PR DESCRIPTION
This method either returns a Response or nothing: I think this is less misleading.

Moreover, this also triggers Larastan and by extension PHPstan because the return type is not valid (which is true).

Related to https://github.com/laravel/laravel/commit/40f93daa83b17ad47c51ec9beed4c1ba79eb66ed