### PR TITLE
[10.x] Add LARAVEL_HR_START constant for improved performance tracking

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+define('LARAVEL_HR_START', hrtime(true));
 define('LARAVEL_START', microtime(true));
 
 /*

--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 
+define('LARAVEL_HR_START', hrtime(true));
 define('LARAVEL_START', microtime(true));
 
 /*


### PR DESCRIPTION
This commit adds the `LARAVEL_HR_START` constant to the `artisan` and `public/index.php` files to track the start time of Laravel's execution using the `hrtime` function. This will enable more accurate performance tracking and debugging of slow requests.

**Files modified:**
- artisan
- public/index.php

**Further notes:**
LARAVEL_HR_START stands for LARAVEL_HIGH_RESOLUTION_START. The question of whether to abbreviate or not begins with PHP's own function using the abbreviated form. I think it makes sense to abbreviate because PHP abbreviates.

We cannot replace the functionality of microtime(true) with hrtime(true), but we can include both approaches by default. hrtime(true) will greatly improve the accuracy of performance tracking, which I've found necessary in web crawling and scraping applications where optimizations are important to improve your application's capabilities.

In respect of existing applications usage of LARAVEL_START, my pull request runs LARAVEL_HR_START first to ensure LARAVEL_START is unaltered, which also makes sense since LARAVEL_HR_START can then track the full execution time of the application including the definition of LARAVEL_START. This is of course a very minor concern.