### PR TITLE
Make email unique

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,7 +19,7 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'email' => fake()->safeEmail(),
+            'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),


### PR DESCRIPTION
When seeding large amounts of users there is a chance for a duplicate entry SQL error because the [email column is unique](https://github.com/laravel/laravel/blob/64e01753985749fab6626a370b27baa8431e74e6/database/migrations/2014_10_12_000000_create_users_table.php#L19).