### PR TITLE
add DS_Store to git ignore for Mac developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+.DS_Store


### PR DESCRIPTION
most web devs use macs, the .DS_Store file would be nice if it was ignored by default

thanks for your consideration