### PR TITLE
[8.x] Don't trim `current_password`

### DIFF
--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -12,6 +12,7 @@ class TrimStrings extends Middleware
      * @var array
      */
     protected $except = [
+        'current_password',
         'password',
         'password_confirmation',
     ];


### PR DESCRIPTION
Inspired by https://github.com/laravel/framework/pull/36415

As JetStream/Fortify uses a `current_password` field when allowing a user to change their password, and as JetStream is one of the starter kits listed on the docs, this PR adds `current_password` in the `$except` option of the `TrimStrings` middleware.