### PR TITLE
Upgrade to Mix v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     },
     "devDependencies": {
         "axios": "^0.19",
-        "cross-env": "^7.0",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14"

--- a/package.json
+++ b/package.json
@@ -2,18 +2,18 @@
     "private": true,
     "scripts": {
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "watch-poll": "npm run watch -- --watch-poll",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --disable-host-check --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "development": "mix",
+        "watch": "mix watch",
+        "watch-poll": "mix watch -- --watch-options-poll=1000",
+        "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "production": "mix --production"
     },
     "devDependencies": {
         "axios": "^0.19",
         "cross-env": "^7.0",
-        "laravel-mix": "^5.0.1",
+        "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
-        "resolve-url-loader": "^3.1.0"
+        "postcss": "^8.1.14"
     }
 }


### PR DESCRIPTION
This PR upgrades Laravel Mix to v6. 

The update to `package.json` should be all that we need here, but we should also take a look at some of the presets. 

- **Upgrade Guide**: https://github.com/JeffreyWay/laravel-mix/blob/master/UPGRADE.md
- **Changelog**: https://github.com/JeffreyWay/laravel-mix/blob/master/CHANGELOG.md

I've also made a PR to the docs.

https://github.com/laravel/docs/pull/6705