### PR TITLE
Use assertOk instead of assertStatus

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,6 +16,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
If this pull request is approved I am planning to create a pull request in Laravel Framework to update the stub test (https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/stubs/test.stub) in order to generate tests with `php artisan make:test` with `assertOk` method by default.