### PR TITLE
[8.x] Modify the cache.php docblocks

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -13,9 +13,6 @@ return [
     | using this caching library. This connection is used when another is
     | not explicitly specified when executing a given caching function.
     |
-    | Supported: "apc", "array", "database", "file",
-    |            "memcached", "redis", "dynamodb"
-    |
     */
 
     'default' => env('CACHE_DRIVER', 'file'),
@@ -28,6 +25,9 @@ return [
     | Here you may define all of the cache "stores" for your application as
     | well as their drivers. You may even define multiple stores for the
     | same cache driver to group types of items stored in your caches.
+    |
+    | Supported drivers: "apc", "array", "database", "file",
+    |            "memcached", "redis", "dynamodb"
     |
     */
 


### PR DESCRIPTION
In new versions of laravel we do not directly specify the "cache driver" anymore but rather a "cache store",
So it does not make sense to mention the list of drivers in the default section since laravel actually supports any arbitrary values as default cache store defined by the user.
I think it is misleading and the reader thinks that they are the only allowed values to be set as default.

Maybe you want to rename the env variable "CACHE_DRIVER" to "CACHE_STORE" for laravel 9.x (also in `.env.example`)