### PR TITLE
[9.x] Update to the latest version of laravel-vite-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "devDependencies": {
         "axios": "^0.25",
-        "laravel-vite-plugin": "^0.3.0",
+        "laravel-vite-plugin": "^0.4.0",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
         "vite": "^2.9.11"


### PR DESCRIPTION
The `laravel-vite-plugin` had a pre-1.x major version bump due to a change to the default SSR build directory.
