### PR TITLE
Move timezone management to .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+APP_TIMEZONE=UTC
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/config/app.php
+++ b/config/app.php
@@ -63,11 +63,11 @@ return [
     |
     | Here you may specify the default timezone for your application, which
     | will be used by the PHP date and date-time functions. We have gone
-    | ahead and set this to a sensible default for you out of the box.
+    | ahead and set this to a sensible default in the basic .env file.
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
More than a few times have I wrestled with timestamps being borked. I usually check the .env file for basic configuration options and I'm always surprised this setting isn't found in there.