### PR TITLE
[8.x] Revert "Fix .gitattributes consistency with .editorconfig"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto
-* text eol=lf
 
 *.blade.php diff=html
 *.css diff=css


### PR DESCRIPTION
Reverts laravel/laravel#5802

I don't feel this is needed since this would apply only in userland, not when developing this skeleton repo. The editorconfig file already has the proper eol defined for the project.