### PR TITLE
Add barryvdh/laravel-ide-helper generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+_ide_helper.php
+_ide_helper_models.php


### PR DESCRIPTION
`_ide_helper.php` & `_ide_helper_models.php` are files that are generated by barryvdh/laravel-ide-helper and are files that should only exists on dev environments.
Therefore, adding this 2 files will not represent a burden on users that are not using barryvdh/laravel-ide-helper and can only represent an improvement to the users of barryvdh/laravel-ide-helper (from a security standpoint).

I know that is not responsibility of the framework to take into consideration software that doesn't form part of the core framework, but that very same token could apply to `.idea` & `.vscode` entries on this file so it's clear that the framework is at least considering popular software that is not part of the framework but is used with it.
barryvdh/laravel-ide-helper currently has 12K github stars, compared with the 68K github stars that this framework currently has one could estimate that 1/6 users could get a benefit of this while the rest would not be affected on any way.