### PR TITLE
Add local_domain option to smtp configuration

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -42,6 +42,7 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
+            'local_domain' => env('MAIL_EHLO_DOMAIN'),
         ],
 
         'ses' => [


### PR DESCRIPTION
Add `local_domain` as an option to the smtp configuration. This can be used to change the domain that is used to send the `EHLO` command during the SMTP handshake.

`null` is a sensible default since Symfony/Mailer will use it's own default (`127.0.0.1`) to send the mail.

I stumbled upon this option while trying to figure out why the [Google Relay Service](https://support.google.com/a/answer/2956491) stopped working. 

From their docs:
> We recommend that you configure your mail server to present a unique identifier (such as your domain name or the name of your mail server) in the HELO or EHLO command in the SMTP relay connections your server makes to Google. Avoid using generic names such as "localhost" or "smtp-relay.gmail.com," which can occasionally result in issues with DoS limits.

By default, Symfony/Mailer uses `127.0.0.1` for the `EHLO` command (which is pretty generic and likely to be blocked). This can be changed by using the `local_domain` option added in this PR.

Note: I created this PR based on the suggestion from @driesvints in https://github.com/laravel/framework/issues/37798.