### PR TITLE
[9.x] Updated Example Feature Test to use fluent syntax

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,8 +14,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response()
     {
-        $response = $this->get('/');
-
-        $response->assertStatus(200);
+        $this->get('/')
+            ->assertOk();
     }
 }


### PR DESCRIPTION
I think that the example feature test case could use a more fluent syntax and also use the assert helper methods for the HTTP status code instead of the `assertStatus` with the 200 which feels like a magic number.