### PR TITLE
[7.x] Make the PHPUnit cache file .gitignore rule more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /vendor
 .env
 .env.backup
-.phpunit.result.cache
+.*.cache
 Homestead.json
 Homestead.yaml
 npm-debug.log


### PR DESCRIPTION
Switches the pattern to `.*.cache`.

Reasoning:

1. PHP CS Fixer uses this pattern too (`.php_cs.cache`).
2. PHP CS Fixer is used by the popular [Laravel Shift](https://laravelshift.com/shiftrc-configuration-file) tool.
1. `.*.cache` is a good generic pattern for various cache files, and a generic rule encourages future tool makers to use it for their cache files.