### PR TITLE
Add log level config value to stderr channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -74,6 +74,7 @@ return [
 
         'stderr' => [
             'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
             'formatter' => env('LOG_STDERR_FORMATTER'),
             'with' => [


### PR DESCRIPTION
All other channels nicely respect the `LOG_LEVEL` env variable, but it is missing for the `stderr` channel by default.