### PR TITLE
[9.x] Use php 8 null safe operator

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,6 @@
 php:
   preset: laravel
+  version: 8
   disabled:
     - no_unused_imports
   finder:

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -57,7 +57,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting()
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
     }
 }


### PR DESCRIPTION
The Pr leverages php 8 "null safe operator" instead of optional()