### PR TITLE
[8.x] Use PHPDoc comments from base class in User model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,7 +24,7 @@ class User extends Authenticatable
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
+     * The attributes that should be hidden for serialization.
      *
      * @var array
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = [
         'name',
@@ -34,7 +34,7 @@ class User extends Authenticatable
     ];
 
     /**
-     * The attributes that should be cast to native types.
+     * The attributes that should be cast.
      *
      * @var array
      */


### PR DESCRIPTION
Use PHPDoc comments from base class to stay consequent.