### PR TITLE
Add security check command to scan for known vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "laravel/tinker": "^2.5"
     },
     "require-dev": {
+        "enlightn/laravel-security-checker": "^1.0",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
@@ -42,6 +43,9 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "post-update-cmd": [
+            "@php artisan security:check"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Description

This PR adds a `php artisan security:check` command to scan for known vulnerabilities in app dependencies. The added package is a thin wrapper around the [Enlightn security checker](https://github.com/enlightn/security-checker) package, which is relatively stable (~500k downloads).

## Motivation

Symfony has [its own](https://symfony.com/doc/current/setup.html#checking-security-vulnerabilities) `symfony check:security` command to scan app dependencies for known vulnerabilities. Drupal (Drush) [uses the Enlightn security checker](https://github.com/drush-ops/drush/blob/1750ad5ea07f6ca121919f2eff3cf900605faf35/composer.json#L42).

I think it would be a good idea for Laravel to have its own security check command to scan dependencies for known vulnerabilities.

## Screenshot

To demonstrate how this would work, here's a Composer update that installs a non-patched/vulnerable dependency. The `security:check` command displays a warning on update.

![sec-checker2](https://user-images.githubusercontent.com/16099046/115505537-3baeb980-a297-11eb-8f19-f6af71281481.png)

## Repository

I thought this would be best suited for `laravel/laravel`. But if you think I should send this to some other repo (say framework or the installer), I'd be happy to do so.