### PR TITLE
[10.x] Small tweak in `welcome` screen

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -51,7 +51,7 @@
                                 <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">Documentation</h2>
 
                                 <p class="mt-4 text-gray-500 dark:text-gray-400 text-sm leading-relaxed">
-                                    Laravel has wonderful, thorough documentation covering every aspect of the framework. Whether you are new to the framework or have previous experience with Laravel, we recommend reading all of the documentation from beginning to end.
+                                    Laravel has wonderful documentation covering every aspect of the framework. Whether you are a newcomer or have prior experience with Laravel, we recommend reading our documentation from beginning to end.
                                 </p>
                             </div>
 


### PR DESCRIPTION
This pull request tweaks the "Documentation" section of our welcome screen to avoid an extra line when displaying the welcome screen.

Here is before:
<img width="100%" alt="before" src="https://user-images.githubusercontent.com/5457236/218536534-ecb2393a-1f47-4ca8-91dc-722edb7f1a79.png">

Here is after:
<img width="100%" alt="after" src="https://user-images.githubusercontent.com/5457236/218536555-2f269032-9680-4e6e-b62e-ad1169439fa7.png">
