### PR TITLE
[8.x] Uses `LazilyRefreshDatabase` by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3|^8.0",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^8.54",
+        "laravel/framework": "^8.62",
         "laravel/sanctum": "^2.11",
         "laravel/tinker": "^2.5"
     },

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,10 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication;
+    use CreatesApplication, LazilyRefreshDatabase;
 }


### PR DESCRIPTION
This pull request makes `LazilyRefreshDatabase` a default trait on the base test class for every new Laravel project. This way people don't need to worry about which test cases use the database or not - things will just work.

If this pull request gets merged, we may need to adapt the documentation before next week's release.