### PR TITLE
[10.x] Add replace_placeholders to log channels

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -69,8 +69,8 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'replace_placeholders' => true,
             'days' => 14,
+            'replace_placeholders' => true,
         ],
 
         'slack' => [
@@ -108,8 +108,8 @@ return [
         'syslog' => [
             'driver' => 'syslog',
             'level' => env('LOG_LEVEL', 'debug'),
-            'replace_placeholders' => true,
             'facility' => LOG_USER,
+            'replace_placeholders' => true,
         ],
 
         'errorlog' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -3,6 +3,7 @@
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
 
@@ -61,12 +62,14 @@ return [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
         ],
 
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
             'days' => 14,
         ],
 
@@ -76,6 +79,7 @@ return [
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
             'level' => env('LOG_LEVEL', 'critical'),
+            'replace_placeholders' => true,
         ],
 
         'papertrail' => [
@@ -87,6 +91,7 @@ return [
                 'port' => env('PAPERTRAIL_PORT'),
                 'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
             ],
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'stderr' => [
@@ -97,17 +102,20 @@ return [
             'with' => [
                 'stream' => 'php://stderr',
             ],
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'syslog' => [
             'driver' => 'syslog',
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
             'facility' => LOG_USER,
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
         ],
 
         'null' => [


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/46344.

Add `replace_placeholders` to `true` to log channels and `PsrLogMessageProcessor` for `monolog` driver channels.

By default with this configuration, new applications will be able to do:

```php
Log::info('Showing the user profile for user: {id}', ['id' => $id]);
```