### PR TITLE
[9.x] Set primary JS dependencies as non-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "prod": "npm run production",
         "production": "mix --production"
     },
-    "devDependencies": {
+    "dependencies": {
         "axios": "^0.25",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",


### PR DESCRIPTION
The dependencies listed in package.json are crucial for the frontend's basic operation. They should be set as regular      `dependencies`, not as `devDependencies`. It is no more appropriate to put `axios` in the `devDependencies` than it is to put `guzzlehttp/guzzle` in `require-dev`.

package.json [`devDependencies`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#devdependencies) works very identically to composer.json's [`require-dev`](https://getcomposer.org/doc/04-schema.md#require-dev), in that those sections are for dependencies that are not needed for production, typically test-related packages.

Just like how `composer install --no-dev` is for [installing only packages in the `require` section](https://getcomposer.org/doc/03-cli.md#install-i), `npm install --production`   is for [installing only the `dependencies`](https://docs.npmjs.com/cli/v8/commands/npm-install#description).