### PR TITLE
[8.x] Adds flag to declare the container volume as the source of truth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
         volumes:
-            - '.:/var/www/html'
+            - '.:/var/www/html:delegated'
         networks:
             - sail
         depends_on:


### PR DESCRIPTION
Adds the `:delegated` flag to volumes to improve Mac performance. 

Running the command `time sail composer update` went from 46 seconds down to 26 seconds. 
Times will vary for other developers but it is a significant speed increase

This flag used to be documented on the Docker docs but it's been removed and I can't find anything official about this anymore.