### PR TITLE
add .env.* to .gitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /storage/*.key
 /vendor
 .env
+.env.*
 .env.backup
 .phpunit.result.cache
 Homestead.json


### PR DESCRIPTION
it should be an explicit conscious decision to remove all variations of .env. from the .gitignore and push it to the repo since the .env files usually contains sensitive information.