### PR TITLE
Add the `.php-cs-fixer.cache` file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.php-cs-fixer.cache
 .phpunit.result.cache
 docker-compose.override.yml
 Homestead.json


### PR DESCRIPTION
The `php-cs-fixer`CLI tool adds a `.php-cs-fixer.cache` cache file. This PR lets Git ignore that.