### PR TITLE
[9.x] Update sendmail default params

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -58,7 +58,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -t -i'),
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),
         ],
 
         'log' => [


### PR DESCRIPTION
This is needed to solve an issue with BCC recipients in the new Symfony mailer. This has come up on Symfony's issue tracker: https://github.com/symfony/symfony/issues/40070 and was discussed in a PR: https://github.com/symfony/symfony/pull/39744. Basically it comes down to `-bs` being preferred over `-t`. I don't know exactly the deep explanation for this but it seems to help the OP from the below issue. `-bs` is also the default in the Sendmail Mailer from Symfony. 

See https://github.com/laravel/framework/issues/41357.