### PR TITLE
[8.x] PHPDoc types should be covariant with the parent type

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,7 +10,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontReport = [
         //
@@ -19,7 +19,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontFlash = [
         'current_password',


### PR DESCRIPTION
The parent exception handler class has the type `string[]` for both `dontReport` and `dontFlash`. But the child handler class had only `array` Both types should be covariant. This PR fixes that.