### PR TITLE
Add folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+/.idea
+/.vscode


### PR DESCRIPTION
Add folders to gitignore. The same exclusions exist in the laravel / framework gitignore.