### PR TITLE
Fix misleading APP_KEY character length docs

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -114,7 +114,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This key is used by the Illuminate encrypter service and should be set
-    | to a random, 32 character string, otherwise these encrypted strings
+    | to a random, 42 character string, otherwise these encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
     */


### PR DESCRIPTION
The key is actually 42 characters long, not 32. Here's the proof:

1. Generate a new key:

```
php artisan key:generate --show
=> base64:DpYk0NpUp6NMFg2h/0hTWTodPPlSLQp0itYcKzG7tlg=
```

2. Take the value in between `base64:` and `=`

3. Count the characters:

```
echo -n "DpYk0NpUp6NMFg2h/0hTWTodPPlSLQp0itYcKzG7tlg" | wc -m
=> 43
```

As you can see this key has 43 characters, but I've managed to generate
keys what have 42 characters as well.

Here's how you would generate the key without artisan:

```
tr -dc "a-zA-Z0-9" < /dev/urandom | head -c 42
```

Generating one with 43 won't work here, not sure why.

Anyway, the current documentation is misleading as it will not work if
you add a 32 character random string.

For the purposes of this PR I hope you will keep the discussion centered around the incorrect docs and not why I need to generate the key without artisan as I can assure you I have a valid reason.