### PR TITLE
[9.x] Remove redundant `null`s

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -57,6 +57,7 @@ return [
     'url' => env('APP_URL', 'http://localhost'),
 
     'asset_url' => env('ASSET_URL'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/config/app.php
+++ b/config/app.php
@@ -56,8 +56,7 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'asset_url' => env('ASSET_URL', null),
-
+    'asset_url' => env('ASSET_URL'),
     /*
     |--------------------------------------------------------------------------
     | Application Timezone


### PR DESCRIPTION
Following up with #5791.

After a quick search using the following Regex `env\(['"]{1}(.+)['"]{1},\s*null\)`, this is the last one in `laravel/laravel`.