### PR TITLE
[7.x] Document asset_url key

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -54,8 +54,6 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'asset_url' => env('ASSET_URL', null),
-
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Asset URL
+    |--------------------------------------------------------------------------
+    |
+    | The base URL used for your application's asset files, if you are defining
+    | them via asset('img/photo.jpg') through a different server or a content
+    | delivery network, for example. If it's not set, we'll default to the
+    | application URL (above). Leave off the trailing slash.
+    |
+    */
+    'asset_url' => env('ASSET_URL', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/config/app.php
+++ b/config/app.php
@@ -59,10 +59,10 @@ return [
     | Asset URL
     |--------------------------------------------------------------------------
     |
-    | The base URL used for your application's asset files, if you are defining
-    | them via asset('img/photo.jpg') through a different server or a content
-    | delivery network, for example. If it's not set, we'll default to the
-    | application URL (above). Leave off the trailing slash.
+    | The base URL used for your application's asset files, if you are using
+    | asset('img/photo.jpg') this may be a separate server or a content
+    | delivery network, for example. If it's not set, we'll default to
+    | the application URL (above). Leave off the trailing slash.
     |
     */
     'asset_url' => env('ASSET_URL', null),


### PR DESCRIPTION
Hello,

As far as I can determine, the `asset_url` configuration key hasn't been used since the 3.x era in `laravel/url.php`. A grep of asset_url through the entire repo is empty after removing this key from config/app.php.