### PR TITLE
API version specification for AWS

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -63,6 +63,7 @@ return [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
+            'version' => env('AWS_API_VERSION', 'latest'),
         ],
 
     ],

--- a/config/mail.php
+++ b/config/mail.php
@@ -47,6 +47,7 @@ return [
 
         'ses' => [
             'transport' => 'ses',
+            'version' => env('AWS_API_VERSION', 'latest'),
         ],
 
         'mailgun' => [


### PR DESCRIPTION
API version specification is required by current version of official [aws/aws-sdk-php package](https://github.com/aws/aws-sdk-php)