### PR TITLE
[9.x] Add option to configure Mailgun transporter scheme

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -18,6 +18,7 @@ return [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
         'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
+        'scheme' => 'https',
     ],
 
     'postmark' => [


### PR DESCRIPTION
Adds a config option to allow overriding the Mailgun transporter scheme. See also https://github.com/laravel/framework/pull/41309.