### PR TITLE
Add generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /node_modules
 /public/hot
 /public/storage
+/public/css/app.css
+/public/js/app.js
+/public/mix-manifest.json
 /storage/*.key
 /vendor
 .env


### PR DESCRIPTION
This pull request is to add the following files to the default `.gitignore`:

* `public/css/app.css`
* `public/js/app.js`
* `public/mix-manifest.json`

The reason for this PR is to avoid pushing generated assets when running `npm run dev` and/or `npm run prod`