### PR TITLE
[8.x] Bump framework version to include SQL server security fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.12",
+        "laravel/framework": "^8.40",
         "laravel/tinker": "^2.5"
     },
     "require-dev": {


### PR DESCRIPTION
Security advisory: [GHSA-4mg9-vhxq-vm7j](https://github.com/laravel/framework/security/advisories/GHSA-4mg9-vhxq-vm7j)