### PR TITLE
Remove redundant `@return` docblock in UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,8 +28,6 @@ class UserFactory extends Factory
 
     /**
      * Indicate that the model's email address should be unverified.
-     *
-     * @return $this
      */
     public function unverified(): static
     {


### PR DESCRIPTION
Remove redundant `@return` docblock in `UserFactory`.

```php
public function unverified(): static
{
    ...
}
```

already shows what it returns