### PR TITLE
Change "Login" text to "Log in"

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -27,7 +27,7 @@
                     @auth
                         <a href="{{ url('/home') }}" class="text-sm text-gray-700 underline">Home</a>
                     @else
-                        <a href="{{ route('login') }}" class="text-sm text-gray-700 underline">Login</a>
+                        <a href="{{ route('login') }}" class="text-sm text-gray-700 underline">Log in</a>
 
                         @if (Route::has('register'))
                             <a href="{{ route('register') }}" class="ml-4 text-sm text-gray-700 underline">Register</a>


### PR DESCRIPTION
As this is used as a verb, like its sibling "Register", the verb form ("Log in") should be used, instead of the noun form ("Login").

The full argument is here: http://notaverb.com/login and https://grammarist.com/spelling/log-in-login/

The short version is: the past tense is "logged in" not "logined", so the present imperative tense is "log in" (but you can use "login" as a noun, as in "I have a login on that site").

This also would bring Laravel in line with things like Facebook, Twitter, WordPress, Drupal, and more.

<img width="422" alt="Screen Shot 2021-02-15 at 3 51 38 PM" src="https://user-images.githubusercontent.com/353790/107992311-6aae6380-6fa6-11eb-9fa9-0b2222192367.png">
<img width="434" alt="Screen Shot 2021-02-15 at 3 57 22 PM" src="https://user-images.githubusercontent.com/353790/107992354-81ed5100-6fa6-11eb-868a-6d75041d2213.png">
<img width="446" alt="Screen Shot 2021-02-15 at 3 57 50 PM" src="https://user-images.githubusercontent.com/353790/107992380-92053080-6fa6-11eb-8e5a-cda56fe179a6.png">
<img width="371" alt="Screen Shot 2021-02-15 at 3 58 43 PM" src="https://user-images.githubusercontent.com/353790/107992430-b19c5900-6fa6-11eb-9a93-60f5871242f5.png">


If accepted, I'm happy to open PRs for Jetstream and Breeze, which in addition to using "Login" as a verb in several places, also use "Logout", about which the same arguments apply.