### PR TITLE
[9.x] Handle precognition requests by default 

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,7 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
+        // \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
     ];
 
     /**


### PR DESCRIPTION
> Requires a framework release for https://github.com/laravel/framework/pull/44339

This PR adds the `HandlePrecognitiveRequests` middleware to the default middleware stack. The goal of this is to make it even more frictionless for people to get started with implementing precognition requests.

Precognition requests are invoked with a `Precognition: true` header meaning apps that don't explicitly pass this aren't affected. The only thing that's left to do for users is to implement the `isPrecognitive` checks in their apps. Adding the middleware on a route-per-route basis isn't needed anymore. 

People can still turn off this global middleware and implement on a route-per-route basis but I could not see a problem by adding this by default.