### PR TITLE
Allow php-http/discovery as a composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": true
         }
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
[php-http/discovery](https://packagist.org/packages/php-http/discovery) is widely used by SDK authors to provide auto-discovery of PSR-17/18 implementations. It's widely used in all PHP communities (Laravel, Symfony, etc.)

Since v1.15, it became a composer plugin, see https://github.com/php-http/discovery/pull/208. Adding this line improves DX by removing one needless prompt by Composer when the package is (transitively) required when installing a dependency. This takes a similar approach to #5959.

You might want to check the README of https://github.com/FriendsOfPHP/well-known-implementations for back ground on why this became a plugin.

For cross-ref, Symfony's skeleton also enabled this by default, see https://github.com/symfony/skeleton/pull/214