### PR TITLE
[8.x] Using faker method instead of properties

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,8 +23,8 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->name,
-            'email' => $this->faker->unique()->safeEmail,
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),


### PR DESCRIPTION
After Faker PHP 1.14, using properties is deprecated, and it is recommended to use methods instead.

See [#164](https://github.com/FakerPHP/Faker/pull/164) for details.

It shouldn't be a breaking change.