### PR TITLE
[8.x] Add unverified state to UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -30,4 +30,18 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
         ];
     }
+
+    /**
+     * Define the model's unverified state.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function unverified()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'email_verified_at' => null,
+            ];
+        });
+    }
 }


### PR DESCRIPTION
This will add an unverified state to the User model factory to give an example for newcomers of how to use states in the new 8.x syntax. It also serves as a useful addition when writing feature tests where the faked user is intended to not have their email verified yet.