### PR TITLE
[8.x] Remove unused import

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
Import "Illuminate\Contracts\Auth\MustVerifyEmail" is never used.

![image](https://user-images.githubusercontent.com/5250117/94352279-13f2cc80-008d-11eb-8a72-7c8076af3b21.png)
