### PR TITLE
[8.x] Use intended redirect if authenticated

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -23,7 +23,7 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
-                return redirect(RouteServiceProvider::HOME);
+                return redirect->intended(RouteServiceProvider::HOME);
             }
         }
 


### PR DESCRIPTION
There is a popular Stack Overflow thread on how to make [Laravel redirect back to original destination after login](https://stackoverflow.com/q/15389833). The best answer is by Scott Byers (kudos!), which changes exactly one line in the `RedirectIfAuthenticated` middleware that comes shipped with Laravel.

I wonder why Laravel doesn't redirect to the previously intended location by default, so I'm hereby proposing that change.