### PR TITLE
Adjusting code explanations through comments.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -50,7 +50,7 @@ return [
     |
     | This URL is used by the console to properly generate URLs when using
     | the Artisan command line tool. You should set this to the root of
-    | your application so that it is used when running Artisan tasks.
+    | your application, so that it is used when running Artisan tasks.
     |
     */
 
@@ -204,7 +204,7 @@ return [
     |
     | This array of class aliases will be registered when this application
     | is started. However, feel free to register as many as you wish as
-    | the aliases are "lazy" loaded so they don't hinder performance.
+    | the aliases are "lazy" loaded, so they don't hinder performance.
     |
     */
 


### PR DESCRIPTION
Use a comma before 'so' if it connects two independent clauses (unless they are closely connected and short).