### PR TITLE
[8.x] Hide .env.bak as well as .env.backup in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /storage/*.key
 /vendor
 .env
-.env.backup
+.env.ba*
 .phpunit.result.cache
 docker-compose.override.yml
 Homestead.json


### PR DESCRIPTION
Using the Laravel curl installation command, it creates a `.env.bak` file instead of `.env.backup`. Changing the .gitignore to `.env.ba*` hides both.