### PR TITLE
JSON & XML should be with indent size of 2(less then 4)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml}]
+[*.{yml,yaml,json,xml}]
 indent_size = 2


### PR DESCRIPTION
JSON and XML seems more clearly and easy to understand with only indent size of 2.
4 indent size is too much when you have JSON file with lots of details a fortiori when we talking about XML files :).
moreover this way it makes JSON and XML looks close to their RFCs respectively.

source:
https://tools.ietf.org/html/rfc7159#page-4
https://tools.ietf.org/html/rfc3470#page-3