### PR TITLE
Remove unused import

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase


### PR DESCRIPTION
The `RefreshDatabase` trait is imported from `Illuminate\Foundation\Testing` namespace but never referenced in this example test.