### PR TITLE
[9.x]  Add Cloudflare R2 storage configuration to filesystems.

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,6 +56,18 @@ return [
             'throw' => false,
         ],
 
+        'r2' => [
+            'driver' => 's3',
+            'key' => env('R2_ACCESS_KEY_ID'),
+            'secret' => env('R2_SECRET_ACCESS_KEY'),
+            'region' => env('R2_DEFAULT_REGION'),
+            'bucket' => env('R2_BUCKET'),
+            'url' => env('R2_URL'),
+            'visibility' => 'private',
+            'endpoint' => env('R2_ENDPOINT'),
+            'use_path_style_endpoint' => env('R2_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+        ],
     ],
 
     /*


### PR DESCRIPTION
This PR adds support for Cloudflare R2 storage.

Whilst R2 is billed as a S3 API compatible, the full S3 API is not supported. In particular the x-amx-acl header is not respected, so any attempt to use the public visibility flag will cause file uploads to fail.

This PR adds a base configuration where the visibility is set to private. 