### PR TITLE
 Fixing MYSQL  Forgien-key's migrations bugs

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -52,12 +52,12 @@ return [
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'charset' => 'utf8',  // fixing encoding bugs
+            'collation' => 'utf8_general_ci', // fixing encoding bugs
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
-            'engine' => null,
+            'engine' => 'innodb', // fixing the bugs of forgein keys migrations
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],


### PR DESCRIPTION
+ Fixing MYSQL  Forgien-key's migrations bugs with 'innodb' engine by default
+ Fixing languages Encoding bugs UTF-8 encludes accented languages.