### PR TITLE
[8.x] Add option to set sendmail path. Fix default

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -59,7 +59,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -t'),
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -t -i'),
         ],
 
         'log' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -59,7 +59,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => '/usr/sbin/sendmail -bs',
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -t'),
         ],
 
         'log' => [


### PR DESCRIPTION
Testing this in an application, it would seem that sendmail -bs is the wrong option for this case?

What Laravel appears to do is pipe an RFC-2822 formatted message on STDIN and requires the sendmail emulation to deal with it,
rather than -bs which initiates an SMTP session.

if Exim is the default MTA then -t would seem to be the correct option.

If you have an alternative installed instead of sendmail/exim, then there's no way to set the path, so I added MAIL_SENDMAIL_PATH
so you can do, e.g.:

MAIL_SENDMAIL_PATH="/usr/bin/msmtp -t --tls=off --from=${MAIL_FROM_ADDRESS} --auto-from=off"

msmtp doesn't support -bs at all