### PR TITLE
[8.x] Remove unnecessary visibility declaration

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    const HOME = '/home';
 
     /**
      * The controller namespace for the application.


### PR DESCRIPTION
The default visibility of class constants is public.