### PR TITLE
Fixing Authenticate middleware for phpstan level 2

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,5 +17,7 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
+
+        return null;
     }
 }


### PR DESCRIPTION
In a freshly installed vanilla Laravel app, using phpstan and larastan on level 2 (to 8) raises
an error, this commit fixes that by adding an explicit return :

```
Line   Http/Middleware/Authenticate.php
 ------ ---------------------------------------------------
  17     Method
         App\Http\Middleware\Authenticate::redirectTo()
         should return string|null but return statement is
         missing.
```

It's my first MR on laravel, please be gentle :pray:  (also not sure if this is the proper destination branch, I figured it would benefit the LTS to the 8 version).

P.S. I would really appreciate if it could count toward my Hacktoberfest goal :jack_o_lantern: (by adding the `hacktoberfest-accepted` on this PR :pray: )