### PR TITLE
[9.x] Analysis routes files test coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./routes</directory>
         </include>
     </coverage>
     <php>


### PR DESCRIPTION
This pull request makes the routes file to be analysed in terms of test coverage. This is necessary, as just like `./app`, the files within the routes folder contain application code.

<img width="100%" alt="coverage" src="https://user-images.githubusercontent.com/5457236/150373972-f6498eee-3dd5-4e9b-a348-e8163f8861a6.png">

