### PR TITLE
Delete hidden class at auth menu

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,7 +23,7 @@
     <body class="antialiased">
         <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center py-4 sm:pt-0">
             @if (Route::has('login'))
-                <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">
+                <div class="fixed top-0 right-0 px-6 py-4 sm:block">
                     @auth
                         <a href="{{ url('/home') }}" class="text-sm text-gray-700 dark:text-gray-500 underline">Home</a>
                     @else


### PR DESCRIPTION
I have come across the casuistry of wanting to test the internal sections of my new laravel application but it is not possible to access them from the welcome view because the auth menu is hidden by default, so you can not log in or register into the aplication.

The div has a `sm:block`, but that will only display the information starting at 640px. For example, an iPhone 13 Pro Max in portrait mode is 428px wide, so the menu will never appear. (Please see https://tailwindcss.com/docs/responsive-design#overview).