### PR TITLE
Update sail to the v1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
-        "laravel/sail": "^0.0.5",
+        "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3.3"


### PR DESCRIPTION
The Laravel Sail section (https://laravel.com/docs/8.x/sail) provides a list of arguments that we can use with the 'sail' command. Some of the arguments are 'not found' after the fresh install(e.g. https://laravel.com/docs/8.x/sail#sharing-your-site).

The laravel/sail package is updated to the v1.0.1.