### PR TITLE
Update database.php

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -57,7 +57,7 @@ return [
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB',
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],


### PR DESCRIPTION
Fixed Foreign key not generated during migration on wamp- MySQL version: 5.5.5-10.3.14-MariaDB by adding a default value.