### PR TITLE
[8.x] Fix for telescope: Target class [env] does not exist

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,6 @@
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
-        <server name="TELESCOPE_ENABLED" value="false"/>
+        <server name="TELESCOPE_ENABLED" value="false" verbatim="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Solution for: laravel/telescope#943

Reference: sebastianbergmann/phpunit#2451