### PR TITLE
Add missing translation prefix to pagination file

### DIFF
--- a/lang/en/pagination.php
+++ b/lang/en/pagination.php
@@ -13,6 +13,10 @@ return [
     |
     */
 
+    'showing' => 'Showing',
+    'to' => 'to',
+    'of' => 'of',
+    'results' => 'results',
     'previous' => '&laquo; Previous',
     'next' => 'Next &raquo;',
 


### PR DESCRIPTION
Currently some translations of the pagination templates are not translated. Since the prefix for the strings is missing, a translation is also not easily possible without adapting the template.

The strings have now been translated in the language file and the prefixes added.

This ticket belongs to this ticket:
https://github.com/laravel/framework/pull/43114