### PR TITLE
Add Octane cache store

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -37,6 +37,10 @@ return [
             'driver' => 'apc',
         ],
 
+        'octane' => [
+            'driver' => 'octane',
+        ],
+
         'array' => [
             'driver' => 'array',
             'serialize' => false,


### PR DESCRIPTION
This PR adds Octane cache store to `cache.php` config in order to fix `Cache store [octane] is not defined.` error when using the Octane powered cache and ticks.