### PR TITLE
bump vite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
         "laravel-vite-plugin": "^0.4.0",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
-        "vite": "^2.9.11"
+        "vite": "^3.0.2"
     }
 }


### PR DESCRIPTION
Current tree:
npm list --depth=0
laravel@ /Users/rana/sites/laravel
├── axios@0.27.2
├── laravel-vite-plugin@0.4.0
├── lodash@4.17.21
├── postcss@8.4.14
└── vite@2.9.14

After applying this update

npm list --depth=0
laravel@ /Users/rana/sites/laravel
├── axios@0.27.2
├── laravel-vite-plugin@0.4.0
├── lodash@4.17.21
├── postcss@8.4.14
└── vite@3.0.2