### PR TITLE
[8.x] Add missing 'after_commit' key to queue config

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -39,6 +39,7 @@ return [
             'table' => 'jobs',
             'queue' => 'default',
             'retry_after' => 90,
+            'after_commit' => false,
         ],
 
         'beanstalkd' => [
@@ -47,6 +48,7 @@ return [
             'queue' => 'default',
             'retry_after' => 90,
             'block_for' => 0,
+            'after_commit' => false,
         ],
 
         'sqs' => [
@@ -57,6 +59,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'after_commit' => false,
         ],
 
         'redis' => [
@@ -65,6 +68,7 @@ return [
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => 90,
             'block_for' => null,
+            'after_commit' => false,
         ],
 
     ],


### PR DESCRIPTION
There's a new `after_commit` config option that isn't in the default config for `queue` connections: 
https://laravel.com/docs/8.x/queues#jobs-and-database-transactions

For new projects it may be better to have these defaulted to `true`, but I left them as `false` for now.