### PR TITLE
[7.x] Use assertOk() in ExampleTest to make easier to read

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,6 +16,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
If merged I'll open a pull request to update https://github.com/laravel/docs/blob/7.x/http-tests.md#introduction