### PR TITLE
If XHR request then don't redirect already logged in users

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,11 +19,13 @@ class RedirectIfAuthenticated
      */
     public function handle(Request $request, Closure $next, ...$guards)
     {
-        $guards = empty($guards) ? [null] : $guards;
+        if(!$request->expectsJson()){
+            $guards = empty($guards) ? [null] : $guards;
 
-        foreach ($guards as $guard) {
-            if (Auth::guard($guard)->check()) {
-                return redirect(RouteServiceProvider::HOME);
+            foreach ($guards as $guard) {
+                if (Auth::guard($guard)->check()) {
+                    return redirect(RouteServiceProvider::HOME);
+                }
             }
         }
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,7 +19,7 @@ class RedirectIfAuthenticated
      */
     public function handle(Request $request, Closure $next, ...$guards)
     {
-        if(!$request->expectsJson()){
+        if (! $request->expectsJson()) {
             $guards = empty($guards) ? [null] : $guards;
 
             foreach ($guards as $guard) {


### PR DESCRIPTION
When accessing auth routes via an api it doesn't seem like you'd ever want a route being returned so this just wraps that already existing redirect code in a json check.

https://stackoverflow.com/questions/33029676/disable-redirect-in-authattempt-laravel-5-1
https://stackoverflow.com/questions/33341150/redirect-if-authenticated-logic-in-laravels-built-in-auth