### PR TITLE
Stop Env Commits

### DIFF
--- a/.git_hook_precommit
+++ b/.git_hook_precommit
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# A hook to try and prevent users committing credentials
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+git diff --cached --name-only --diff-filter=AM -z $against | grep "^.env" > /dev/null
+	if [ $? -eq 0 ]
+then
+	cat <<\EOF
+Error: It appears your trying to commit changes to an environment file
+
+This is probably not what you want to do, if you commit these changes to a public place
+such as Github, these credentials will also be public.
+
+If you know what you are doing you can disable this check using:
+
+  git commit --no-verify
+
+This will disable the check on this commit only.
+
+Otherwise use:
+
+  git restore --staged -- .env*
+EOF
+	exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.env.example
 .phpunit.result.cache
 docker-compose.override.yml
 Homestead.json

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
+            "@php artisan package:discover --ansi",
+            "@php -r \"file_exists('.git/hooks/pre-commit') || symlink('../../.git_hook_precommit', '.git/hooks/pre-commit');\""
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""


### PR DESCRIPTION
This is not a laravel issue per se, but there are a portion of users who
change the .env.example file with real data and then commmit it, or even
just commit the generated .env file.

This change adds a hook in to check the commits to see if they contain
an .env file and gives users a way to commit either way (ie they
do know what they are doing and want to skip over the message, or they
were not aware of what they were doing and a way to recover from that
(without losing their changes).

There are a few bots that are actively scanning for these files as
laravel has a large user base and people commit to this file. AWS
Credentials and mail credentials are most common.

This may not be the best solution, but happy to have a discussion on how
to prevent users of laravel making these mistakes which can be costly.