### PR TITLE
[8.x] PHP Version Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.4|^8.0",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.75",


### PR DESCRIPTION
Warning Message:: Since league/commonmark 2.2.0: Calling "convertToHtml()" on a League\CommonMark\MarkdownConverter class is deprecated, use "convert()" instead. in /home/forge/domain/releases/20220614101012/vendor/symfony/deprecation-contracts/function.php on line 25

league/commonmark:^2.2, has a minimum requirement is PHP 7.4 and Up.

For Reference https://packagist.org/packages/league/commonmark