### PR TITLE
Include CHANGELOG.md in releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,3 @@
 *.php diff=php
 
 /.github export-ignore
-CHANGELOG.md export-ignore


### PR DESCRIPTION
I would like to propose to include the CHANGELOG.md in releases. On Stackoverflow I found [this question](https://stackoverflow.com/questions/71900068/how-to-find-out-the-laravel-app-laravel-laravel-version-and-where-is-it-defi ):

> What I am interested in, is how to figure out which version (GitHub's tag) was used when the Laravel "app" was created? So not the [laravel/framework](https://github.com/laravel/framework) version, as this was already explained in the other answer, but the Laravel "starter app" [laravel/laravel](https://github.com/laravel/laravel) version?

>  (I am interested in this so I could compare the differences on GitHub, but I don't know which tag/branch was used when the original app was created over a year ago.)

I found myself in a similar situation while ago. AFAIK there is no way to find out the version of the Laravel skeleton (`laravel/laravel`not `laravel/framework`) which an app was bootstrapped from. 

As I can see in https://github.com/laravel/laravel/pull/4186 it was an active decision in 2017 to leave CHANGELOG.md out of the releases. But I would argue that it would be helpful to include CHANGELOG.md as README.md is included. 

Maybe the decision of that time can be reconsidered?

By including CHANGELOG.md developers will be able to compare their skeleton version with the current version, and easily find the relevant changes since the app got created. 

Developers who don't want to keep the file can delete it as they can delete the readme.