### PR TITLE
Add x-forwarded-prefix to TrustProxies

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -24,5 +24,6 @@ class TrustProxies extends Middleware
         Request::HEADER_X_FORWARDED_HOST |
         Request::HEADER_X_FORWARDED_PORT |
         Request::HEADER_X_FORWARDED_PROTO |
+        Request::HEADER_X_FORWARDED_PREFIX |
         Request::HEADER_X_FORWARDED_AWS_ELB;
 }


### PR DESCRIPTION
This was added in the framework here https://github.com/laravel/framework/pull/40014.

---

Question: should the `Request::HEADER_X_FORWARDED_TRAEFIK` be added to?
Link: https://github.com/symfony/http-foundation/blob/ff2818d1c3d49860bcae1f2cbb5eb00fcd3bf9e2/Request.php#L54
