### PR TITLE
[8.x]  Use new TrustProxies middleware

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use Fideloper\Proxy\TrustProxies as Middleware;
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 
 class TrustProxies extends Middleware

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,9 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
-        "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.40",
+        "laravel/framework": "^8.54",
         "laravel/tinker": "^2.5"
     },
     "require-dev": {


### PR DESCRIPTION
This uses the new TrustProxies middleware from https://github.com/laravel/framework/pull/38295. This way we can safely drop the dependency on fideloper/proxy.﻿

I wasn't 100% sure to directly use the middleware in the Kernel instead of overwriting it like now. The current property values are exactly the same as the parent class. But you could argue that this is an easier starting point for people wanting to overwrite them.