### PR TITLE
[8.x] Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.3 || ^8.0",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",


### PR DESCRIPTION
Replace the [deprecated](https://github.com/composer/composer/issues/6755) single pipe (`|`) with a double pipe (`||`).

See the [Composer documentation for version ranges](https://getcomposer.org/doc/articles/versions.md#version-range) for more information.

On a related note, maybe it's possible to add [`composer-normalize`](https://github.com/ergebnis/composer-normalize) as an action to automatically check the `composer.json` file.