### PR TITLE
Remove usage of non-strict empty() function

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -12,13 +12,13 @@ class RedirectIfAuthenticated
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string|null  $guard
+     * @param  Closure  $next
+     * @param  string[] $guards
      * @return mixed
      */
     public function handle($request, Closure $next, ...$guards)
     {
-        $guards = empty($guards) ? [null] : $guards;
+        $guards = count($guards) === 0 ? [null] : $guards;
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,7 +13,7 @@ class RedirectIfAuthenticated
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  Closure  $next
-     * @param  string[] $guards
+     * @param  string[]|string|null $guards
      * @return mixed
      */
     public function handle($request, Closure $next, ...$guards)


### PR DESCRIPTION
PHPstan recommends against usage of the `empty()` function: <https://github.com/phpstan/phpstan-strict-rules/blob/master/src/Rules/DisallowedConstructs/DisallowedEmptyRule.php>

I also updated the PHPdoc to match the new function parameter names.