### PR TITLE
[8.x] Fix "View path not found" when managing view cache

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -30,7 +30,7 @@ return [
 
     'compiled' => env(
         'VIEW_COMPILED_PATH',
-        realpath(storage_path('framework/views'))
+        storage_path('framework/views')
     ),
 
 ];


### PR DESCRIPTION
Commands around managing the view cache with Artisan (e.g., `php artisan view:clear`) are failing in a fresh deployment with the following message:

```
In ViewClearCommand.php line 57:
  View path not found.
```

`view.php` is the only config file where `realpath()` is still used. All other Artisan commands involving the cache are working without issue in this deployment. Removing the call to `realpath()` appears to resolve the issue.