### PR TITLE
Remove redundant default value for asset_url in app.php config file

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -54,7 +54,7 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'asset_url' => env('ASSET_URL', null),
+    'asset_url' => env('ASSET_URL'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The default value for env function is null, so null value in asset_url is just simply redundant