### PR TITLE
[9.x] adding json condition for RedirectIfAuthenticated

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -15,7 +15,7 @@ class RedirectIfAuthenticated
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @param  string|null  ...$guards
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     public function handle(Request $request, Closure $next, ...$guards)
     {
@@ -23,6 +23,12 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
+                if ($request->expectsJson()) {
+                    return response()->json([
+                        'message' => 'You must be as guest user to access this route'
+                    ], 400);
+                }
+
                 return redirect(RouteServiceProvider::HOME);
             }
         }


### PR DESCRIPTION
When add ```guest``` middleware into routes and add guard for example ```sanctum```, if send request as json the middleware redirect to ```/home``` url.
But for api is better to return json response.

Before:
![2023-02-02_12-33-06](https://user-images.githubusercontent.com/98118400/216279229-cc842544-b850-415d-ade7-8d9e8c57ebb0.png)

After:
![2023-02-02_12-32-33](https://user-images.githubusercontent.com/98118400/216279261-3235ae2c-3c4c-4d4d-9ed2-2ca231d52400.png)
