### PR TITLE
set constant value instead of based on application environment(.env)

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -123,7 +123,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+            'prefix' => env('REDIS_PREFIX', 'laravel_database_'),
         ],
 
         'default' => [


### PR DESCRIPTION
when you are working on local(server) environment we have `.env` file so it will get `app_name` so  value is 

**appname_database_**

but when you are in production(server) environment we don't have `.env` file(don't upload `.env `file in production for security reason) so it will get value is

**laravel_database_** 

because of we don't upload `.env` file in production(server) 

**it's bit confusing so better to set constant value if user want to change prefix then do**

  