### PR TITLE
support sqlite cfg for memory unit tests & relative proj path

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -38,7 +38,8 @@ return [
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DATABASE_URL'),
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => env('DB_DATABASE') === ':memory:' ? ':memory:'
+                : database_path(env('DB_DATABASE', 'database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],


### PR DESCRIPTION
Config fix, to allow :memory: for unit tests, as well as relative paths for projects.
This allows projects to bundle pre-built sqlite databases.
Old code required users to edit .env.example with an absolute path for sqlite file.