### PR TITLE
[8.x] Add cookie prefixes to prevent cookie smuggling attacks

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -133,6 +133,48 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Session Cookie Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This feature adds a set of restrictions upon the names which may be used
+    | for cookies with specific properties. These restrictions enable user
+    | agents to smuggle cookie state to the server within the confines of the
+    | existing `Cookie` request header syntax and limits the ways in which
+    | cookies may be abused.
+    |
+    | It is ideal to make secure cookies writable only from `secure origins`.
+    | Cookie prefixes make it possible to flag your cookies to have different
+    | behaviour, in a backward compatible way. It uses a dirty trick to put a
+    | flag in the name of the cookie. When a cookie name starts with this
+    | flag, it triggers additional browser policies on the cookie in
+    | supporting browsers.
+    |
+    | The `__Secure-` prefix makes a cookie accessible from HTTPS sites only.
+    | A HTTP site can not read or update a cookie if the name starts with
+    | `__Secure-`. This protects against the cookie smuggling attack, where
+    | an attacker uses a forged insecure site to overwrite a secure cookie.
+    |
+    | The `__Host-` prefix does the same as the `__Secure-` prefix and more.
+    | A `__Host-` prefixed cookie is only accessible by the same domain it is
+    | set on. This means that a 'subdomain can no longer overwrite the cookie
+    | value'.
+    |
+    | Supported: "secure", "host" and "none"
+    |
+    | Secure - Requires `https`, cookie `session.secure` set to `true` and
+    | can be used with subdomains. This is the `default` setting.
+    |
+    | Host - Requires `https`, cookie `session.secure` set to `true`, can't
+    | be used with subdomains and the `session.path` has a value of `/`.
+    |
+    | None - Don't turn this security feature on. Not recommended.
+    |
+    */
+
+    'cookie_prefix' => 'secure',
+
+    /*
+    |--------------------------------------------------------------------------
     | Session Cookie Path
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This pr follows on from the discussion and pr found here: https://github.com/octobercms/october/pull/5468

This is the first time I've submitted something to the laravel repo.

If I'm correct this repo will be to update the config file and the laravel/framework repo will be doing the code processing for the config value.

To be honest I'm a bit confused on the laravel/framework repo side of things and not sure how to convert my pr into the laravel core code? If one of the Laravel team could look at my pr code and do the framework side, that would be really great, my original code is found here: https://github.com/octobercms/october/pull/5468/files

### Introduction

The goal of this pr is to add the extra security flags browsers have set up using cookie prefixes.

To learn more see here: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00#section-3

### Summary

Mike West from Google said a good summary in a private conversation, see here:

> `secure` ought to mean "secure": Though it's well-known that cookies
> cross back and forth over protocol boundaries, recent research from
> Zheng, et al. has highlighted the fact that this behaviour remains
> surprising to developers, and also that there's little practical recourse
> without changes in the browser.
> 
> We intend to make it more difficult for non-secure origins to influence the
> state of secure origins by preventing non-secure origins from writing
> cookies with a 'secure' flag and overwriting cookies whose 'secure' flag is
> set. We're also planning to tweak the eviction rules to ensure that a
> host's non-secure cookies are removed before its secure cookies.

A detailed explanation of the attack can be found here: https://www.usenix.org/system/files/conference/usenixsecurity15/sec15-paper-zheng.pdf

### PR Explanation

Below is the overview of the logic:

- There is a new config setting in the `Session.php` config file, under the attribute `cookie_prefix`

This allows three settings:

- `Secure` this is the **default** setting in Laravel and the cms will add the prefix, if the cookie name doesn't contain a hardcoded prefix, the cms is running `https` and the Cookie `Secure` setting is set to true. This setting allows subdomain cookies to work.

```
__Secure-laravel_session
```

- `Host` this is a more **strict** setting and the cms will add the prefix, if the cookie name doesn't contain a hardcoded prefix, the cms is running `https` and the Cookie `Secure` setting is set to true. This setting doesn't allow subdomains to work with the cookie and the cookie `path` must be set to `/`.

```
__Host-laravel_session
```

- `None` this completely turns off the cms from adding a cookie prefix automatically! This is not recommended, but I've added it to allow users to have complete control and be able to **opt-in** to this enhanced cookie security feature.

```
laravel_session
```

### Browser Compatibility

Google created the cookie prefix spec way back in 2015 and added it to Google Chrome 49.

All major browsers accept cookie prefixes, see below for the latest MDN browser compatibility stats.

![image](https://user-images.githubusercontent.com/57409060/105410542-fb08bb00-5c29-11eb-876d-a5e7da16cef4.png)

For browsers like `IE11` who don't use cookie prefixes, nothing will happen and nothing will break! Cookie prefixes have been fully tested to pass browsers that don't understand them!

For browsers that understand cookie prefixes - the browser will turn on an extra security flag - helping to prevent cookie smuggling attacks!
