### PR TITLE
[10.x] throw file-system exceptions by default

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -33,7 +33,7 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
-            'throw' => false,
+            'throw' => true,
         ],
 
         'public' => [
@@ -41,7 +41,7 @@ return [
             'root' => storage_path('app/public'),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
-            'throw' => false,
+            'throw' => true,
         ],
 
         's3' => [
@@ -53,7 +53,7 @@ return [
             'url' => env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
-            'throw' => false,
+            'throw' => true,
         ],
 
     ],


### PR DESCRIPTION
Ref https://github.com/laravel/framework/pull/41308

Laravel 8 used to throw file-system excretions but
Laravel 9 changed this behaviour and made it configurable instead.

This PR brings back the Laravel 8 behaviour and throw exceptions by default.
I think most of Laravel 9 developers are living in dark and unknown about this behaviour.

Exceptions are good :) 
