### PR TITLE
[8.x] Add failover in supported mail configurations comment section

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -29,7 +29,7 @@ return [
     | mailers below. You are free to add additional mailers as required.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses",
-    |            "postmark", "log", "array"
+    |            "postmark", "log", "array", "failover"
     |
     */
 


### PR DESCRIPTION
I can see a new mail driver failover has been added. I would like to add this driver in comment section as a supported driver.