### PR TITLE
[9.x] switch password reset email to a primary key

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
+            $table->string('email')->primary();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });


### PR DESCRIPTION
Switching from a normal index here to a primary index behaves the same except for adding a `UNIQUE` constraint.

The `DatabaseTokenRepository` deletes existing records with an email first, before creating a new one, so this additional constraint will be okay. https://github.com/laravel/framework/blob/9.x/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php#L88

Something similar was tried in #5652, but that PR added an **additional** `id` field as the primary key, which is probably a little overkill since we can just use the existing `email` field.

I have confirmed this solves the problem when the database has `SQL_REQUIRE_PRIMARY_KEY` set to `TRUE`, as it is on DigitalOcean Managed Databases.  I would say this is a good change to the default Laravel skeleton, as it is recommended to have primary keys on all tables for multi-node systems.