### PR TITLE
[9.x] Use <env> element

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,14 +18,14 @@
         </include>
     </coverage>
     <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="BCRYPT_ROUNDS" value="4"/>
-        <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
-        <server name="MAIL_MAILER" value="array"/>
-        <server name="QUEUE_CONNECTION" value="sync"/>
-        <server name="SESSION_DRIVER" value="array"/>
-        <server name="TELESCOPE_ENABLED" value="false"/>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
     </php>
 </phpunit>


### PR DESCRIPTION
This changes the default configuration to avoiding a developer experience where you spend hours trying to determine why your CI configuration is not working.

The `<server>` element has a higher than system environment variables (e.g. `export APP_ENV=ci`). As such, anything currently set in `phpunit.xml` can only be overridden by setting the configuration within your application (e.g. `app()->config('app.env', 'ci')`).

The `<env>` element is lower than system environment variables. For more detail, I wrote about [configuration precedence during testing](https://jasonmccreary.me/articles/laravel-testing-configuration-precedence/).

Considering this repo is static, this could likely be retargeted at `8.x`. However, I felt the upcoming `9.x` release provided a clean transition point.