### PR TITLE
Return explicit values in Authenticate::redirectTo

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,10 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
-            return route('login');
+        if ($request->expectsJson()) {
+            return null;
         }
+
+        return route('login');
     }
 }


### PR DESCRIPTION
`@return string|null`

@phpstan warned that returning void is not null.