### PR TITLE
Remove lodash from the default window._ object

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "axios": "^0.19",
         "cross-env": "^7.0",
         "laravel-mix": "^5.0.1",
-        "lodash": "^4.17.19",
         "resolve-url-loader": "^3.1.0"
     }
 }

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,5 +1,3 @@
-window._ = require('lodash');
-
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
  * to our Laravel back-end. This library automatically handles sending the


### PR DESCRIPTION
Lodash is a pretty big library at 70kb unminified. https://bundlephobia.com/result?p=lodash@4.17.20. Laravel includes it by default in the bootstrap.js file, thus making the bundle unnecessarily large.

New applications should generally not be using lodash, as the default javascript library has improved significantly since it was created. If lodash is needed, it can be imported as https://www.npmjs.com/package/lodash-es in a treeshakeable way, as and when needed.

This doesn't really break anything as far as I can tell in the base laravel template. This might break existing projects, but that is very easily worked around by just adding it back in when updating.