### PR TITLE
Fix .gitattributes consistency with .editorconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
+* text eol=lf
 
 *.blade.php diff=html
 *.css diff=css


### PR DESCRIPTION
`lf` EOL is defined in `.editorconfig` but missed in `.gitattributes`, so here is the fix.
This little fix helps keep the EOL consistent across the project and ensures it doesn't get messed up by GitHub Desktop or any other GIT client.