### PR TITLE
Ignore Development logs && also Log Daily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/logs/*
 /vendor
 .env
 .env.backup

--- a/config/logging.php
+++ b/config/logging.php
@@ -53,7 +53,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily'],
             'ignore_exceptions' => false,
         ],
 


### PR DESCRIPTION
1. .gitignore(storage/logs/*)...To avoid publishing development error logs to the deployment server.
2. 'channels' => ['daily'] ... for ease in reading log or finding errors.
