### PR TITLE
Add /.fleet directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ Homestead.yaml
 auth.json
 npm-debug.log
 yarn-error.log
+/.fleet
 /.idea
 /.vscode


### PR DESCRIPTION
Since [JetBrains Fleet](https://www.jetbrains.com/fleet/) has been released, we should add its config folder to `.gitignore` for consistency, like it is done with `.idea` and `.vscode` directories.