### PR TITLE
Add visibility parameter on S3 config

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -54,6 +54,7 @@ return [
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,
+            'visibility' => env('AWS_VISIBILITY', 'private'),
         ],
 
     ],


### PR DESCRIPTION
This prevents a write error if you write to a private bucket.