### PR TITLE
Git ignore Mac OS Desktop Services Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Homestead.yaml
 auth.json
 npm-debug.log
 yarn-error.log
+.DS_Store
 /.fleet
 /.idea
 /.vscode


### PR DESCRIPTION
For Mac users, it's expected they use the Mac OS `Finder` when developing an app. So definitely the `.DS_Store` fill will be created. I'm curious why we can't ignore it from git by default? I think it'll be helpful for the developers who use Mac and they adding `.DS_Store` to `.gitignore` each time whenever they start a new project.