### PR TITLE
[9.x] Remove namespace from Routes

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -31,11 +31,9 @@ class RouteServiceProvider extends ServiceProvider
         $this->routes(function () {
             Route::prefix('api')
                 ->middleware('api')
-                ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));
 
             Route::middleware('web')
-                ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
         });
     }


### PR DESCRIPTION
Since we removed the namespace property in https://github.com/laravel/laravel/pull/5816 we can also remove the namespace method from the routes which uses this property