### PR TITLE
Added composer `dev` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "dev": [
+            "@php artisan serve"
         ]
     },
     "extra": {


### PR DESCRIPTION
This addition enables to start the development server by running `composer dev`.

**If this will be a useful addition**

![Screenshot 2021-06-02 at 10 06 23](https://user-images.githubusercontent.com/34090541/120452569-3199d380-c38a-11eb-8beb-b14de61b5274.png)
