### PR TITLE
[8.x] Update typehints to current support type

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -19,7 +19,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontFlash = [
         'current_password',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',


### PR DESCRIPTION
This pr is to update the typehint so the property declaration is the same as the parents.

Summary changes:
- Updated app/Exceptions/Handler.php to be an array of string[] instead of array
- Updated app/Http/Middleware/TrustProxies.php to support union type `int|null|string` on `$headers` prop
- Updated app/Models/User.php `$fillable` prop to be an array of string[]

I ran into this when running some static analysis with https://github.com/psalm/psalm-plugin-laravel