### PR TITLE
[8.x] Fixes `Authenticate::redirectTo` return type

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,7 +10,7 @@ class Authenticate extends Middleware
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string|null
+     * @return string|void
      */
     protected function redirectTo($request)
     {


### PR DESCRIPTION
This pull request instructs static analysis tools that `redirectTo` will return a string or void.