### PR TITLE
[9.x] Added needful indexes for `failed_jobs` table

### DIFF
--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -16,11 +16,13 @@ return new class extends Migration
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();
-            $table->text('connection');
-            $table->text('queue');
+            $table->text('connection')->index();
+            $table->text('queue')->index();
             $table->longText('payload');
             $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
+            $table->timestamp('failed_at')->index()->useCurrent();
+
+            $table->index(['connection', 'queue']);
         });
     }
 


### PR DESCRIPTION
## Improvement

It is "nice-to-have" these kinds of indexes for Laravel applications since the beginning when we hit the "laravel new project". 

For debugging, analyze failure and check/re-trigger failed jobs faster, especially in a datetime range.

My current app has like 1M records of failed_jobs but it is a pain to search for something.

Cheers 😉 