### PR TITLE
[9.x] Update console.php

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -14,6 +14,5 @@ use Illuminate\Support\Facades\Artisan;
 |
 */
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+Artisan::command('inspire', fn () => $this->comment(Inspiring::quote()))
+    ->purpose('Display an inspiring quote');


### PR DESCRIPTION
Uses php 7.4 arrow function in console.php.
Technically not needed but this helps readers to learn about the arrow function.