### PR TITLE
[9.x] Add an example to the class aliases

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -191,7 +191,7 @@ return [
     */
 
     'aliases' => Facade::defaultAliases()->merge([
-        // 'YourClass' => App\SomePath\YourClass::class,
+        // 'ExampleClass' => App\Example\ExampleClass::class,
     ])->toArray(),
 
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -191,7 +191,7 @@ return [
     */
 
     'aliases' => Facade::defaultAliases()->merge([
-        // ...
+        // 'YourClass' => App\SomePath\YourClass::class,
     ])->toArray(),
 
 ];


### PR DESCRIPTION
Now that we no longer have all the defaults (#5769), it would be helpful if we had one example of how to write one.