### PR TITLE
[8.x] Multiple guards for RedirectIfAuthenticated

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -16,10 +16,18 @@ class RedirectIfAuthenticated
      * @param  string|null  $guard
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, ...$guards)
     {
-        return Auth::guard($guard)->check()
-                    ? redirect(RouteServiceProvider::HOME)
-                    : $next($request);
+        if (empty($guards)) {
+            $guards = [null];
+        }
+
+        foreach ($guards as $guard) {
+            if (auth()->guard($guard)->check()) {
+                return redirect(RouteServiceProvider::HOME);
+            }
+        }
+
+        return $next($request);
     }
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -23,7 +23,7 @@ class RedirectIfAuthenticated
         }
 
         foreach ($guards as $guard) {
-            if (auth()->guard($guard)->check()) {
+            if (Auth::guard($guard)->check()) {
                 return redirect(RouteServiceProvider::HOME);
             }
         }


### PR DESCRIPTION
allow the middleware to have the same behavior as https://laravel.com/api/5.8/Illuminate/Auth/Middleware/Authenticate.html#method_authenticate

so now the guest middleware have the same footprint as auth ex.`guest:web,admin` instead of creating multiple lines for different guards.