### PR TITLE
fix(log):deprecation warnings

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -117,6 +117,11 @@ return [
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],
+        
+        'deprecations' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel-deprecation-warnings.log'),
+        ],
     ],
 
 ];


### PR DESCRIPTION
when lose this config, log will create so much warning log in laravel.log. maybe 1 mb, just one time !

like

```
laravel.EMERGENCY: Unable to create configured logger. Using emergency logger. {"exception":"[object] (ErrorException(code: 0)...
```