### PR TITLE
enable naming the migrations table via environment

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -104,7 +104,7 @@ return [
     |
     */
 
-    'migrations' => 'migrations',
+    'migrations' => env('DB_MIGRATIONS_TABLE_NAME', 'migrations'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Proposal to offer an environment variable for declaring a custom name for the `migrations` table, overriding the default in `config/database.php`...

I frequently rename `migrations` to `_migrations`, for example, to isolate it from application (model) tables, and float it to the top in database GUI tools.