### PR TITLE
Add label for pagination

### DIFF
--- a/resources/lang/en/pagination.php
+++ b/resources/lang/en/pagination.php
@@ -15,5 +15,6 @@ return [
 
     'previous' => '&laquo; Previous',
     'next' => 'Next &raquo;',
+    'label' => 'Pagination',
 
 ];


### PR DESCRIPTION
The documentation states that we shouldn't use localization keys that equal localization filenames, i.e. `__("Paginator")` when `en/pagination.php` exists. See "Key / File conflicts" https://laravel.com/docs/8.x/localization#using-translation-strings-as-keys

Unaware of this, I send a PR (laravel/framework/pull/39928) and as per https://github.com/laravel/framework/pull/39928#issuecomment-994112464 broke someone's flow.  This PR will help resolve the  aforementioned issue in concert with https://github.com/laravel/framework/pull/40047 