### PR TITLE
[10.x] Uses PHP Native Type Declarations 🐘

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -9,21 +9,16 @@ class Kernel extends ConsoleKernel
 {
     /**
      * Define the application's command schedule.
-     *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
      */
-    protected function schedule(Schedule $schedule)
+    protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
     }
 
     /**
      * Register the commands for the application.
-     *
-     * @return void
      */
-    protected function commands()
+    protected function commands(): void
     {
         $this->load(__DIR__.'/Commands');
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -38,10 +38,8 @@ class Handler extends ExceptionHandler
 
     /**
      * Register the exception handling callbacks for the application.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->reportable(function (Throwable $e) {
             //

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -3,16 +3,14 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
 
 class Authenticate extends Middleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string|null
      */
-    protected function redirectTo($request)
+    protected function redirectTo(Request $request): string|null
     {
         if (! $request->expectsJson()) {
             return route('login');

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -12,8 +12,6 @@ class Authenticate extends Middleware
      */
     protected function redirectTo(Request $request): string|null
     {
-        if (! $request->expectsJson()) {
-            return route('login');
-        }
+        return $request->expectsJson() ? null : route('login');
     }
 }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -4,20 +4,17 @@ namespace App\Http\Middleware;
 
 use App\Providers\RouteServiceProvider;
 use Closure;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 class RedirectIfAuthenticated
 {
     /**
      * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
-     * @param  string|null  ...$guards
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
-    public function handle(Request $request, Closure $next, ...$guards)
+    public function handle(Request $request, Closure $next, string|null ...$guards): Response|RedirectResponse
     {
         $guards = empty($guards) ? [null] : $guards;
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -4,19 +4,18 @@ namespace App\Http\Middleware;
 
 use App\Providers\RouteServiceProvider;
 use Closure;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
 
 class RedirectIfAuthenticated
 {
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string|null ...$guards): Response|RedirectResponse
+    public function handle(Request $request, Closure $next, string|null ...$guards): Response
     {
         $guards = empty($guards) ? [null] : $guards;
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -13,6 +13,8 @@ class RedirectIfAuthenticated
 {
     /**
      * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      */
     public function handle(Request $request, Closure $next, string|null ...$guards): Response|RedirectResponse
     {

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -15,7 +15,7 @@ class RedirectIfAuthenticated
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string|null ...$guards): Response
+    public function handle(Request $request, Closure $next, string ...$guards): Response
     {
         $guards = empty($guards) ? [null] : $guards;
 

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -11,7 +11,7 @@ class TrustHosts extends Middleware
      *
      * @return array<int, string|null>
      */
-    public function hosts()
+    public function hosts(): array
     {
         return [
             $this->allSubdomainsOfApplicationUrl(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,20 +8,16 @@ class AppServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
 
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -18,10 +18,8 @@ class AuthServiceProvider extends ServiceProvider
 
     /**
      * Register any authentication / authorization services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->registerPolicies();
 

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -9,10 +9,8 @@ class BroadcastServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         Broadcast::routes();
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -22,20 +22,16 @@ class EventServiceProvider extends ServiceProvider
 
     /**
      * Register any events for your application.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }
 
     /**
      * Determine if events and listeners should be automatically discovered.
-     *
-     * @return bool
      */
-    public function shouldDiscoverEvents()
+    public function shouldDiscoverEvents(): bool
     {
         return false;
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,10 +21,8 @@ class RouteServiceProvider extends ServiceProvider
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->configureRateLimiting();
 
@@ -40,10 +38,8 @@ class RouteServiceProvider extends ServiceProvider
 
     /**
      * Configure the rate limiters for the application.
-     *
-     * @return void
      */
-    protected function configureRateLimiting()
+    protected function configureRateLimiting(): void
     {
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,7 +15,7 @@ class UserFactory extends Factory
      *
      * @return array<string, mixed>
      */
-    public function definition()
+    public function definition(): array
     {
         return [
             'name' => fake()->name(),
@@ -28,10 +28,8 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the model's email address should be unverified.
-     *
-     * @return static
      */
-    public function unverified()
+    public function unverified(): static
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,8 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the model's email address should be unverified.
+     *
+     * @return $this
      */
     public function unverified(): static
     {

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -8,10 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
@@ -26,10 +24,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('users');
     }

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -8,10 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
@@ -22,10 +20,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('password_resets');
     }

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -8,10 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
@@ -26,10 +24,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('failed_jobs');
     }

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -8,10 +8,8 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
@@ -27,10 +25,8 @@ return new class extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('personal_access_tokens');
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -9,10 +9,8 @@ class DatabaseSeeder extends Seeder
 {
     /**
      * Seed the application's database.
-     *
-     * @return void
      */
-    public function run()
+    public function run(): void
     {
         // \App\Models\User::factory(10)->create();
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,15 +3,14 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 
 trait CreatesApplication
 {
     /**
      * Creates the application.
-     *
-     * @return \Illuminate\Foundation\Application
      */
-    public function createApplication()
+    public function createApplication(): Application
     {
         $app = require __DIR__.'/../bootstrap/app.php';
 

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -9,10 +9,8 @@ class ExampleTest extends TestCase
 {
     /**
      * A basic test example.
-     *
-     * @return void
      */
-    public function test_the_application_returns_a_successful_response()
+    public function test_the_application_returns_a_successful_response(): void
     {
         $response = $this->get('/');
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -8,10 +8,8 @@ class ExampleTest extends TestCase
 {
     /**
      * A basic test example.
-     *
-     * @return void
      */
-    public function test_that_true_is_true()
+    public function test_that_true_is_true(): void
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
This section, contains the list of next steps, and details the release this feature:

1. @taylorotwell should validate the code on the following pull requests, so @driesvints can merge those pull requests on `master`:

- [x] [`laravel/docs`](https://github.com/laravel/docs/pull/8287)
- [x] [`laravel/framework`](https://github.com/laravel/framework/pull/44545)
- [ ] [`laravel/laravel`](https://github.com/laravel/laravel/pull/6010)

2. @taylorotwell should validate the code **and merge** on the following pull requests, so @driesvints can release:

- [ ] [`laravel/vapor-ui`](https://github.com/laravel/vapor-ui/pull/81)
- [ ] [`laravel/fortify`](https://github.com/laravel/fortify/pull/421)
- [ ] [`laravel/sanctum`](https://github.com/laravel/sanctum/pull/405)
- [ ] [`laravel/cashier-paddle`](https://github.com/laravel/cashier-paddle/pull/171)
- [ ] [`laravel/cashier-stripe`](https://github.com/laravel/cashier-stripe/pull/1472)
- [ ] [`laravel/dusk`](https://github.com/laravel/dusk/pull/1004)
- [ ] [`laravel/horizon`](https://github.com/laravel/horizon/pull/1206)
- [ ] [`laravel/passport`](https://github.com/laravel/passport/pull/1594)
- [ ] [`laravel/breeze`](https://github.com/laravel/breeze/pull/201)
- [ ] [`laravel/telescope`](https://github.com/laravel/telescope/pull/1267/files) ( note, this will bump the needed PHP version )

> @taylorotwell @driesvints Once `laravel/fortify` is released, bump `laravel/fortify` version, and release:

- [ ] [`laravel/jetstream`](https://github.com/laravel/jetstream/pull/1175)
- [ ] [`laravel/jetstream-docs`](https://github.com/laravel/jetstream-docs/pull/71)

> @driesvints Once `laravel/cashier-paddle` and `laravel/cashier-stripe` is release, bump their versions on `spark-paddle@v3` and `spark-stripe@v3`, and release:

- [ ] [`laravel/spark-paddle`](https://github.com/laravel/spark-paddle/pull/48)
- [ ] [`laravel/spark-stripe`](https://github.com/laravel/spark-stripe/pull/92)
- [ ] [`laravel/spark-docs`](https://github.com/laravel/spark-docs). // Note, this still need to be done...

3. Near the Laravel `v10.x` release date, perform the following tasks:

- [ ] Merge [`laravel/bootcamp.laravel.com`](https://github.com/laravel/bootcamp.laravel.com/pull/18)
- [ ] Merge and release Pint `v2.x` [`laravel/pint`](https://github.com/laravel/pint/pull/126)
- [ ] Document potential breaking changes made on [`laravel/framework`](https://github.com/laravel/framework/pull/44545)
- [ ] Update `contributing.md`, so it's clear where / when / and how are we accepting pull requests that make changes on types. 

4. Coordinate with the Nova team, and ensure this pull requests are already included on the `5.x` branch:

- [ ] [`laravel/nova`](https://github.com/laravel/nova/pull/2232)
- [ ] [`laravel/nova-docs`](https://github.com/laravel/nova-docs/pull/490)

---

This pull request adds and ensures PHP native types can be used across any generated code that can exist at user-land. This includes:  **Laravel `v10.x`** skeleton, generated code by `make` commands, starter kits like breeze and jetstream, and more. Let's see some examples:

```diff
          *
          * Run the migrations.
-         *
-         * @return void
          */
-        public function up()
+        public function up(): void
```

```diff
         /**
          * Handle the User "created" event.
-         *
-         * @param  \App\Models\User  $user
-         * @return void
         */
-        public function created($user)
+        public function created(User $user): void
```

```diff
    /**
     * Define the application's command schedule.
     *
-    * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-    * @return void
     */
-    protected function schedule($schedule)
+    protected function schedule(Schedule $schedule): void
```

In this proposal, PHP native types were added in a way that is **realistically possible** —  and **without breaking changes**. In addition, we are equally proposing changes coding-style-wise. Let's see the proposed changes in detail:

1. **Allow user-land types around methods arguments and return types**. Due to PHP's covariance and contravariance rules, we've typed **only arguments** on classes that exist user vendor directory, so all the cases below are possible:

```php
class A { function foo(string $a); } // framework
class B extends A { function foo($a); } // skeleton
class C extends A { function foo($a): int; } // skeleton
class D extends A { function foo(string $a); } // skeleton
class E extends A { function foo(string $a): int ; } // skeleton
```

Following this reasoning, none of the changes made at framework level are breaking, and users can remove type-hints if they want.

2. **Removal of superfluous PHP annotations**. So, when the native argument type or return type is exactly the same as the PHP Annotation, we can safely remove it. Here is an example:


```diff
    /**
     * Update the specified resource in storage.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\Chirp  $chirp
-    * @return \Illuminate\Http\Response
     */
-    public function update(Request $request, Chirp $chirp)
+    public function update(Request $request, Chirp $chirp): Response
```

Yet, if the PHP annotation adds auto-completion or static analysis value, we keep it, so the user can leverage a better developer experience. In the example below, we know via the native type that the return should be an array, and via the PHP annotation that should be an array composed of string values:

```diff
    /**
     * Get the host patterns that should be trusted.
     *
     * @return array<int, string>
     */
-    public function hosts()
+    public function hosts(): array
    {
        return [
            'laravel.test',
        ];
    }
```

3. **Allow user-land types around closures arguments**. This pull request proposes adding native typing around closures arguments, but not return types to keep the code aesthetically pretty:

```diff
    public function register(): void
    {
-        $this->reportable(function ($e) {
+        $this->reportable(function (Throwable $e) {
            //
        });
    }
```

When convenient for the code - meaning that It's obvious that the user will always return the first line - the closures may be replaced by short closures. And here, the rules are the same, where native PHP typing only gets applied to arguments:

```diff
    /**
     * Indicate that the model's email address should be unverified.
     */
    public function unverified(): static
    {
-        return $this->state(function (array $attributes) {
-            return [
-                'email_verified_at' => null,
-            ];
-        });

+        return $this->state(fn (array $attributes) => [
+            'email_verified_at' => null,
+        ]);
    }
```

4. **We are not addressing typed properties**.  While this pull request makes pretty much possible to use native typing on an entire Laravel project, our users won't be able type "properties" that are extended from Framework classes. E.g: Models, service providers, etc. This does not mean we are not addressing in the future, yet it does not belong to the scope of this pull request.

The rules stated above should be applied across the entire Laravel organization. And bellow, we talk about how we are doing that.