### PR TITLE
Added public css and js folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules
 /public/hot
 /public/storage
+/public/css
+/public/js
 /storage/*.key
 /vendor
 .env


### PR DESCRIPTION
If you create a new project with a start kit like jetstream, it is very common to run `npm run dev` before `git add .` for the initial commit. You end up with a commited auto generated .css and .js file you don't want to have. It would be very helpful if these folders are ignored by default and if needed you can change it really easy. And since there are no folders by default, there is no `gitkeep` (or a similar name with same purpose) needed.