### PR TITLE
The docker-compose.override.yml should not be ignored by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .env
 .env.backup
 .phpunit.result.cache
-docker-compose.override.yml
 Homestead.json
 Homestead.yaml
 npm-debug.log


### PR DESCRIPTION
While this file can be used for local overrides, that is not its
only intended usage. E.g. a common setup would be like this:

- *docker-compose.yml*: services shared across builds
- *docker-compose.override.yml*: services only used in development
- *docker-compose.production.yml*: configuration needed for building production images.

Now for regular development you just need to run `docker-compose up --build` and only
in you CI you would build and run for production by explicitly naming the yml files.

**TL;DR**: Excluding docker-compose.override.yml seems to be a personal preference of
someone and they should do that in their global .gitignore if the are so inclined.