### PR TITLE
Allows setting local and public root path

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -32,13 +32,13 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            'root' => env('FILESYSTEM_DISK_LOCAL_ROOT', storage_path('app')),
             'throw' => false,
         ],
 
         'public' => [
             'driver' => 'local',
-            'root' => storage_path('app/public'),
+            'root' => env('FILESYSTEM_DISK_PUBLIC_ROOT', storage_path('app/public')),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
             'throw' => false,


### PR DESCRIPTION
This allows on any new started project to be able to provide out of the installation alternative local disks paths, both private and public.