### PR TITLE
Fix typo in config/session.php

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -163,7 +163,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | By setting this option to true, session cookies will only be sent back
-    | to the server if the browser has a HTTPS connection. This will keep
+    | to the server if the browser has an HTTPS connection. This will keep
     | the cookie from being sent to you when it can't be done securely.
     |
     */


### PR DESCRIPTION
'a' should be 'an' in this context  🙂