### PR TITLE
Replace schema with search_path in pgsql config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -74,7 +74,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'schema' => 'public',
+            'search_path' => 'public',
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
Per https://github.com/laravel/framework/pull/35588 , the term "schema" (a namespace) has been corrected to "search_path" (a list of namespaces), where appropriate, throughout the framework.

Accordingly, the `schema` configuration key should be changed to `search_path` to better reflect the fact that it may specify a _list_ of schemata (schemas), and not just a single schema. (In several Laravel versions prior to 9.0, the `schema` key could already specify more than one schema, but this fact was undocumented and non-obvious without examining the implementation carefully.)

As of Laravel 9.0, the `search_path` may specify any number of schemata, in any of the following formats:

'search_path' => 'public',
'search_path' => 'public,laravel',
'search_path' => ['public', '"laravel"', "'foobar'", '$bat'],
'search_path' => '\'public\', "laravel", "\'foobar\'", \'$bat\'',
'search_path' => '"$user", public',

Note that in the last example, the `$user` variable refers to PostgreSQL's special $user variable, as described in the Schema Documentation ( https://www.postgresql.org/docs/current/ddl-schemas.html ).

Note also that Laravel's default `search_path` value, 'public', is not necessarily the best choice for every use case. Developers should consult the "Usage Patterns" section of the aforementioned documentation before deciding how best to set the `search_path`, as it has security implications.