### PR TITLE
[10.x] sets ASSET_URL to use `/` as the fallback value

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,7 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'asset_url' => env('ASSET_URL'),
+    'asset_url' => env('ASSET_URL', '/'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

If there is no `ASSET_URL` for a Laravel project, Laravel will fallback to appending the current request's host. It ignores the `APP_URL`.

```php
APP_URL=https://app-url.com
ASSET_URL=
```

If the site is served at `http://127.0.0.1:8008`...

```php
asset('style.css');

// http://127.0.0.1:8000/style.css 
```

This works great for the backend, but Vite will never know what the host of the request is, as all its knowledge must be known at build time. So Vite and Laravel can not truly share the asset URL across the build time / runtime divide _when `ASSET_URL` is empty_.

**Why is this a problem?**

Laravel outputs preload tags for all the required assets for the initial page load (hashes removed for readability).

```html
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/Register.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/GuestLayout.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/TextInput.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/PrimaryButton.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/ApplicationLogo.js">
```

Internally we use the `asset` helper to generate these URLs. You can see they have appended the incoming request host.

When Vite boots and on subsequent page navigation Vite will also preload all required assets that _have not yet been seen_.

Vite does not know about `http://127.0.0.1:8000/build/assets/app.css`. Vite only knows about `/build/assets/app.css`. This results in duplicate preload tags populating the document on initial page load.

```html
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/Register.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/GuestLayout.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/TextInput.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/PrimaryButton.js">
<link rel="modulepreload" href="http://127.0.0.1:8000/build/assets/ApplicationLogo.js">

<!-- ... -->

<link rel="modulepreload" as="script" href="/build/assets/Register.js">
<link rel="modulepreload" as="script" href="/build/assets/GuestLayout.js">
<link rel="modulepreload" as="script" href="/build/assets/TextInput.js">
<link rel="modulepreload" as="script" href="/build/assets/PrimaryButton.js">
<link rel="modulepreload" as="script" href="/build/assets/ApplicationLogo.js">
```

This isn't hugely problematic, as the browser knows that both of these URLs point to the same resource, i.e. the browser doesn't try to preload 2 sets of resources. The Vite preloads are a noop in the case that Laravel has already output its own preload tags.

## Solution

If we have the `ASSET_URL` fallback to a `/` (which was not possible in `9.x` but is in `10.x`) we get uniform output from both Laravel and Vite, and thus Vite does not output duplicate tags.

```html
<link rel="modulepreload" href="/build/assets/Register.js">
<link rel="modulepreload" href="/build/assets/GuestLayout.js">
<link rel="modulepreload" href="/build/assets/TextInput.js">
<link rel="modulepreload" href="/build/assets/PrimaryButton.js">
<link rel="modulepreload" href="/build/assets/ApplicationLogo.js">
```

We could look at changing this in the framework, but I figure doing it in the skeleton allows for ultimate control for developers if they want to restore the previous functionality of using the incoming request's host.

## Not just a Vite problem

Although this is motivated by a Vite related problem, this will benefit other and future tools. 

I believe that a known static value for `ASSET_URL` makes total sense as a default. The asset helper is meant to link to assets, and very often those assets are built by a 3rd party. This allows a more expected shared value across the runtime / build time divide.

I also don't believe this should be problematic in anyway, because the request host and `/` should be equivalent unless you are doing something really funky.