### PR TITLE
[8.x] Implements new BufferedConsoleOutput

### DIFF
--- a/artisan
+++ b/artisan
@@ -34,7 +34,7 @@ $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 
 $status = $kernel->handle(
     $input = new Symfony\Component\Console\Input\ArgvInput,
-    new Symfony\Component\Console\Output\ConsoleOutput
+    new Illuminate\Console\BufferedConsoleOutput
 );
 
 /*


### PR DESCRIPTION
Implements [this PR](https://github.com/laravel/framework/pull/36404) on the framework.

Calling the code below currently results in a fatal error because the current class doesn't implement the `fetch` method.

```php
use Illuminate\Console\Events\CommandFinished;

Event::listen(function (CommandFinished $event) {
    dump($event->output->fetch());
});
```