### PR TITLE
ignore .env backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.env.bak
 .phpunit.result.cache
 docker-compose.override.yml
 Homestead.json


### PR DESCRIPTION
> Your .env file should not be committed to your application's source control ... this would be a security risk in the event an intruder gains access to your source control repository, since any sensitive credentials would get exposed 
> https://laravel.com/docs/8.x#initial-configuration

my fresh laravel installation creates .env.bak file exposing sensitive data, which is not ignored by default