### PR TITLE
[8.x] Update TrustedProxies::$headers 

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -19,5 +19,8 @@ class TrustProxies extends Middleware
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers = Request::HEADER_X_FORWARDED_FOR
+        | Request::HEADER_X_FORWARDED_HOST
+        | Request::HEADER_X_FORWARDED_PORT
+        | Request::HEADER_X_FORWARDED_PROTO;
 }


### PR DESCRIPTION
Dear,

Since Symfony 5.2, `Request::HEADER_X_FORWARDED_ALL` is deprecated.
This PR update `App\Http\Middleware\TrustedProxies::$headers` use  `HEADER_X_FORWARDED_FOR | HEADER_X_FORWARDED_HOST | HEADER_X_FORWARDED_PORT | HEADER_X_FORWARDED_PROTO` instead.

Fixed laravel/framework#35700