### PR TITLE
[8.x] Better SPA Routing Support

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -29,6 +29,15 @@ class RouteServiceProvider extends ServiceProvider
     // protected $namespace = 'App\\Http\\Controllers';
 
     /**
+     * The SPA route action for the application.
+     *
+     * When present, all routes in your routes/spa.php file will be directed to this action.
+     *
+     * @var array|string
+     */
+    protected $spaAction = 'SPAController@index';
+
+    /**
      * Define your route model bindings, pattern filters, etc.
      *
      * @return void
@@ -46,6 +55,15 @@ class RouteServiceProvider extends ServiceProvider
             Route::middleware('web')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
+
+            Route::middleware('web')
+                ->namespace($this->namespace)
+                ->group(function () {
+                    collect(require base_path('routes/spa.php'))
+                        ->each(function ($path) {
+                            Route::get($path, $this->spaAction);
+                        });
+                });
         });
     }
 

--- a/routes/spa.php
+++ b/routes/spa.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | SPA Routes
+    |--------------------------------------------------------------------------
+    |
+    | Here is where you can register SPA routes for your application. These
+    | routes are loaded by the RouteServiceProvider within a group which
+    | is assigned the "web" middleware and directed to the SPA action.
+    |
+    */
+
+    // '/users/{userId}',
+
+];


### PR DESCRIPTION
**Motivation**
Currently, there's no official guidance on how to register SPA routes in Laravel. I think the majority of folks use [`Route::fallback`](https://github.com/laravel/framework/pull/21299) to register a catch-all route for SPAs. While this does solve the problem to a certain extent, it is [not recommended for SEO](https://thegray.company/blog/single-page-application-spas-404s-seo) as it serves a 200 response code for every single route from the backend. Search engines such as Google call these [soft 404s](https://support.google.com/webmasters/answer/181708?hl=en) and currently have very little support to detect and flag such pages as 404s on their own.

There are other alternatives such as redirecting to a 404 page or serving a `no-index` meta tag. Ultimately, these are sub-par solutions. The best solution for SEO is to serve the correct 404 response code from the server. It not only solves the SEO issue at hand but also makes it easy for tools such as broken link checkers and analytics tools to flag errors.

This PR makes it easy for Laravel users to register SPA routes (or patterns) in a single file so as to properly serve 404 response codes for un-registered routes.

**Why not leave it to users to do this in their own apps**
I reckon this is the 80% use case. Most web apps are using SPAs today (and Laravel has traditionally supported SPA frameworks such as Vue out-of-the-box) and this is probably a challenge for the majority of users that have SPAs.

**Possible Extension**
Sometime down the road, we could even have SPA frameworks such as Vue or React generate a list of SPA route patterns from their routers as part of the build process and have PHP (the `routes/spa.php` file) cache and serve these routes.
