### PR TITLE
[8.x] Add `app.mix_url` and `MIX_URL`

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,8 @@ return [
 
     'asset_url' => env('ASSET_URL', null),
 
+    'mix_url' => env('MIX_ASSET_URL', null),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,7 @@ return [
 
     'asset_url' => env('ASSET_URL', null),
 
-    'mix_url' => env('MIX_URL', null),
+    'mix_url' => env('MIX_ASSET_URL', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,7 @@ return [
 
     'asset_url' => env('ASSET_URL', null),
 
-    'mix_url' => env('MIX_ASSET_URL', null),
+    'mix_url' => env('MIX_URL', null),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
With Laravel Octane, you will serve Laravel routes using Octane and public content including assets require separate Nginx, Apache web-server, etc.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>