### PR TITLE
add namespace for controller

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,6 +20,13 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
+     * This namespace applied to controller routes.
+     *
+     * @var string
+     */
+//    protected string $namespace = 'App\Http\Controllers';
+
+    /**
      * Define your route model bindings, pattern filters, and other route configuration.
      *
      * @return void


### PR DESCRIPTION
Some developers like to write controller in string like this :
```
Route::get('laravel', 'LaravelController@index');
```
I comment namespace but some developers if liked to uncomment namespace!