### PR TITLE
Fix PHPUnit bool server consts result in null

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,6 @@
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
-        <server name="TELESCOPE_ENABLED" value="false"/>
+        <server name="TELESCOPE_ENABLED" value="(false)"/>
     </php>
 </phpunit>


### PR DESCRIPTION
After updating to Laravel 8 I suddenly had my test suite failing because telescope would not be disabled properly by `phpunit.xml` anymore.
This change fixed my test suite.

I've also created a clean Laravel 8 project and added some tests to demonstrate the issue:
https://github.com/hettiger/laravel-env-demo/commit/908d3405b84e769c12d296e98bef1ca567127254

Maybe this needs to be addressed in PHPUnit. However I'm adding this workaround here because it's a viable solution IMHO.
Maybe should add a note on this in the docs and be done with it…?