### PR TITLE
[9.x] Change session serialization defaults

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -50,6 +50,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Session Serialization
+    |--------------------------------------------------------------------------
+    |
+    | The session serialization strategy determines how the array of session
+    | data will get serialized into a string for storage. Typically, JSON
+    | serialization will be fine unless PHP objects are in the session.
+    |
+    | Supported: "json", "php"
+    |
+    */
+
+    'serialization' => 'json',
+
+    /*
+    |--------------------------------------------------------------------------
     | Session File Location
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
In previous releases of Laravel, the PHP `serialize` and `unserialize` functions were used to serialize the session data for storage. In general, this is fine since all Laravel session cookies are encrypted and signed using message authentication; therefore, they can't be tampered with by the client and raw user, controlled input can not make it into the `unserialize` function.

However, if the application encryption key (`APP_KEY`) is compromised, user controlled input could be passed to the `unserialize` function by crafting an encrypted cookie using the stolen encryption key. This could lead to remote code execution.

This changes the default behavior of new Laravel 9 applications to use JSON encoding to serialize session data. Applications upgrading from Laravel 8 may continue using PHP serialization without issue - though I will note this in the upgrade guide because I know many people start with a blank Laravel 9 skeleton and move their existing Laravel 8 code into it in order to "upgrade" their application (note that I don't recommend doing this). And, changing this value on an existing application will invalidate existing sessions and logout currently authentication users.

In summary - this does not address any known security vulnerability. A security vulnerability only surfaces if the application encryption key `APP_KEY` is stolen. And, if that happens, your application is **still compromised** regardless of this change because the attacker can craft valid session cookies to login as other users. This only addresses the possible remote code execution vulnerability if the `APP_KEY` leaks.