### PR TITLE
Fixing the length of the description block

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 |
 | Here is where you can register web routes for your application. These
 | routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
+| contains the "web" middleware group. Now create something great
 |
 */
 


### PR DESCRIPTION
I know that every next comment description block should be exactly 3 symbols shorter, than on the previous line. I found the bug and fixed it!