### PR TITLE
[8.x] Add validation translation for new methods

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -113,6 +113,8 @@ return [
     'starts_with' => 'The :attribute must start with one of the following: :values.',
     'string' => 'The :attribute must be a string.',
     'timezone' => 'The :attribute must be a valid zone.',
+    'unfilled_if' => 'The :attribute field must not be used when :other field is :value.',
+    'unfilled_with' => 'The :attribute field must not be used when :values is present.',
     'unique' => 'The :attribute has already been taken.',
     'uploaded' => 'The :attribute failed to upload.',
     'url' => 'The :attribute format is invalid.',


### PR DESCRIPTION
This change matches: 
[8.x] Add unfilled_if & unfilled_with validation rules to Validator - https://github.com/laravel/framework/pull/34425