### PR TITLE
[8.x] Ignores csrf on logout route for guest users

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -3,6 +3,8 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+use Illuminate\Support\Facades\Auth;
+use Closure;
 
 class VerifyCsrfToken extends Middleware
 {
@@ -14,4 +16,27 @@ class VerifyCsrfToken extends Middleware
     protected $except = [
         //
     ];
+
+
+    /**
+     * Handle an incoming request. Ignores csrf for guests at the logout route, so
+     * no error is thrown when posting to logout on an already expired session
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Illuminate\Session\TokenMismatchException
+     */
+    public function handle($request, Closure $next)
+    {
+        if(Auth::guest() && $request->route()->named('logout')) {
+        
+            $this->except[] = route('logout');
+            
+        }
+
+        return parent::handle($request, $next);
+    }
+
 }


### PR DESCRIPTION
A problem with the CSRF token in the logout form is that it can become stale in at least the following three scenarios

- User has more than one tab open and logs out in one of them. The logout action on other tabs will now produce 419 Page Expired error
- User has a single tab open but leaves the site and does not return during the session duration. The CSRF token is then stale and pressing logout gives 419 error.
- The user uses the option to close all sessions on other devices. Logout on a terminated session will generate the error.

csrf protection for logged in users and guests for other than the logout route is unchanged