### PR TITLE
PSR-12 constructor parentheses

### DIFF
--- a/artisan
+++ b/artisan
@@ -33,8 +33,8 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 
 $status = $kernel->handle(
-    $input = new Symfony\Component\Console\Input\ArgvInput,
-    new Symfony\Component\Console\Output\ConsoleOutput
+    $input = new Symfony\Component\Console\Input\ArgvInput(),
+    new Symfony\Component\Console\Output\ConsoleOutput()
 );
 
 /*


### PR DESCRIPTION
As PSR-12 says:

> When instantiating a new class, parentheses MUST always be present even when there are no arguments passed to the constructor.
> 
> `new Foo();`

https://www.php-fig.org/psr/psr-12/