### PR TITLE
[8.x] Uncomment TrustHosts middleware to enable it by default

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,7 +14,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        // \App\Http\Middleware\TrustHosts::class,
+        \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
         \Fruitcake\Cors\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,


### PR DESCRIPTION
We recently learned of a vulnerability in our app through our Bug Bounty program which allowed an attacker to change the host of a signed URL using the `X-Forwarded-Host` header. This allowed an attacker to generate a malicious password-reset email which, if the link was clicked, would send the user's password reset token to a website controlled by the hacker.

Enabling this middleware by default could close this vulnerability for many websites who may currently be exposed to this same vulnerability.