### PR TITLE
[10.x] Specify facility in the syslog driver config

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -102,6 +102,7 @@ return [
         'syslog' => [
             'driver' => 'syslog',
             'level' => env('LOG_LEVEL', 'debug'),
+            'facility' => LOG_USER,
         ],
 
         'errorlog' => [


### PR DESCRIPTION
This is not mentioned in the documentation so there was no way to know how to specify a facility like `local0` unless you go digging in `\Illuminate\Log\Logmanager`'s source code, which IMHO should not be necessary to figure out what options are available.

Another solution would be to add it to the documentation, but I believe it's simpler to just have it in the default config file.