### PR TITLE
Update index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -27,7 +27,7 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 |
 | Composer provides a convenient, automatically generated class loader for
 | this application. We just need to utilize it! We'll simply require it
-| into the script here so we don't need to manually load our classes.
+| into the script here, so we don't need to manually load our classes.
 |
 */
 


### PR DESCRIPTION
Use a comma before 'so' if it connects two independent clauses (unless they are closely connected and short). 