### PR TITLE
[8.x] Fix asset publishing if they were already published

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi"
+            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""


### PR DESCRIPTION
Thank you @sebdesign for the fix. See https://github.com/laravel/laravel/pull/5654#issuecomment-977988782. The `vendor:publish` command will not update files if they already exist, without the `--force` parameter. Horizon and Telescope's publish commands add the force param, so we need to add it here also.