### PR TITLE
initial config for telegram bot handler

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -3,6 +3,7 @@
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Handler\TelegramBotHandler;
 
 return [
 
@@ -116,6 +117,16 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        'telegram' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => TelegramBotHandler::class,
+            "with" => [
+                "apiKey" => env('LOG_TELEGRAM_API_KEY'),
+                "channel" => env('LOG_TELEGRAM_CHANNEL'),
+            ]
         ],
     ],
 


### PR DESCRIPTION
Nowadays many developers prefer using Telegram features over web applications, but laravel don't have any official documenation to use telegram API for debug, so I have added initial config for telegram bot hander in logging.php file.