### PR TITLE
Remove --no-progress from npm run prod key & use laravel-mix 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
         "axios": "^0.19",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "devDependencies": {
         "axios": "^0.19",
         "cross-env": "^7.0",
-        "laravel-mix": "^5.0.1",
+        "laravel-mix": "^6.0.0",
         "lodash": "^4.17.19",
         "resolve-url-loader": "^3.1.0"
     }


### PR DESCRIPTION
laravel mix 6 is out and I got an "Unknown argument: --no-progress" error when trying out npm run prod. 

So I guess the latest webpack removed it.