### PR TITLE
Use shared application instance instead of helper in welcome view

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', $app->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Hello 👋🏼

The reasoning behind this tiny change is to expose a feature unknown to the vast majority of Laravel developers.

Since the welcome view is the first thing opened up by many developers, it would be a nice way of telling "hey, you can also access the app instance like this!". Using helpers is already a very well-known thing, but knowing the alternatives could also be beneficial IMHO.

Thank you for taking your time reviewing this.