### PR TITLE
Make it easier to support Papertrail on Vapor out of the box

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -78,10 +78,11 @@ return [
         'papertrail' => [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => SyslogUdpHandler::class,
+            'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
             'handler_with' => [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://' . env('PAPERTRAIL_URL') . ':' . env('PAPERTRAIL_PORT'),
             ],
         ],
 


### PR DESCRIPTION
I'd like to make it easier to log to Papertrail from Vapor with the stock `logging.php` configuration. This PR discusses two approaches. The patch relates to the first and lighter approach.

With the way Vapor automatically sets up things like queues and caches, it's surprisingly difficult to get Papertrail working. After finally finding examples of getting Papertrail working with Vapor and finally getting it working myself, I wanted to see how easy I could make it to set up for other projects. Bonus points for getting Papertrail to work out of the box on Vapor with only *having* to set `PAPERTRAIL_URL` and `PAPERTRAIL_PORT`.

For Vapor specifically, there are some additional steps that need to be taken on the Papertrail side, so some additional docs specific to Vapor may still need to be written. In short, it comes down to:

 * Making sure TCP and TLS are enabled for the log destination
 * Optionally adding a log destination for each specific Vapor project to ensure logging can be separated by Vapor project since the IP address/hostnames may not be stable.

I'd be happy to write these docs (or at least suggest copy) if that helps. I'd actually be happy to help contribute docs to Vapor for setting up Papertrail even if nothing ultimately comes of this PR. :)

----

The first approach is to add a `LOG_PAPERTRAIL_HANDLER` environment variable that can be set to override the default `SyslogUdpHandler` used by the `papertrail` channel.

This patch allows someone to specify the following environment variable to send logs to Papertrail even from Laravel Vapor by just using the existing `PAPERTRAIL_URL` and `PAPERTRAIL_PORT` variables already used to configure `SyslogUdpHandler`.

This is accomplished by ensuring `LOG_PAPERTRAIL_HANDLER` is used if it is set and falling back to `SyslogUdpHandler` if it is not. Additionally, `handler_with` has a new entry that is a string built from the existing `PAPERTRAIL_URL` and `PAPERTRAIL_PORT` variables that represent the `connectionString` used by `SocketHandler`.

```sh
# .env
LOG_PAPERTRAIL_HANDLER=Monolog\Handler\SocketHandler
```

In theory, Vapor could automatically set `LOG_PAPERTRAIL_HANDLER=Monolog\Handler\SocketHandler` for projects so it is automatically configuring a supported handler out of the box.

To be clear, people can do this themselves. It's just not super obvious how to go about doing it.

-----

The second approach is to take this to a slightly higher level. Rather than juggling monolog handler definitions, we could create a Papertrail specific handler that decorates either `SyslogUdpHandler` or `SocketHandler` depending on an additional setting.

This would be a bit more work and even though I like this approach better (seems nicer, friendly, and cleaner) I didn't want to spend time on it before I knew it had a chance of getting accepted.

Off the top of my head, I'd expect the new default Papertrail logging configuration to look something like this:

```php
// config/logging.php
return [
    'channels' => [
        'papertrail' => [
            'driver' => 'monolog',
            'level' => 'debug',
            'handler' => env('LOG_PAPERTRAIL_HANDLER', PapertrailHandler::class),
            'handler_with' => [
                'host' => env('PAPERTRAIL_URL'),
                'port' => env('PAPERTRAIL_PORT'),
                'protocol' => ENV('LOG_PAPERTRAIL_PROTOCOL', 'syslog'),
            ],
        ],
    ],
];
```

```sh
# .env

# Valid options: syslog, tcp
LOG_PAPERTRAIL_PROTOCOL=tcp
```

In *this* case, Vapor could automatically set `LOG_PAPERTRAIL_PROTOCOL=tcp` and things would just work on new Vapor projects out of the box.

Also, I'm not sure we'd need to allow people to override `LOG_PAPERTRAIL_HANDLER` in this case.  Totally happy to not include that in a patch if we want to try going in this direction.