### PR TITLE
[8.x] Removes the `Console\Kernel::$commands` property

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -8,15 +8,6 @@ use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 class Kernel extends ConsoleKernel
 {
     /**
-     * The Artisan commands provided by your application.
-     *
-     * @var array
-     */
-    protected $commands = [
-        //
-    ];
-
-    /**
      * Define the application's command schedule.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule


### PR DESCRIPTION
This pull request proposes the removal of the `Console\Kernel::$commands` property by default.

It's been a while since Laravel has introduced the possibility of loading commands from a specific folder, and since then, I don't remember the last time I've used this property.

Of course, just like multiple properties today on modals, for example, people can add back this property when they want.