### PR TITLE
[8.x] Remove redundant tap() helper in index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -48,8 +48,8 @@ $app = require_once __DIR__.'/../bootstrap/app.php';
 
 $kernel = $app->make(Kernel::class);
 
-$response = tap($kernel->handle(
+$response = $kernel->handle(
     $request = Request::capture()
-))->send();
+)->send();
 
 $kernel->terminate($request, $response);


### PR DESCRIPTION
`Kernel@handle` contract returns `\Symfony\Component\HttpFoundation\Response`, which in turn has a method `send()` that returns itself (`Response`). So there is no need for wrapping Response in HigherOrderTapProxy each time.