### PR TITLE
[9.x] Change default disk env key

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('FILESYSTEM_DRIVER', 'local'),
+    'default' => env('FILESYSTEM_DISK', 'local'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
There is a difference between `disk` and `driver` and the `default` key in `filesystems.php` is the default for disks, not drivers.
And developers may be confused when they see the filesystem config file.
I guess you should fix this in the new version.