### PR TITLE
[8.x] Update validation.php for URL

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -120,7 +120,7 @@ return [
     'timezone' => 'The :attribute must be a valid zone.',
     'unique' => 'The :attribute has already been taken.',
     'uploaded' => 'The :attribute failed to upload.',
-    'url' => 'The :attribute format is invalid.',
+    'url' => 'The :attribute must be a valid URL.',
     'uuid' => 'The :attribute must be a valid UUID.',
 
     /*


### PR DESCRIPTION
Reference to docs:
https://laravel.com/docs/8.x/validation#rule-url

#url
The field under validation must be a valid URL.

```diff
-    'url' => 'The :attribute format is invalid.',
+    'url' => 'The :attribute must be a valid URL.',
```