### PR TITLE
[8.x] Fixed redirection on session timed out

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -23,7 +23,7 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
-                return redirect(RouteServiceProvider::HOME);
+                return redirect()->intended(RouteServiceProvider::HOME);
             }
         }
 


### PR DESCRIPTION
Each session timed out on remember me mode, Laravel makes re-login, if authenticated redirection haven't intended support, user will be lost the last page and will be redirected to home page.