### PR TITLE
[9.x] Remove extra underscore from cache key prefix

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -105,6 +105,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
 
 ];


### PR DESCRIPTION
PR #5817 accidentally adds an excessive underscore to the end of the Redis cache key prefix, causing keys to become `laravel_cache_:key` instead of simply `laravel_cache:key`.

A colon is already included at the end of the prefix for Redis, which occurs in `Illuminate\Cache\RedisStore.php`:

```
public function setPrefix($prefix)
{
    $this->prefix = ! empty($prefix) ? $prefix.':' : '';
}
```

This commit will simply undo the change to streamline the prefix as it was before without the underscore.

The issue mentioned in the PR linked above only affects the database cache driver, so it would be more efficient and consistent to just add a colon to the prefix in `Illuminate\Cache\DatabaseStore.php` instead.