### PR TITLE
Add the DisableFloc middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
+            // \App\Http\Middleware\DisableFloc::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,

--- a/app/Http/Middleware/DisableFloc.php
+++ b/app/Http/Middleware/DisableFloc.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class DisableFloc
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $response->header('Permissions-Policy', 'interest-cohort=()');
+
+        return $response;
+    }
+}


### PR DESCRIPTION
This adds a middleware that sets the `Permissions-Policy` header, to disable FloC.

This PR is more a start of a discussion on how we as the Laravel Community think about `Google's Federated Learning of Cohorts`.