### PR TITLE
vite: remove comments from output

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,5 +10,8 @@ export default defineConfig({
             ],
             refresh: true,
         }),
+        esbuild: {
+           legalComments: 'none',
+        },
     ],
 });


### PR DESCRIPTION
Hi, @timacdonald 

Vite uses `esbuild` to minify js; which does not remove legal comments from output

Read more:
https://esbuild.github.io/api/#legal-comments

Removing comments from output can greatly reduce the bundle size and i think it should be default for Laravel.

I tried other options as well, for example

Remove debugger and console from minified build
```js
 drop: ['debugger', 'console'],
```
But it does not work for me.

