### PR TITLE
[8.x] Gitignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .env
 .env.backup
 .phpunit.result.cache
+docker-compose.override.yml
 Homestead.json
 Homestead.yaml
 npm-debug.log


### PR DESCRIPTION
Docker allows for you to override parts of `docker-compose.yml` locally with the help of a `docker-compose.override.yml` file: https://docs.docker.com/compose/extends/#understanding-multiple-compose-files

I propose to have this file ignored by default for new projects, similarly to how `.env` is ignored to be able to override default configuration (locally).

Example use case: Someone might want to use Laravel Sail, but would have multiple Laravel projects running in MySQL and would like to run a single MySQL server for each project and have a way to be able to override docker-compose to make that happen. Or maybe just in general they want to add a new service that they want to run only for themselves, and not for colleagues.