### PR TITLE
Remove unused class

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
I believe this class never used in the `User` model and should be removed.

It already used here in the `Authenticatable` class.

https://github.com/laravel/framework/blob/83b70546fc43fa3278d5d101141033fd37edb4c6/src/Illuminate/Foundation/Auth/User.php#L1-L20