### PR TITLE
[8.x] Add middleware responsible for removing trailing slashes 

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\RemoveTrailingSlash::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/RemoveTrailingSlash.php
+++ b/app/Http/Middleware/RemoveTrailingSlash.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Redirect;
+
+class RemoveTrailingSlash
+{
+    public function handle($request, Closure $next)
+    {
+        if (preg_match('/.+\/$/', $request->getRequestUri())) {
+            return Redirect::to(rtrim($request->getRequestUri(), '/'), 301);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
It is important as this applies to all applications made with laravel and it is bad for SEO as Google sees every single page twice. The correct behaviour is to create 301 for ever page with trailing slash to avoid content duplication in search results.

BTW even main laravel.com does not have this implemented.

Here is the source: https://developers.google.com/search/blog/2010/04/to-slash-or-not-to-slash