### PR TITLE
[7.x] Add stdout log channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -71,7 +71,16 @@ return [
                 'port' => env('PAPERTRAIL_PORT'),
             ],
         ],
-
+        
+        'stdout' => [
+            'driver' => 'monolog',
+            'handler' => StreamHandler::class,
+            'formatter' => env('LOG_STDERR_FORMATTER'),
+            'with' => [
+                'stream' => 'php://stdout',
+            ],
+        ],
+        
         'stderr' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,


### PR DESCRIPTION
Hi,

Useful in worker instance (AWS) where we want to send all log calls (not just errors).