### PR TITLE
Prevent silently discarding model attributes by default

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Model;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Model::preventSilentlyDiscardingAttributes();
     }
 }


### PR DESCRIPTION
I don't see a reason why this shouldn't be the default.

Related https://github.com/laravel/framework/pull/43893.