### PR TITLE
Update laravel-mix to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,16 @@
     "private": true,
     "scripts": {
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "watch-poll": "npm run watch -- --watch-poll",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "development": "mix",
+        "watch": "mix watch",
+        "watch-poll": "mix watch -- --watch-options-poll=1000",
+        "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "mix --production"
     },
     "devDependencies": {
         "axios": "^0.19",
-        "cross-env": "^7.0",
-        "laravel-mix": "^5.0.1",
+        "laravel-mix": "^6.0.5",
         "lodash": "^4.17.19",
         "resolve-url-loader": "^3.1.0"
     }


### PR DESCRIPTION
[Jeffrey](https://github.com/JeffreyWay) already released v6.0.0 of [laravel-mix](https://github.com/JeffreyWay/laravel-mix) for 8 days ago.

> This release brings Laravel Mix current with webpack 5. It additionally includes a variety of bug fixes and enhancements.

I think this update will be very important to use tailwind 2 easily