### PR TITLE
[8.x] Improve APP_KEY documentation

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -113,8 +113,8 @@ return [
     | Encryption Key
     |--------------------------------------------------------------------------
     |
-    | This key is used by the Illuminate encrypter service and should be set
-    | to a random, 32 character string, otherwise these encrypted strings
+    | This key is used by the Illuminate encrypter service and must be set to
+    | a random 32 bytes base64 encoded string, otherwise encrypted strings
     | will not be safe. Please do this before deploying an application!
     |
     */


### PR DESCRIPTION
I'm reopening the discussion of a [previous pull request](https://github.com/laravel/laravel/pull/5641) from @sdwolfz where the user suggested changing "32 characters" for "42 characters", after trying to generate the string without artisan and finding out the app would not start. The number is actually 32, but bytes, not characters. Per [strlen() documentation](https://www.php.net/manual/en/function.strlen.php):
```strlen() returns the number of bytes rather than the number of characters in a string.```

A few points:
- A byte may be interpreted as a character or may not. In this case, because this is used for cryptography, the word "character" does not apply.
- Bytes in text have to be encoded. In this case laravel uses base64.
- Given that if the decoded length is incorrect, the app would not work (according to the linked PR), I changed the word "should" for the word "must".

I have changed the documentation so that these points are clear.

Btw, the length of each comment line might look familiar ;)
```
$ echo -n "This key is used by the Illuminate encrypter service and must be set to" | wc -m
71
$ echo -n "a random 32 bytes base64 encoded string, otherwise encrypted strings" | wc -m
68
$ echo -n "will not be safe. Please do this before deploying an application!" | wc -m
65
```

