### PR TITLE
[8.x] Remove unused javaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "devDependencies": {
         "axios": "^0.21",
         "laravel-mix": "^6.0.6",
-        "lodash": "^4.17.19",
         "postcss": "^8.1.14"
     }
 }

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,5 +1,3 @@
-window._ = require('lodash');
-
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
  * to our Laravel back-end. This library automatically handles sending the


### PR DESCRIPTION
lodash seems to be included and included in bootstrap.js but it's never used. Thought I'd make this PR if people are okay with removing this or is it used that often that it should be left in the scaffolding of a fresh application?