### PR TITLE
[9.x] Remove default commented namespace

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,15 +20,6 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
-     * The controller namespace for the application.
-     *
-     * When present, controller route declarations will automatically be prefixed with this namespace.
-     *
-     * @var string|null
-     */
-    // protected $namespace = 'App\\Http\\Controllers';
-
-    /**
      * Define your route model bindings, pattern filters, etc.
      *
      * @return void


### PR DESCRIPTION
I want to propose to remove the default namespace property in the `RouteServiceProvider` to push people to use class referenced controllers more. The current setting causes confusion and leads to situations like https://github.com/laravel/framework/pull/41021. 