### PR TITLE
[9.x] Bumps Collision version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.2",
-        "nunomaduro/collision": "^5.0",
+        "nunomaduro/collision": "^5.2",
         "phpunit/phpunit": "^9.3.3"
     },
     "config": {


### PR DESCRIPTION
This pull request bumps the Collision version, to a version that supports Parallel Testing: https://github.com/laravel/framework/pull/35778.