### PR TITLE
[9.x] Improve typing on user factory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -13,7 +13,7 @@ class UserFactory extends Factory
     /**
      * Define the model's default state.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function definition()
     {
@@ -29,7 +29,7 @@ class UserFactory extends Factory
     /**
      * Indicate that the model's email address should be unverified.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return static
      */
     public function unverified()
     {


### PR DESCRIPTION
This fixes some PHPStan issues in the user factory (I tested at level 8)

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   database/factories/UserFactory.php                                                                                                                                    
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  18     Method Database\Factories\UserFactory::definition() return type has no value type specified in iterable type array.                                                   
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                              
  34     Method Database\Factories\UserFactory::unverified() return type with generic class Illuminate\Database\Eloquent\Factories\Factory does not specify its types: TModel  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.dist.                                                          
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
```