### PR TITLE
Force LF EOL in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
+* text eol=lf
 *.css linguist-vendored
 *.scss linguist-vendored
 *.js linguist-vendored


### PR DESCRIPTION
Fix issue when GitHub Desktop on windows changes LF to CRLF