### PR TITLE
[9.x] Update database.php

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => 'utf8mb4_0900_ai_ci',
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
@@ -61,6 +61,7 @@ return [
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
+            'timezone' => '+00:00',
         ],
 
         'pgsql' => [


### PR DESCRIPTION
Without a 'timezone' specification of '+00:00', MySQL will perform a secondary time conversion to UTC based on the MySQL (or the system) time zone.
This may cause problems when shifting from winter to summer time.
In my case, this caused a non-existent timestamp in my time zone:
"Invalid datetime format: 1292 Incorrect datetime value: '2022-03-27 02:27:03' for column 'updated_at' at row 1 (SQL: insert into "...
For details, see https://www.tutorialguruji.com/dbms/laravel-sqlstate22007-invalid-datetime-format-1292-incorrect-datetime-value-2019-03-10-020039-for-column-updated_at-daylight-savings/ (March 27, 2022)

Furthermore, the collation "utf8mb4_0900_ai_ci" should be used (default collation in MySQL 8.0.1 and later): accent insensitivity, case insensitivity.
See https://www.monolune.com/articles/what-is-the-utf8mb4_0900_ai_ci-collation/ (March 27, 2022)