### PR TITLE
Made default queue for database and beanstalkd connections configurable via env

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -37,7 +37,7 @@ return [
         'database' => [
             'driver' => 'database',
             'table' => 'jobs',
-            'queue' => 'default',
+            'queue' => env('DATABASE_QUEUE', 'default'),
             'retry_after' => 90,
             'after_commit' => false,
         ],
@@ -45,7 +45,7 @@ return [
         'beanstalkd' => [
             'driver' => 'beanstalkd',
             'host' => 'localhost',
-            'queue' => 'default',
+            'queue' => env('BEANSTALKD_QUEUE', 'default'),
             'retry_after' => 90,
             'block_for' => 0,
             'after_commit' => false,


### PR DESCRIPTION
This PR allows for the default queue for the database and beanstalkd queue connections to be configured using environment variables, similar to how the Redis and SQS connections are set up.