### PR TITLE
[9.x] Revert default serialization

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -57,11 +57,11 @@ return [
     | data will get serialized into a string for storage. Typically, JSON
     | serialization will be fine unless PHP objects are in the session.
     |
-    | Supported: "json", "php"
+    | Supported: "php", "json"
     |
     */
 
-    'serialization' => 'json',
+    'serialization' => 'php',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
It seems this causes validation errors not to be persisted for views. It might be best we revert this for now until we find a better way as this usage is very common and standard in Laravel apps.

Fixes https://github.com/laravel/framework/issues/40773