### PR TITLE
[9.x] Mailhog's forward ports configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
     mailhog:
         image: 'mailhog/mailhog:latest'
         ports:
-            - 1025:1025
-            - 8025:8025
+            - '${FORWARD_MAILHOG_PORT:-1025}:1025'
+            - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
         networks:
             - sail
 networks:


### PR DESCRIPTION
To avoid port clash between different projects running on the same machine, it could be useful making mailhog's port configurable.