### PR TITLE
Ignore SQLite files generated on parallel testing

### DIFF
--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,2 +1,1 @@
-*.sqlite
-*.sqlite-journal
+*.sqlite*


### PR DESCRIPTION
Hello,

When I run tests in parallel with `php artisan test --parallel`, I get lots of SQLite files, one per process.

I have updated the `.gitignore` file to automatically ignore any file that matches the `*.sqlite*`pattern.

![Captura de pantalla 2021-04-15 a las 20 16 58](https://user-images.githubusercontent.com/6053012/114918652-9a071280-9e27-11eb-884c-d8edee53af6b.png)
