### PR TITLE
[10.x] Uses Laravel Ignition `v2.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^6.1",
         "phpunit/phpunit": "^9.5.10",
-        "spatie/laravel-ignition": "dev-l10"
+        "spatie/laravel-ignition": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request updates Laravel 10's composer file to use Laravel Ignition `v2.x`. This is the version that should be used with Laravel 10.