### PR TITLE
Don't flash 'current_password' input

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,6 +24,7 @@ class Handler extends ExceptionHandler
     protected $dontFlash = [
         'password',
         'password_confirmation',
+        'current_password',
     ];
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -22,9 +22,9 @@ class Handler extends ExceptionHandler
      * @var array
      */
     protected $dontFlash = [
+        'current_password',
         'password',
         'password_confirmation',
-        'current_password',
     ];
 
     /**


### PR DESCRIPTION
With starter packs like Jetstream, the `current_password` input is used.

I believe that adding `current_password` to the `$dontFlash` list by default would help to ensure new projects follow security best practices from the get-go.