### PR TITLE
Fixing "Line exceeds 120 characters" in TrustProxies to comply with PSR-2

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -19,5 +19,10 @@ class TrustProxies extends Middleware
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+    protected $headers =
+        Request::HEADER_X_FORWARDED_FOR |
+        Request::HEADER_X_FORWARDED_HOST |
+        Request::HEADER_X_FORWARDED_PORT |
+        Request::HEADER_X_FORWARDED_PROTO |
+        Request::HEADER_X_FORWARDED_AWS_ELB;
 }


### PR DESCRIPTION
When installing a new project with `laravel new` and installing `squizlabs/php_codesniffer`, the projects has one error that cannot be fixed automatically by `phpcbf` because the `app/Http/Middleware/TrustProxies.php` class has a line of more than 120 characters.

Laravel is supposed to follow the PSR-2 conventions : https://laravel.com/docs/8.x/contributions#coding-style

To reproduce :

```bash
laravel new test-coding-standards
cd test-coding-standards
composer require squizlabs/php_codesniffer
vi phpcs.xml
```

Small phpcs.xml file :

```xml
<?xml version="1.0"?>
<ruleset name="PHP_CodeSniffer">
    <description>The coding standard for our project.</description>
    <rule ref="PSR2"/>

    <file>app</file>
    <file>bootstrap</file>
    <file>config</file>
    <file>database</file>
    <file>resources</file>
    <file>routes</file>
    <file>tests</file>

    <exclude-pattern>bootstrap/cache/*</exclude-pattern>
    <exclude-pattern>bootstrap/autoload.php</exclude-pattern>
    <exclude-pattern>*/migrations/*</exclude-pattern>
    <exclude-pattern>*/seeds/*</exclude-pattern>
    <exclude-pattern>*.blade.php</exclude-pattern>
    <exclude-pattern>*.js</exclude-pattern>
    <exclude-pattern>tests/Feature/ExampleTest.php</exclude-pattern>
    <exclude-pattern>tests/Unit/ExampleTest.php</exclude-pattern>

    <!-- Show progression -->
    <arg value="p"/>
</ruleset>
```

And run `vendor/bin/phpcs`, here is the output :

```
...........W................................... 47 / 47 (100%)

FILE: /Users/gabriel/Workspace/test-cs/app/Http/Middleware/TrustProxies.php
---------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------
 22 | WARNING | Line exceeds 120 characters; contains 201 characters
---------------------------------------------------------------------------

Time: 176ms; Memory: 8MB
```



