### PR TITLE
[8.x] Ensures downloaded version of Collision supports PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.2",
-        "nunomaduro/collision": "^5.0",
+        "nunomaduro/collision": "^5.10",
         "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {


### PR DESCRIPTION
This pull request ensures the download version of Collision in new Laravel projects support PHP 8.1.