### PR TITLE
[8.x] Rename test methods

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -12,7 +12,7 @@ class ExampleTest extends TestCase
      *
      * @return void
      */
-    public function testBasicTest()
+    public function test_example()
     {
         $response = $this->get('/');
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -11,7 +11,7 @@ class ExampleTest extends TestCase
      *
      * @return void
      */
-    public function testBasicTest()
+    public function test_example()
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
We decided a while back to go for snake case as our convention for methods names in tests. All of our other first party libraries except for the framework are already on this convention. This PR moves the skeleton to the same convention. We'll convert the framework as well at some point.

Note that these new method names reflect the ones from the stub files in the framework when scaffolding a test using `make:test`. This also removes the duplicate "test" word.