### PR TITLE
[9.x] Add default reloading to skeleton

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,9 +3,12 @@ import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/css/app.css',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
     ],
 });


### PR DESCRIPTION
This PR makes the skelton come with the default Laravel watching configuration out of the box.

As it stands, this will perform a full page refresh while running `npm run dev` and saving files within the following directories:

```
resources/views/**
routes/**
```

The directories can still be manually configured when needed.

See: https://github.com/laravel/vite-plugin/pull/43