### PR TITLE
[8.x] add RateLimiter facade alias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -215,6 +215,7 @@ return [
         'Notification' => Illuminate\Support\Facades\Notification::class,
         'Password' => Illuminate\Support\Facades\Password::class,
         'Queue' => Illuminate\Support\Facades\Queue::class,
+        'RateLimiter' => Illuminate\Support\Facades\RateLimiter::class,
         'Redirect' => Illuminate\Support\Facades\Redirect::class,
         // 'Redis' => Illuminate\Support\Facades\Redis::class,
         'Request' => Illuminate\Support\Facades\Request::class,


### PR DESCRIPTION
#5556 added the `Date` facade alias and claimed that only `ParallelTesting` didn't have (and doesn't need) an alias. However, `RateLimiter` does not have an alias either. This MR fixes that.

By the way, the missing `RateLimiter` alias seems to have caused [an issue when using Psalm](https://github.com/psalm/psalm-plugin-laravel/issues/134), but of course the main reason to add that alias is consistency.

PS: Maybe it would even make sense to add a `ParallelTesting` alias, but to comment it out like the `Redis` alias. 🤔 