### PR TITLE
add default secure option in seesion.php config

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -168,7 +168,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => env('SESSION_SECURE_COOKIE', false),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
the default env doen't have SESSION_SECURE_COOKIE
so it convenint to have default value in the config in case developer use the config.