### PR TITLE
[8.x] Requires PHP 7.3 and bumps both PHPUnit and Collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.3",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^6.3",
@@ -18,8 +18,8 @@
     "require-dev": {
         "fzaninotto/faker": "^1.9.1",
         "mockery/mockery": "^1.3.1",
-        "nunomaduro/collision": "^4.1",
-        "phpunit/phpunit": "^8.5"
+        "nunomaduro/collision": "^5.0",
+        "phpunit/phpunit": "^9.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This pull request makes the Laravel skeleton require PHP 7.3. Note that, the [framework itself already requires PHP 7.3](https://github.com/laravel/framework/blob/9a7a475f895643e015dc287ddb7593cda2cff945/composer.json#L18).

Another note: Collision `^5.0` is not available yet, at the moment, this requirement will pull `v5.0.0-BETA3`.