### PR TITLE
[8.x] Add lock connection config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -46,6 +46,7 @@ return [
             'driver' => 'database',
             'table' => 'cache',
             'connection' => null,
+            'lock_connection' => null,
         ],
 
         'file' => [
@@ -75,6 +76,7 @@ return [
         'redis' => [
             'driver' => 'redis',
             'connection' => 'cache',
+            'lock_connection' => 'default',
         ],
 
         'dynamodb' => [


### PR DESCRIPTION
This PR adds the `lock_connection` configuration option based on https://github.com/laravel/framework/pull/35621. By default, the Redis lock connection is set to `default` instead of `cache` so that a `clear:cache` doesn't clear locks. 

The Database store doesn't need a separate connection (even though there is an option for it) because the store flush just deletes the cache specific table (the lock table stays intact).