### PR TITLE
[6.x] target 1.16.15 of facade/ignition for Laravel 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravel/tinker": "^2.5"
     },
     "require-dev": {
-        "facade/ignition": "^1.16.4",
+        "facade/ignition": "^1.16.15",
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^3.0",


### PR DESCRIPTION
fixes CVE-2021-3129 vulnerability (Laravel 6)