### PR TITLE
[9.x] Added routes for user authentication and channel authorization

### DIFF
--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -17,6 +17,12 @@ class BroadcastServiceProvider extends ServiceProvider
         Broadcast::channelAuthorizationRoutes();
         Broadcast::userAuthenticationRoutes();
 
+        Broadcast::resolveAuthenticatedUserUsing(function ($request) {
+            return [
+                'id' => $request->user()->id,
+            ];
+        });
+
         require base_path('routes/channels.php');
     }
 }

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -14,7 +14,8 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Broadcast::routes();
+        Broadcast::channelAuthorizationRoutes();
+        Broadcast::userAuthenticationRoutes();
 
         require base_path('routes/channels.php');
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^9.16",
+        "laravel/framework": "^9.17",
         "laravel/sanctum": "^2.14.1",
         "laravel/tinker": "^2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^9.11",
+        "laravel/framework": "^9.16",
         "laravel/sanctum": "^2.14.1",
         "laravel/tinker": "^2.7"
     },


### PR DESCRIPTION
## Caveats

- `channelAutorhizationRoutes()` is an alias for `routes()`
- `userAuthenticationRoutes()` will work from `laravel/framework` 9.16+

## Related PRs

- https://github.com/laravel/framework/pull/42664/files

## Checklist before merging
- [x] `laravel/framework`'s next release (`9.16.0`)
- [ ] Laravel Docs PR (https://github.com/laravel/docs/pull/7965)