### PR TITLE
Remove 'MustVerifyEmail' import from 'User' class

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
Minor, cosmetic change, but the imported `MustVerifyEmail` contract/interface is not being used in the `User` class, therefore in a new Laravel project it will most likely be removed by users either way if they will choose not to add the implementation.

![image](https://user-images.githubusercontent.com/35897850/114388841-e985de00-9b9c-11eb-9422-aab6993bd173.png)

Could it be that the framework's `User` class (`Authenticatable`) is missing the `MustVerifyEmail` contract/interface, since it already uses the `MustVerifyTrait`? (It should have been moved at some point but wasn't?)

![image](https://user-images.githubusercontent.com/35897850/114388902-faceea80-9b9c-11eb-8a95-5b96a5918a8f.png)

