### PR TITLE
[10.x] Remove extra underscore from cache key prefix

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -105,6 +105,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
 
 ];


### PR DESCRIPTION
This will undo a breaking change introduced in Laravel 9 that added an excessive underscore to the cache key prefixes which unnecessarily turned `laravel_cache:key` into `laravel_cache_:key`.

The underscore was originally added to address the issue of the database cache driver not having a separator between the prefix and key name, but it would be more efficient and consistent to add a colon to the key prefix in `Illuminate\Cache\DatabaseStore.php` instead to match the other cache drivers.

Reopening under 10.x instead of 9.x since reverting this is potentially a breaking change, although still worth it for the sake of brevity.