### PR TITLE
[9.x] Don't need to ignore vite config file

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,8 +5,5 @@ php:
   finder:
     not-name:
       - index.php
-js:
-  finder:
-    not-name:
-      - vite.config.js
+js: true
 css: true

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,10 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: [
-                'resources/css/app.css',
-                'resources/js/app.js',
-            ],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
Whether the list is multi-line is controlled by single-line length. Once it exceeds the threshold, it is moved to multi-line.