### PR TITLE
Added php artisan init for simple project initialization

### DIFF
--- a/app/Console/Commands/InitProject.php
+++ b/app/Console/Commands/InitProject.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+
+class InitProject extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'init';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Runs all the necessary commands to make Laravel project ready to use';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        //Optional: serve after finishing
+        $serve = $this->choice(
+            "Would you like to serve after finishing?",
+            ["No", "Yes"],
+            1
+        );
+
+        //Get name for database
+        $name = strtolower($this->ask('Name for database: ', config('app.name')));
+
+        //Create .env file
+        File::copy('.env.example', '.env');
+
+        //Generate key
+        $this->call('key:generate');
+
+        //Put database name into .env
+        file_put_contents('.env', preg_replace('/^DB_DATABASE=.+$/m', "DB_DATABASE=$name", file_get_contents('.env')));
+
+        //Create database
+        DB::statement("CREATE DATABASE IF NOT EXISTS $name CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;");
+
+        //Migrate
+        $this->call('migrate');
+
+        //Seed
+        $this->call('db:seed');
+
+        //Serve
+        if (strtolower($serve) == 'yes') {
+            $this->call('serve');
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/InitProject.php
+++ b/app/Console/Commands/InitProject.php
@@ -31,8 +31,8 @@ class InitProject extends Command
     {
         //Optional: serve after finishing
         $serve = $this->choice(
-            "Would you like to serve after finishing?",
-            ["No", "Yes"],
+            'Would you like to serve after finishing?',
+            ['No', 'Yes'],
             1
         );
 


### PR DESCRIPTION
It may take some time to run every command separately when you want to initialize existing project so I added php artisan init command which does simple configuration to save some time. 

php artisan init:

> **Copies .env.example to .env**
> **Calls php artisan key:generate**
> **Changes DB_DATABASE name in .env**
> **Creates Database**
> **Calls php artisan migrate**
> **Calls php artisan db:seed**
> **And serves application if wanted**