### PR TITLE
Add underscore to prefix in database cache key

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -105,6 +105,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
 
 ];


### PR DESCRIPTION
For Redis caching prefix with underscore : 
'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),

but when cache stored in database, then the key is created "merged" with prefix, by this line:  'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'), for example, if "key" is a key for cache, then the result is: "laravel_cachekey", not a preferable "laravel_cache_key"