### PR TITLE
[8.x] Add explanation about effect of "timezone" config

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -64,6 +64,8 @@ return [
     | Here you may specify the default timezone for your application, which
     | will be used by the PHP date and date-time functions. We have gone
     | ahead and set this to a sensible default for you out of the box.
+    | This will affect how dates are stored in your database and it
+    | is strongly recommended to leave this configuration as UTC.
     |
     */
 


### PR DESCRIPTION
I think it's important to be explicit that this configuration value affects how dates are stored in the database, and that it doesn't simply adjust dates when you echo them out.

Also, add some language to highly discourage changing the value away from UTC, as I believe the general consensus is that all datetimes should be stored as UTC in the database.

Might even be worth dropping this out of the standard config completely, so only users who have an explicit reason to not use UTC override it.