### PR TITLE
[9.x] Add client_options to Pusher driver

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -40,8 +40,7 @@ return [
                 'useTLS' => true,
             ],
             'client_options' => [
-                // Pass custom Guzzle options: https://docs.guzzlephp.org/en/stable/request-options.html
-                // 'verify' => true,
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
             ],
         ],
 

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -39,6 +39,10 @@ return [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
                 'useTLS' => true,
             ],
+            'client_options' => [
+                // Pass custom Guzzle options: https://docs.guzzlephp.org/en/stable/request-options.html
+                // 'verify' => true,
+            ],
         ],
 
         'ably' => [


### PR DESCRIPTION
Framework PR: https://github.com/laravel/framework/pull/39924

This PR just adds the information that `client_options` can be passed.