### PR TITLE
[9.x] Reverts analysing routes folder coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,6 @@
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./app</directory>
-            <directory suffix=".php">./routes</directory>
         </include>
     </coverage>
     <php>


### PR DESCRIPTION
This pull request reverts analysing routes folder coverage as it seems to cause issues with different coverage reporters than the one we added for L9.