### PR TITLE
Bump laravel/framework version to latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^9.2",
+        "laravel/framework": "^9.10",
         "laravel/sanctum": "^2.14.1",
         "laravel/tinker": "^2.7"
     },


### PR DESCRIPTION
Required for password rule translations to work properly (see https://github.com/laravel/framework/pull/42060)

In the current skeleton, if someone was to update the `password` entries in `validations.php` and resolved an older `laravel/framework` version, the changes would not affect the actual displayed message, which could be quite confusing.