### PR TITLE
Reverts change in asset helper

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,7 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
-    'asset_url' => env('ASSET_URL', '/'),
+    'asset_url' => env('ASSET_URL'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
See the comments in #6089

tl;dr; The asset helper does not generate usable URLs on the console and for emails out of the box. I would rather have good URLs in emails out of the box than to remove some duplicate noop tags output from Vite.