### PR TITLE
change id type of personal_access_tokens table

### DIFF
--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->id();
+            $table->bigIncrements();
             $table->morphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();


### PR DESCRIPTION
on sanctum, the id of the personal_access_tokens table is bigIncrements type,
but on the personal_access_tokens table that creates as default, the id has id type.
this merge request change id to the bigIncrements on the personal_access_tokens table.