### PR TITLE
[9.x] Fix alphabetical order for password rules

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -101,10 +101,10 @@ return [
     'not_regex' => 'The :attribute format is invalid.',
     'numeric' => 'The :attribute must be a number.',
     'password' => [
-        'mixed' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
         'letters' => 'The :attribute must contain at least one letter.',
-        'symbols' => 'The :attribute must contain at least one symbol.',
+        'mixed' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
         'numbers' => 'The :attribute must contain at least one number.',
+        'symbols' => 'The :attribute must contain at least one symbol.',
         'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
     ],
     'present' => 'The :attribute field must be present.',


### PR DESCRIPTION
Sorting the newly added `password` rules in alphabetical order.