### PR TITLE
Add autoinc id column to password_resets table

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
+            $table->id();
             $table->string('email')->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();


### PR DESCRIPTION
It is generally good hygiene to have auto-incrementing id columns explicitly defined on all MySQL tables.