### PR TITLE
Add `public/vendor` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /public/build
 /public/hot
+/public/vendor
 /public/storage
 /storage/*.key
 /vendor


### PR DESCRIPTION
According to https://github.com/laravel/laravel/pull/5904, we moved from committing compiled assets, to build them 👍 

In addition Laravel vendor assets publishing fires by default on composer `post-update-cmd` event https://github.com/laravel/laravel/pull/5654

Adding the `public/vendor` directory to .gitignore will be suitable for these changes.