### PR TITLE
[9.x] Log deprecation warnings by default

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -30,7 +30,7 @@ return [
     |
     */
 
-    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'stack'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Currently the default is "null", my understanding about this meaning that all deprecation warnings simply get discarded with no one getting to know about them. This would cause problems in the future when it becomes time to upgrade PHP/Laravel/package versions with the user not getting enough warning time about features they should move away from using.

I believe it would be good if deprecation warnings would be logged somewhere by default, like in previous Laravel versions.

Or please let me know if I misunderstood the meaning of this config option and that deprecation warnings do get reported by default somewhere.