### PR TITLE
[8.x] Fix footer on mobile

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -21,7 +21,7 @@
         </style>
     </head>
     <body class="antialiased">
-        <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center sm:pt-0">
+        <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center py-4 sm:pt-0">
             @if (Route::has('login'))
                 <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
                     @auth


### PR DESCRIPTION
Before:

![Screenshot 2021-03-12 at 10 25 25](https://user-images.githubusercontent.com/594614/110922735-5862e380-8320-11eb-84a6-5bbd922bcc91.jpg)

After:

![Screenshot 2021-03-12 at 10 25 15](https://user-images.githubusercontent.com/594614/110922741-59941080-8320-11eb-9cca-ece8f1155f53.jpg)

I wanted to display the nav links on mobile as well but that turned out to be a little too challenging.