### PR TITLE
[9.x] Add auth.json to skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml
+auth.json
 npm-debug.log
 yarn-error.log
 /.idea


### PR DESCRIPTION
An `auth.json` is commonly used when working with Nova, etc. I feel like this should be a default in the Laravel skeleton since the ecosystem uses it quite a bit. This will help developers from accidentally committing sensitive credentials.