### PR TITLE
Bump guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2.5",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0"
     },


### PR DESCRIPTION
Guzzle 7.x's PHP requirement is now ^7.2.5, the same as laravel/laravel's and laravel/framework's. Current laravel/framework (7.x) already has guzzlehttp/guzzle bumped to ^6.3.1|^7.0 .. so I figure this can also be similarly bumped, even for forthcoming 7.x releases (i.e. even ahead of Laravel 8.x) ..?

Let me know if I've missed something..