### PR TITLE
[7.x] Preventing auth.json and Nova directory from being committed accidentally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 /nova
-auth.json
+/auth.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+/nova
+auth.json


### PR DESCRIPTION
Sometime ago when I pushed one of my projects to github I realized that the **Nova** directory is pushed with it! and it got me a horrible feeling that I have committed an accidental copyright infringement!!

And think of it when it happens about the ``auth.json`` file that contains your important credentials!

So I added them to ``.gitignore`` to prevent such horrible mistakes.