### PR TITLE
[9.x] Run tests for skeleton

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction
 
+      - name: Copy environment file
+        run: cp .env.example .env
+
       - name: Generate app key
         run: php artisan key:generate
 


### PR DESCRIPTION
This PR will make sure that the test suite for the skeleton is always run so nothing accidentally breaks. The GitHub workflow is excluded from new installs because of the `.gitattributes` entry.
