### PR TITLE
added missing env variables for smtp config section

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -41,8 +41,15 @@ return [
             'encryption' => env('MAIL_ENCRYPTION', 'tls'),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
-            'timeout' => null,
-            'auth_mode' => null,
+            'timeout' => env('MAIL_TIMEOUT'),
+            'auth_mode' => env('MAIL_AUTH_MODE'),
+            'stream' => [
+                'ssl' => [
+                    'allow_self_signed' => env('MAIL_STREAM_ALLOW_SELF_SIGNED', false),
+                    'verify_peer' => env('MAIL_STREAM_VERIFY_PEER', true),
+                    'verify_peer_name' => env('MAIL_STREAM_VERIFY_PEER_NAME', true),
+                ],
+            ],
         ],
 
         'ses' => [


### PR DESCRIPTION
added following env variables for allow use self hosted mail servers with self signed certificates.
To enable self signed certificates in your .env file set
```
MAIL_STREAM_ALLOW_SELF_SIGNED=true
```
also when you need to skip verifying peers then set
```
MAIL_STREAM_VERIFY_PEER=false
MAIL_STREAM_VERIFY_PEER_NAME=false
```

| Variable  | Default |
| ------------- | ------------- |
| MAIL_TIMEOUT | null |
| MAIL_AUTH_MODE | null |
| MAIL_STREAM_ALLOW_SELF_SIGNED | false |
| MAIL_STREAM_VERIFY_PEER | true |
| MAIL_STREAM_VERIFY_PEER_NAME | true |
