### PR TITLE
[9.x] Switch to ESM imports

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,1 @@
-require('./bootstrap');
+import './bootstrap';

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,5 @@
-window._ = require('lodash');
+import _ from 'lodash';
+window._ = _;
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
@@ -6,7 +7,8 @@ window._ = require('lodash');
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
-window.axios = require('axios');
+import axios from 'axios';
+window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -18,7 +20,8 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 // import Echo from 'laravel-echo';
 
-// window.Pusher = require('pusher-js');
+// import Pusher from 'pusher-js';
+// window.Pusher = Pusher;
 
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',


### PR DESCRIPTION
The Laravel skeleton currently uses Node/CommonJS `require()` statements to load several dependencies. These statements are not supported when using Vite because it exclusively leverages ES Modules (which use the `import` syntax) to achieve lightning-fast speeds.

This PR replaces the `require` statements with equivalent `import` statements to make the transition to Vite smoother. Webpack supports both, so this should have no noticeable impact for Mix users other than improving type information in their IDEs :nerd_face: 