### PR TITLE
IGNORE ANY .env.* by Default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /storage/*.key
 /vendor
 .env
+.env.*
 .env.backup
 .phpunit.result.cache
 Homestead.json


### PR DESCRIPTION
Add .env.* to .gitIgnore in order to enforce the security of private keys by preventing accidentally publishing keys accidentally in ANY environment.