### PR TITLE
Fixing the length of the description block

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -80,7 +80,7 @@ return [
     | than one user table or model in the application and you want to have
     | separate password reset settings based on the specific user types.
     |
-    | The expire time is the number of minutes that the reset token should be
+    | The expire time - the number of minutes that the reset token should be
     | considered valid. This security feature keeps tokens short-lived so
     | they have less time to be guessed. You may change this as needed.
     |


### PR DESCRIPTION
There is a bug in one of your description blocks. The second comment line is 4!! (should be 3) symbols shorter than the first one. But don't worry - I fixed this issue. That will definitely improve the project!