### PR TITLE
Ignore .phpstorm.meta.php generated by Laravel IDE Helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+.phpstorm.meta.php


### PR DESCRIPTION
Adding the .phpstorm.meta.php, generated by Laravel IDE Helper, in .gitignore