### PR TITLE
Add global helper method for paginating collections

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+
+if (!function_exists('paginate_collection')) {
+    /**
+     * @param  $items
+     * @param int $perPage
+     * @param null $page
+     * @param array $options
+     * @return  LengthAwarePaginator
+     */
+    function paginate_collection($items, int $perPage = 15, $page = null, array $options = []): LengthAwarePaginator
+    {
+        $page = $page ?: (Paginator::resolveCurrentPage() ?: 1);
+        $items = $items instanceof Collection ? $items : Collection::make($items);
+        return new LengthAwarePaginator($items->forPage($page, $perPage), $items->count(), $perPage, $page, $options);
+    }
+}

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -4,18 +4,19 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 
-if (!function_exists('paginate_collection')) {
+if (! function_exists('paginate_collection')) {
     /**
      * @param  $items
-     * @param int $perPage
-     * @param null $page
-     * @param array $options
-     * @return  LengthAwarePaginator
+     * @param  int  $perPage
+     * @param  null  $page
+     * @param  array  $options
+     * @return LengthAwarePaginator
      */
     function paginate_collection($items, int $perPage = 15, $page = null, array $options = []): LengthAwarePaginator
     {
         $page = $page ?: (Paginator::resolveCurrentPage() ?: 1);
         $items = $items instanceof Collection ? $items : Collection::make($items);
+
         return new LengthAwarePaginator($items->forPage($page, $perPage), $items->count(), $perPage, $page, $options);
     }
 }

--- a/app/Providers/HelperServiceProvider.php
+++ b/app/Providers/HelperServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class HelperServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $file = app_path('Helpers/helpers.php');
+        if (file_exists($file)) {
+            require_once($file);
+        }
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/app/Providers/HelperServiceProvider.php
+++ b/app/Providers/HelperServiceProvider.php
@@ -15,7 +15,7 @@ class HelperServiceProvider extends ServiceProvider
     {
         $file = app_path('Helpers/helpers.php');
         if (file_exists($file)) {
-            require_once($file);
+            require_once $file;
         }
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -174,6 +174,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\HelperServiceProvider::class,
 
     ],
 


### PR DESCRIPTION
Out of the box pagination works on query builders but not collections. This helper method will be globally available and allow developers to now paginate collections as easily as query builders

Sample Usage + Steps to reproduce example:

Inline example used in `web.php`. I set up a basic `.env` file and a local database. I ran the out of the box migrations in order to have access to a users table. I entered multiple users in the database and queried for them as seen below.
```
Route::get('/users', function() {
   $users = User::all();

   $paginatedUsers = paginate_collection(
       $users->flatten()->sortDesc(),
       10,
       null
   );
   
   dd($paginatedUsers);
})
```

Result:

```
Illuminate\Pagination\LengthAwarePaginator {#251 ▼
  #total: 2
  #lastPage: 1
  #items: Illuminate\Support\Collection {#265 ▶}
  #perPage: 10
  #currentPage: 1
  #path: "users"
  #query: []
  #fragment: null
  #pageName: "page"
  +onEachSide: 3
  #options: array:1 [▶]
}
```
No need to import the helper as it is registered as a service provider and is globally available.
Now paginating collections is as easy as paginating query builders.