### PR TITLE
[9.x] Add Redis facade as comment in app.php config file

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -191,7 +191,7 @@ return [
     */
 
     'aliases' => Facade::defaultAliases()->merge([
-        // ...
+        // 'Redis' => Illuminate\Support\Facades\Redis::class,
     ])->toArray(),
 
 ];


### PR DESCRIPTION
This adds the comment for the `Redis` facade which was present in < 9.x and was there for easy activation.

https://github.com/laravel/laravel/blob/6c1f430aa76809084668f9a97121bd2ca8bafa10/config/app.php#L221