### PR TITLE
Bump lodash from 4.17.13 to 4.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "axios": "^0.19",
         "cross-env": "^7.0",
         "laravel-mix": "^5.0.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.19",
         "resolve-url-loader": "^3.1.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0"


### PR DESCRIPTION
Bumps lodash from 4.17.13 to 4.17.19 to fix a security vulnerability. Most Laravel applications should not be affected but this PR will prevent the "security vulnerability" alert from GitHub on newly created Laravel applications. 

https://github.com/advisories/GHSA-p6mc-m468-83gw

Sourced from The GitHub Security Advisory Database:

> Prototype Pollution in lodash
> Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The function zipObjectDeep allows a malicious user to modify the prototype of Object if the property identifiers are user-supplied. Being affected by this issue requires zipping objects based on user-provided property arrays.
> 
> This vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.
> 
> Affected versions: ["< 4.17.19"]