### PR TITLE
Bump `laravel/pint` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
-        "laravel/pint": "^1.0",
+        "laravel/pint": "^1.2",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.1",


### PR DESCRIPTION
Bump [`laravel/pint`](https://github.com/laravel/pint/releases/tag/v1.2.0) version