### PR TITLE
Use nullable typing

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -10,7 +10,7 @@ class Authenticate extends Middleware
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      */
-    protected function redirectTo(Request $request): string|null
+    protected function redirectTo(Request $request): ?string
     {
         return $request->expectsJson() ? null : route('login');
     }


### PR DESCRIPTION
Before the official Laravel 10 release I want to [revisit this conversation](https://github.com/laravel/laravel/pull/6010/files#r992625264). This is the only instance of a union type being used over a nullable type in the new skeleton code. As such it sets a _precedent_ since many developers look to the documentation or source code for conventions.

If Laravel prefers to use explicit union types over nullable types, please close my PR. If the streamlined nullable type is preferred, then 🏄‍♂️ 

Please note, it is not my intention to start the Type Wars of 2023. I mostly want to finish the conversation so I may code the _Laravel 10.x Shift_ accordingly.