### PR TITLE
[9.x] add `throw` to filesystems config

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -33,6 +33,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'throw' => false,
         ],
 
         'public' => [
@@ -40,6 +41,7 @@ return [
             'root' => storage_path('app/public'),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
+            'throw' => false,
         ],
 
         's3' => [
@@ -51,6 +53,7 @@ return [
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
         ],
 
     ],


### PR DESCRIPTION
Ref PR https://github.com/laravel/framework/pull/41308

I kept it `false` so it does not change the current behaviour.

One can make it `true` to get errors related to file operations such as uploading to S3 via `Storage::put()`

Thanks.