### PR TITLE
[9.x] void return type for example tests

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -9,10 +9,8 @@ class ExampleTest extends TestCase
 {
     /**
      * A basic test example.
-     *
-     * @return void
      */
-    public function test_the_application_returns_a_successful_response()
+    public function test_the_application_returns_a_successful_response(): void
     {
         $response = $this->get('/');
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -8,10 +8,8 @@ class ExampleTest extends TestCase
 {
     /**
      * A basic test example.
-     *
-     * @return void
      */
-    public function test_that_true_is_true()
+    public function test_that_true_is_true(): void
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Since Laravel 9.x requires PHP 8.0 and above, void return types may be used for example tests.

