### PR TITLE
add .phpintel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+/.phpintel


### PR DESCRIPTION
The same as `.idea` for PHPStorm.

Those files have nothing to do with your real code (which is what you want to source control), will repeatedly generate diffs and merge conflicts if you do track them in Git, and are useless to anyone else who's not using Sublime with that extension installed.