### PR TITLE
[9.x] Remove "password" from validation lang

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -100,7 +100,6 @@ return [
     'not_in' => 'The selected :attribute is invalid.',
     'not_regex' => 'The :attribute format is invalid.',
     'numeric' => 'The :attribute must be a number.',
-    'password' => 'The password is incorrect.',
     'present' => 'The :attribute field must be present.',
     'prohibited' => 'The :attribute field is prohibited.',
     'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',


### PR DESCRIPTION
The `password` rule was replaced by `current_password` so it seems like the former can be removed now, which would be in line with what was said [here](https://github.com/laravel/laravel/pull/5628#issuecomment-859629877)