### PR TITLE
[7.x] Show synchronous_commit setting for Postgres

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -76,6 +76,7 @@ return [
             'prefix_indexes' => true,
             'schema' => 'public',
             'sslmode' => 'prefer',
+            // 'synchronous_commit' => 'on',
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
It's deliberately not enabled but provided commented out so developers can easily
discover that the setting is available.

The default `on` is _probably_ safe (Postgres default), but a server might
have a different default value and blindly setting it to `on` may cause problems.

Connected to https://github.com/laravel/framework/pull/33897