### PR TITLE
[9.x] Remove Event facade alias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -203,7 +203,7 @@ return [
         'Crypt' => Illuminate\Support\Facades\Crypt::class,
         'DB' => Illuminate\Support\Facades\DB::class,
         'Eloquent' => Illuminate\Database\Eloquent\Model::class,
-        'Event' => Illuminate\Support\Facades\Event::class,
+        // 'Event' => Illuminate\Support\Facades\Event::class,
         'File' => Illuminate\Support\Facades\File::class,
         'Gate' => Illuminate\Support\Facades\Gate::class,
         'Hash' => Illuminate\Support\Facades\Hash::class,


### PR DESCRIPTION
As Laravel Swoole users will experience a silent conflict with alias `\Event`
https://github.com/imanghafoori1/laravel-microscope/issues/79#issuecomment-698201489

Any laravel package which uses the Alias of facade (`\Event::`) will become incompatible with laravel-swoole. In other words: package maintainers should not use `\Event` otherwise their package won't work properly on swoole.
So I thought commenting out the alias for laravel 9.x will alert the package developers not to use the `\Event` and make their packages swoole compatible.

- Plus is it really needed to have the alias? aliases are meant to be used in blade files where importing a class is clunky and we never fire events in blade files.