### PR TITLE
[9.x] Bumps `nunomaduro/collision` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^6.0",
+        "nunomaduro/collision": "^6.1",
         "phpunit/phpunit": "^9.5.10",
         "spatie/laravel-ignition": "^1.0"
     },


### PR DESCRIPTION
This pull request bumps `nunomaduro/collision` dependency to ensure people get the `--coverage` option even when running a `composer update  --prefer-lowest`.