### PR TITLE
[8.x] Add sample routing for API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,10 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::get('/hello', function () {
+    return response(['data' => 'Hello from Laravel!']);
+});
+
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });


### PR DESCRIPTION
I'm writing an introduction to Laravel API with Serverless Framework and it would be nice if there was a sample routing that works out-of-the-box that doesn't require authentication so that I can focus the post on the Serverless aspect and not divert to
making code changes to Laravel