### PR TITLE
[10.x] Add api prefix in name route

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -29,6 +29,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->routes(function () {
             Route::middleware('api')
                 ->prefix('api')
+                ->name('api.')
                 ->group(base_path('routes/api.php'));
 
             Route::middleware('web')

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+Route::middleware('auth:sanctum')->name('user')->get('/user', function (Request $request) {
     return $request->user();
 });


### PR DESCRIPTION
When downloading a Laravel project, our API routes do not come with the api name.

This means that we have to change the RouteServiceProvider file to meet this requirement.

I see it as necessary and prudent for api routes to have the api prefix. in their names.

Ex.: execute `php artisan route:list` command and see:

Before: 
<img width="1714" alt="Captura de Tela 2023-02-22 às 19 23 52" src="https://user-images.githubusercontent.com/16225726/220773993-9f7ac998-e3e0-41d2-9802-023855972743.png">


After:
<img width="1719" alt="Captura de Tela 2023-02-22 às 19 24 06" src="https://user-images.githubusercontent.com/16225726/220774014-8fcb7ab9-bb69-4490-a01a-e1b5b31aa33c.png">
