### PR TITLE
[7.x] Use `Route::view` for the initial route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::view('/', 'welcome');


### PR DESCRIPTION
Define the usage of a view route on the initial view instead of a callback.