### PR TITLE
[9.x] add cache option to `view.php`

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -19,6 +19,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | View Cache
+    |--------------------------------------------------------------------------
+    |
+    | This option determines whether the compiled Blade templates will be
+    | cached for your application. Disabling cached views can be helpful
+    | during development, however make sure to enable it in production.
+    |
+    */
+
+    'cache' => env('VIEW_CACHE', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Compiled View Path
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
In this [PR](https://github.com/laravel/framework/pull/41859) `cache` option was added, would be nice to have it in view.php for more visibility and usability. 