### PR TITLE
Update the default Argon2 options

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -44,9 +44,9 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
-        'threads' => 2,
-        'time' => 2,
+        'memory' => 65536,
+        'threads' => 1,
+        'time' => 4,
     ],
 
 ];


### PR DESCRIPTION
I noticed 2 problems with the default Argon2 options.

### Argon2 options may be dated
When first introduced, the indicated values for memory cost, time cost and threads for Argon2 hashing was the same as defined in their PHP constant counterparts. However, they have since been updated in [PHP bug #78269](https://bugs.php.net/bug.php?id=78269), where the old defaults are called "weak".

New values are as follows:
```
'argon' => [
    'memory' => 65536,
    'threads' => 1,
    'time' => 4,
],
```
### Argon2 threads option is lowered further on RHEL
A second issue arises when using the old values on PHP supplied from Remi's RPM repository, e.g. on RHEL. For creating new hashes, [PHP here relies on libsodium (on PHP version 7.4 onwards)](https://forum.remirepo.net/viewtopic.php?id=3961), which [does not support a thread value > 1](https://wiki.php.net/rfc/sodium.argon.hash#additional_changes).

As a result, the threads options is lowered from 2 to 1 when generating a new password hash in Laravel 6.
```
>>> config('hashing.argon.memory')
=> 1024
>>> config('hashing.argon.time')
=> 2
>>> config('hashing.argon.threads')
=> 2
>>> Illuminate\Support\Facades\Hash::make('password')
=> "$argon2id$v=19$m=1024,t=2,p=1$RYHaLaomzQJndI6JwX3QsQ$09pfe8PsWhTY7AgoDBivE/Fr+Jhb5wdjN73U4I9n1ls"
```
This may not affect a lot of people, but updating the Argon2 options to the values now used by PHP can easily fix this. It would also bring Laravel's Argon2 options back in line with PHP's.
Site admins may then want to check if they have stored any password hashes affected by this and have to decide whether or not to reset the users' passwords.