### PR TITLE
Moving Database\\Factories\\ to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/",
-            "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
         }
     },
     "autoload-dev": {
         "psr-4": {
+            "Database\\Factories\\": "database/factories/",
             "Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
Hello,

i'm proposing to move factories autoloading to autoload-dev,
factories have a hard dependency to faker, which is in require-dev,
it does not make sense to autoload factories in production since they don't have any way of working in production environments

# Reproduce

```
- git clone https://github.com/laravel/laravel.git
- composer install --no-dev
- touch .env
- echo "APP_ENV=production" >> .env
- php artisan key:generate
- php artisan tinker --execute='User::factory()->create()'
```

result in :

```
[!] Aliasing 'User' to 'App\Models\User' for this Tinker session.
PHP Error:  Class 'Faker\Factory' not found in vendor/laravel/framework/src/Illuminate/Database/DatabaseServiceProvider.php on line 91
```
i don't think it will cause any harm require-dev/autoload-dev are needed for any factory related stuff, and there is no usecase for using them in production and it's not working and not supported.

I don't think it will cause any autoloading boost, but perhaps it could be on some projects.

thanks.
