### PR TITLE
Make middleware word in $routeMiddleware and $middleware PHPDocs plural at http Kernel.php file

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -9,7 +9,7 @@ class Kernel extends HttpKernel
     /**
      * The application's global HTTP middleware stack.
      *
-     * These middleware are run during every request to your application.
+     * These middlewares are run during every request to your application.
      *
      * @var array<int, class-string|string>
      */
@@ -48,7 +48,7 @@ class Kernel extends HttpKernel
     /**
      * The application's route middleware.
      *
-     * These middleware may be assigned to groups or used individually.
+     * These middlewares may be assigned to groups or used individually.
      *
      * @var array<string, class-string|string>
      */


### PR DESCRIPTION
The plural demonstrative 'These' does not agree with the singular noun 'middleware'. 