### PR TITLE
[7.x] .env: change 127.0.0.1 to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ APP_URL=http://localhost
 LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
+DB_HOST=localhost
 DB_PORT=3306
 DB_DATABASE=laravel
 DB_USERNAME=root


### PR DESCRIPTION
For homestead, 127.0.0.1 doesn't work in Linux/macOS but localhost works. See https://stackoverflow.com/questions/35394230/sqlstatehy000-2002-connection-refused-within-laravel-homestead