### PR TITLE
[8.x] Add batching config

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -86,4 +86,18 @@ return [
         'table' => 'failed_jobs',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Batching Jobs
+    |--------------------------------------------------------------------------
+    |
+    | These options configure the database connection with which to keep
+    | track of job batches.
+    |
+    */
+
+    'batching' => [
+        'table' => 'job_batches',
+        'database' => env('DB_CONNECTION', 'mysql'),
+    ],
 ];


### PR DESCRIPTION
Currently, there is no config defined for batching in `config/queue.php`, and this PR adds it.

I wasn't too sure whether `queue.batching.database` should match the default value in `config/database.php` (ie: `env('DB_CONNECTION', 'mysql')`, or whether it should be set to `null`. For the initial PR, I set it to the `env()` output. However, my thinking is that if it was `null`, it would match the default database connection, regardless of whether the default database connection was hardcoded or not - and would be the better value.