### PR TITLE
Introduce npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "private": true,
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "watch": "vite build --watch"
     },
     "devDependencies": {
         "axios": "^0.25",


### PR DESCRIPTION
Adding a new script entry point for `npm run watch` provides similar behaviour to webpack version.  Assets are built, placed in the public folder and watched for changes to source files.

This is useful for people that don't want hot reloading and want the assets built and able to be committed to their repository without having to remember to stop the `npm run dev` and execute `npm run build`  

It is actually effective to have two windows open, one with `npm run dev` and one with `npm run watch`. 