### PR TITLE
[8.x] Add date facade alias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -201,6 +201,7 @@ return [
         'Config' => Illuminate\Support\Facades\Config::class,
         'Cookie' => Illuminate\Support\Facades\Cookie::class,
         'Crypt' => Illuminate\Support\Facades\Crypt::class,
+        'Date' => Illuminate\Support\Facades\Date::class,
         'DB' => Illuminate\Support\Facades\DB::class,
         'Eloquent' => Illuminate\Database\Eloquent\Model::class,
         'Event' => Illuminate\Support\Facades\Event::class,


### PR DESCRIPTION
All other facades have an alias (except for ParallelTesting - which I don't think needs one). 

I think having an alias for this makes sense as it can by handy in views to be able to work with dates that aren't always coming from a model where a cast is usable and an alias makes this nicer as we don't need to import the namespace. It is also handy in tinker to just call `Date::parse()` to test some stuff on the fly.

Related: https://github.com/laravel/docs/pull/6897