### PR TITLE
Update phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
When runned for the first time "php artisan test", my db got deleted because of default tests using `Illuminate\Foundation\Testing\RefreshDatabase`. I suggest to use, as default, a SQLite DB in memory, in order to not create any issue.
This problem [is](https://laracasts.com/discuss/channels/laravel/phpunit-is-deleting-my-database) [very](https://stackoverflow.com/questions/52154577/laravel-database-tables-deleted-after-running-phpunit-test) [frequent](https://stackoverflow.com/questions/51776768/laravel-reset-database-after-test), so I think a change should be made