### PR TITLE
[7.x] Use a mutator method to automatically hash plain text passwords

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -5,6 +5,7 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Hash;
 
 class User extends Authenticatable
 {
@@ -36,4 +37,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+    
+    /**
+     * Hash the password if plain text.
+     *
+     * @var string
+     */
+    public function setPasswordAttribute($value)
+    {
+        $this->attributes['password'] = Hash::needsRehash($value) ? bcrypt($value) : $value;
+    }
 }


### PR DESCRIPTION
To avoid passwords being set in plain text, the proposed addition to the default User model will automatically hash any password value. It will not rehash bcrypt strings.

The user factory can be updated to simply provide 'password' as the default.