### PR TITLE
initialized dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM nginx:alpine
+
+EXPOSE 80
+
+RUN apk update
+RUN apk upgrade
+RUN apk add php7 php7-fpm php7-fileinfo php7-dom php7-tokenizer php7-session composer
+
+WORKDIR /app
+
+COPY . .
+
+RUN rm Dockerfile
+RUN rm -r /usr/share/nginx/html
+
+RUN chmod -R 777 .
+
+RUN mv nginx-docker.conf /etc/nginx/conf.d/default.conf
+
+RUN composer install --optimize-autoloader --no-dev
+
+RUN php artisan config:cache
+RUN php artisan view:cache
+
+# Caching the routes still throws an error which hangs the build:
+# https://github.com/laravel/framework/issues/22034
+#RUN php artisan route:cache
+
+RUN echo "php-fpm7" > /run.sh
+RUN echo "nginx -g 'daemon off;'" >> /run.sh
+
+RUN chmod 500 /run.sh
+
+CMD ["sh", "/run.sh"]

--- a/nginx-docker.conf
+++ b/nginx-docker.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    listen [::]:80 ipv6only=on;
+
+    server_name localhost;
+
+    root /app/public;
+
+    index index.php;
+
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    access_log /var/log/nginx/app-access.log;
+    error_log /var/log/nginx/app-error.log;
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_index index.php;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}


### PR DESCRIPTION
This pull-request adds an [docker image](https://www.docker.com/) for generic laravel applications.
By executing the [docker image](https://www.docker.com/) after build the web application will be served by [nginx](https://www.nginx.com/).

Running your laravel app in docker is simple now:
1. Building the docker image (this could take a while): `docker build . -t my_laravel_app`
2. Creating an docker container using the image: `docker run -p 80:80 -d my_laravel_app`
3. The web application is now productive available on [localhost](http://localhost:80/).

This pull-request can be extended by another one containing an `docker-compose.yml` which runs a database, a redis, and the target application easily to provide better deployment.