### PR TITLE
[9.x] Fix initial database config for SQLite 🔧

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -38,7 +38,7 @@ return [
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DATABASE_URL'),
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'database' => database_path(env('DB_DATABASE', 'database').'.sqlite'),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],


### PR DESCRIPTION
## About

`.env:`
```php
DB_CONNECTION=sqlite
DB_DATABASE=test
```

After initialization of a new Laravel project with SQLite database, it suggests creating a database before running migrations:

![1](https://user-images.githubusercontent.com/37669560/212162068-6f7ec0dd-d6fe-4877-8124-436801b5fd1e.png)

---

But if we try to access this auto-created database, we get:

![2](https://user-images.githubusercontent.com/37669560/212162074-3ca64a77-6007-4e2c-9d87-f87c61fdc7d8.png)

This PR fixes the configuration in `config/database.php` to ensure the SQLite database creates correctly in the `database` folder.

---
