### PR TITLE
[8.x] Minor update to the "check if application is under maintenance" documentation in public/index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,11 +7,11 @@ define('LARAVEL_START', microtime(true));
 
 /*
 |--------------------------------------------------------------------------
-| Check If Application Is Under Maintenance
+| Check If The Application Is Under Maintenance
 |--------------------------------------------------------------------------
 |
-| If the application is maintenance / demo mode via the "down" command we
-| will require this file so that any prerendered template can be shown
+| If the application is in maintenance / demo mode via the "down" command
+| we will require this file so that any pre-rendered template can be shown
 | instead of starting the framework, which could cause an exception.
 |
 */


### PR DESCRIPTION
While reading through the documentation in `public/index.php`, the header and initial sentence for the "_checking if application is under maintenance_" section didn't quite read properly to me. So, I'm submitting this small patch to correct it. Just something small, but I hope that it helps. I'm not quite sure if the 8.x branch or master is the correct one to submit this to.