### PR TITLE
[8.x] Keeping access tokens migration id consistent

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ class CreatePersonalAccessTokensTable extends Migration
     public function up()
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();


### PR DESCRIPTION
Hello, Laravel team!

This is the PR on the 8.x branch from my original one (#5690).

This is a tiny "fix," using `id();` to be consistent with the other migrations already included in the framework.