### PR TITLE
[9.x] Remove `server.php` from StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,7 +6,6 @@ php:
   finder:
     not-name:
       - index.php
-      - server.php
 js:
   finder:
     not-name:


### PR DESCRIPTION
As `server.php` was removed in #5747, this is no longer needed in the StyleCI configuration file.