### PR TITLE
ignore .env.production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /vendor
 .env
 .env.backup
+.env.production
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml


### PR DESCRIPTION
According to v9.32.0 release, has been introduced  env:encrypt and env:decrypt commands
To encrypt production env you need to create `.env.production` file first then you can encrypt it become `.env.production.encrypted`

The problem is `.env.production` is not ignored by default, this really dangerous if it's accidentally committed and pushed to repository, your credential will be exposed!