### PR TITLE
Added missing paginator translation keys

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -15,5 +15,9 @@ return [
 
     'previous' => '&laquo; Previous',
     'next' => 'Next &raquo;',
-
+    'showing' => 'Showing',
+    'to' => 'to',
+    'of' => 'of',
+    'results' => 'results',
+    'goto' => 'Go to page :page',
 ];


### PR DESCRIPTION
I made an appeal to the translations of the paginator keys, since this file contained an appeal to both the pagination.php file and the json file.
Has brought the code to a single form.

See my PR: https://github.com/laravel/framework/pull/34518