### PR TITLE
add "ably" in comment as a broadcast connection

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -11,7 +11,7 @@ return [
     | framework when an event needs to be broadcast. You may set this to
     | any of the connections defined in the "connections" array below.
     |
-    | Supported: "pusher", "redis", "log", "null"
+    | Supported: "pusher", "ably", "redis", "log", "null"
     |
     */
 


### PR DESCRIPTION
'ably' was added in the connections array, but the comment was not updated to reflect this fact.