### PR TITLE
[8.x] Update typehint of Authenticate Middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,7 +10,7 @@ class Authenticate extends Middleware
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string|null
+     * @return string|void
      */
     protected function redirectTo($request)
     {

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,12 +10,14 @@ class Authenticate extends Middleware
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string|void
+     * @return string|null
      */
     protected function redirectTo($request)
     {
         if (! $request->expectsJson()) {
             return route('login');
         }
+        
+        return null;
     }
 }

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,7 +17,7 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
-        
+
         return null;
     }
 }


### PR DESCRIPTION
Typehint is not correct as the method can return void.

Phpstan is returning an error about this typehint : 

```
------ ------------------------------------------------------------------------------------------------------------------ 
  Line   app/Http/Middleware/Authenticate.php                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------ 
  17     Method App\Http\Middleware\Authenticate::redirectTo() should return string|null but return statement is missing.  
 ------ ------------------------------------------------------------------------------------------------------------------
```