### PR TITLE
Add ConsoleOutput to Service Container

### DIFF
--- a/artisan
+++ b/artisan
@@ -31,7 +31,7 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 */
 
 $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
-$output = $app->make(Symfony\Component\Console\Output\ConsoleOutput::class);
+$output = $app->make(Symfony\Component\Console\Output\ConsoleOutputInterface::class);
 
 $status = $kernel->handle(
     $input = new Symfony\Component\Console\Input\ArgvInput,

--- a/artisan
+++ b/artisan
@@ -31,10 +31,11 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 */
 
 $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$output = $app->make(Symfony\Component\Console\Output\ConsoleOutput::class);
 
 $status = $kernel->handle(
     $input = new Symfony\Component\Console\Input\ArgvInput,
-    new Symfony\Component\Console\Output\ConsoleOutput
+    $output
 );
 
 /*

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -41,6 +41,11 @@ $app->singleton(
     App\Exceptions\Handler::class
 );
 
+$app->singleton(
+    Symfony\Component\Console\Output\ConsoleOutput::class,
+    Symfony\Component\Console\Output\ConsoleOutput::class
+);
+
 /*
 |--------------------------------------------------------------------------
 | Return The Application

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,7 +42,7 @@ $app->singleton(
 );
 
 $app->singleton(
-    Symfony\Component\Console\Output\ConsoleOutput::class,
+    Symfony\Component\Console\Output\ConsoleOutputInterface::class,
     Symfony\Component\Console\Output\ConsoleOutput::class
 );
 


### PR DESCRIPTION
I have a use-case where I'm extending the LogManager to redirect logs to console output when running via artisan console. To do this elegantly, its necessary to know what the current verbosity level from the ConsoleOutput.

Registering the ConsoleOutput as a singleton in the service container will allow for that verbosity to be retrieved when desired to analyze the current verbosity level.

This PR adds that registration to the bootstrap/app.php and retrieves that binding in the artisan file.