### PR TITLE
Stop running tests when config is cached

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,17 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        if (config('app.env') !== 'testing') {
+            throw new \Exception('APP ENV IS NOT TESTING! (check config:clear)');
+        }
+        
+        if (config('database.default') !== 'sqlite') {
+            throw new \Exception('APP TEST DATABASE IS WRONG! (check config:clear)');
+        }
+    }
 }


### PR DESCRIPTION
When config is cached, tests start using wrong database. 
This litle checks ensures that enviroment and database is correct for testing. 
Without this for stupid mistake/unknowlage production database can be truncated.