### PR TITLE
Resolve static analysis issues

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -19,7 +19,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontFlash = [
         'current_password',

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -17,5 +17,7 @@ class Authenticate extends Middleware
         if (! $request->expectsJson()) {
             return route('login');
         }
+
+        return null;
     }
 }

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -17,7 +17,7 @@ class TrustProxies extends Middleware
     /**
      * The headers that should be used to detect proxies.
      *
-     * @var int
+     * @var int|string|null
      */
     protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
 }

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -17,7 +17,7 @@ class TrustProxies extends Middleware
     /**
      * The headers that should be used to detect proxies.
      *
-     * @var int|string|null
+     * @var int
      */
     protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',


### PR DESCRIPTION
Hi! I am using static code analysis tools like Larastan and Psalm. How about fixing some small issues?

Environment: Laravel Sail

```shell
./vendor/bin/sail php artisan --version // Laravel Framework 8.35.1
```

Run Psalm with Laravel Plugin (https://github.com/psalm/psalm-plugin-laravel) and `errorLevel="3"`:

```shell
./vendor/bin/sail php ./vendor/bin/psalm
```

Result:

```
ERROR: NonInvariantDocblockPropertyType - app/Exceptions/Handler.php:24:15 - Property App\Exceptions\Handler::$dontFlash has type array<array-key, mixed>, not invariant with Illuminate\Foundation\Exceptions\Handler::$dontFlash of type array<array-key, string> (see https://psalm.dev/267)
    protected $dontFlash = [


ERROR: NonInvariantDocblockPropertyType - app/Http/Middleware/TrustProxies.php:22:15 - Property App\Http\Middleware\TrustProxies::$headers has type int, not invariant with Fideloper\Proxy\TrustProxies::$headers of type int|null|string (see https://psalm.dev/267)
    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;


ERROR: NonInvariantDocblockPropertyType - app/Models/User.php:19:15 - Property App\Models\User::$fillable has type array<array-key, mixed>, not invariant with Illuminate\Database\Eloquent\Concerns\GuardsAttributes::$fillable of type array<array-key, string> (see https://psalm.dev/267)
    protected $fillable = [
```

Run Larastan with `level: 8`:

```shell
./vendor/bin/sail php ./vendor/bin/phpstan analyse
```

Result:

```
 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   Http/Middleware/Authenticate.php                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------ 
  17     Method App\Http\Middleware\Authenticate::redirectTo() should return string|null but return statement is missing.  
 ------ ------------------------------------------------------------------------------------------------------------------ 
```

And remove unused class import:

```diff
- use Illuminate\Contracts\Auth\MustVerifyEmail;
```

