### PR TITLE
[9.x] Remove auth_mode from config/mail.php

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -42,7 +42,6 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'auth_mode' => null,
         ],
 
         'ses' => [


### PR DESCRIPTION
Symfony Mailer doesn't support auth_mode anymore because the server will negotiate the auth_mode for you.

PR: Where it was removed: https://github.com/laravel/framework/pull/38481

Why Symfony doesn't support it anymore full answer: https://github.com/symfony/symfony/pull/33237