### PR TITLE
[8.x] Update docblocks of 'failed' config in queue.php

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -80,7 +80,9 @@ return [
     |
     | These options configure the behavior of failed queue job logging so you
     | can control which database and table are used to store the jobs that
-    | have failed. You may change them to any database / table you wish.
+    | have failed. Set the table and the driver to null to avoid saving.
+    |
+    | Drivers: "database-uuids", "dynamodb", "null"
     |
     */
 


### PR DESCRIPTION
These docs are according to the code in `QueueServiceProvider@registerFailedJobServices`.