### PR TITLE
[8.x] Add language for prohibited_if and prohibited_unless validation rules

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -104,6 +104,8 @@ return [
     'required_with_all' => 'The :attribute field is required when :values are present.',
     'required_without' => 'The :attribute field is required when :values is not present.',
     'required_without_all' => 'The :attribute field is required when none of :values are present.',
+    'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',
+    'prohibited_unless' => 'The :attribute field is prohibited unless :other is in :values.',
     'same' => 'The :attribute and :other must match.',
     'size' => [
         'numeric' => 'The :attribute must be :size.',


### PR DESCRIPTION
Just adding in language for the new `prohibited_if` and `prohibited_unless` validation rules introduced in 8.x (https://github.com/laravel/framework/pull/36516)

I've mirrored the wording of the "required" validation rules as they *currently* stand, but may need to tweak this depending on the result of #5553.