### PR TITLE
Add ValidateSignature middleware for ignore params

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,7 +60,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
-        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];

--- a/app/Http/Middleware/ValidateSignature.php
+++ b/app/Http/Middleware/ValidateSignature.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use \Illuminate\Routing\Middleware\ValidateSignature as Middleware;
+
+class ValidateSignature extends Middleware
+{
+    /**
+     * The names of the parameters that should be ignored.
+     *
+     * @var array<int, string>
+     */
+    protected $ignore = [
+        'utm_campaign',
+        'utm_source',
+        'utm_medium',
+        'utm_content',
+        'utm_term',
+    ];
+}

--- a/app/Http/Middleware/ValidateSignature.php
+++ b/app/Http/Middleware/ValidateSignature.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use \Illuminate\Routing\Middleware\ValidateSignature as Middleware;
+use Illuminate\Routing\Middleware\ValidateSignature as Middleware;
 
 class ValidateSignature extends Middleware
 {

--- a/app/Http/Middleware/ValidateSignature.php
+++ b/app/Http/Middleware/ValidateSignature.php
@@ -12,10 +12,11 @@ class ValidateSignature extends Middleware
      * @var array<int, string>
      */
     protected $ignore = [
-        'utm_campaign',
-        'utm_source',
-        'utm_medium',
-        'utm_content',
-        'utm_term',
+        //'utm_campaign',
+        //'utm_source',
+        //'utm_medium',
+        //'utm_content',
+        //'utm_term',
+        //'fbclid',
     ];
 }


### PR DESCRIPTION
This provides a work around to an interesting problem with Signed URLs that I encountered and discussed here: https://twitter.com/valorin/status/1547053470389112834.

I've created a PR for the framework here: https://github.com/laravel/framework/pull/43160

### Problem

The problem is that some systems, such as mailing list providers and Facebook will add their own tracking parameters onto URLs. Such as the [UTM tracking parameters](https://usefathom.com/utm-builder) (`utm_*`), and Facebook's `fbclid` parameter,  which it adds to any links clicked for tracking purposes.

Since these are added as query parameters, they break the signature and prevent the URL from being validated.

### Solution 

My solution is to replicate the design used in other core middleware (i.e. `EncryptCookies`, `PreventRequestsDuringMaintenance`, `TrimStrings`, & `VerifyCsrfToken`) and include a configurable `$ignore` parameter, which can be used to specify the query parameters to be ignored when verifying the signature.

```
class ValidateSignature extends Middleware
{
    /**
     * The names of the parameters that should be ignored.
     *
     * @var array<int, string>
     */
    protected $ignore = [
        'utm_campaign',
        'utm_source',
        'utm_medium',
        'utm_content',
        'utm_term',
        'fbclid',
    ];
}
```

### Questions...

The big question is if common tracking query parameters should be ignored by default. 

Signed URL issues are hard to debug, such as when they are [shared on Facebook](https://twitter.com/warsh33p/status/1547113243616870401), so having these default ignored would be beneficial in most cases. However it would break signed URLs that legitimately include those parameters. Although the argument could be made that you'd need to update the middleware to introduce these parameters, so it shouldn't break existing signed URLs.

I've defaulted them commented out for now to be safe, but enabled by default should be considered.