### PR TITLE
Add failover driver to default mail config file

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -70,6 +70,14 @@ return [
         'array' => [
             'transport' => 'array',
         ],
+        
+        'failover' => [
+            'transport' => 'failover',
+            'mailers' => [
+                'smtp',
+                'log',
+            ],
+        ],
     ],
 
     /*

--- a/config/mail.php
+++ b/config/mail.php
@@ -70,7 +70,7 @@ return [
         'array' => [
             'transport' => 'array',
         ],
-        
+
         'failover' => [
             'transport' => 'failover',
             'mailers' => [


### PR DESCRIPTION
laravel/framework#38344 introduced a failover driver for mail. `config/logging.php` includes the scaffold for a "stack" driver, so it makes sense that `config/mail.php` should also include the scaffold for a "failover" driver as they're in the same vein.