### PR TITLE
Change example environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Laravel
-APP_ENV=local
+APP_ENV=production
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_URL=http://localhost
 
 LOG_CHANNEL=stack


### PR DESCRIPTION
This pull request changes the default environment in the `.env.example` to `production`.

The reason for this is to prevent users from easily running insecure setups where they deploy their Laravel app to production, but don't change the pre-configured environment. This could be especially dangerous when using Laravel Telescope.
Telescope makes requests visible through its web interface at the `/telescope` route. When a user deploys their Laravel app with Telescope and does not change the pre-configured environment, information on every request is publicly available.

In my opinion, the risk of someone forgetting to change their `APP_ENV` is too high when you factor in the possible security implications.

I have read about this topic in German IT magazine Golem: https://www.golem.de/news/laravel-telescope-die-sicherheitsluecke-bei-einer-bank-die-es-nicht-gibt-2006-149251.html

According to the article author @hannob, there are "numerous" Telescope instances out there with the `local` environment setting. He has also implemented a check for publicly available Telescope instances in his tool [snallygaster](https://github.com/hannob/snallygaster/commit/e1ed99667bf5716673a9836acef5cd828e3cd07a).