### PR TITLE
[8.x] Implement IDE Helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+_ide_helper.php
+_ide_helper_models.php
+.phpstorm.meta.php

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/tinker": "^2.5"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.9",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
@@ -57,6 +58,11 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "post-update-cmd": [
+            "Illuminate\\Foundation\\ComposerScripts::postUpdate",
+            "@php artisan ide-helper:generate",
+            "@php artisan ide-helper:meta"
         ]
     }
 }


### PR DESCRIPTION
This implements [Laravel IDE Helper Generator](https://github.com/barryvdh/laravel-ide-helper) which can replace the existing DocBocks in the framework.

Goes along with https://github.com/laravel/framework/pull/36583