### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "scripts": {
-        "post-install-cmd": [
+        "pre-install-cmd": [
             "@php -r \"@unlink('bootstrap/cache/packages.php');\""
         ],
         "post-update-cmd": [


### PR DESCRIPTION
Following commit 9986d51, running `composer install` nukes ./bootstrap/cache/packages.php.

Composer seemingly runs package discovery before the `post-install-cmd` script command.
<img width="502" alt="image" src="https://user-images.githubusercontent.com/1807304/162143885-d96b30d4-aee4-4e5a-bb59-4e044302e0c3.png">

This PR proposes to unlink `bootstrap/cache/packages.php` in `pre-install-cmd` instead.

Running `composer update` is not affected.

Thanks for the great work!
