### PR TITLE
Fix type hint of deconstructed $guards

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,7 +13,7 @@ class RedirectIfAuthenticated
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  string[]|null  ...$guards
+     * @param  string|null  ...$guards
      * @return mixed
      */
     public function handle($request, Closure $next, ...$guards)


### PR DESCRIPTION
With deconstructed arguments, we should always use the element's type, not type it as an array.