### PR TITLE
Allow updating session cookie Same-Site attributes

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -196,6 +196,6 @@ return [
     |
     */
 
-    'same_site' => 'lax',
+    'same_site' => env('SESSION_COOKIE_SAME_SITE', 'lax'),
 
 ];


### PR DESCRIPTION
Currently, the majority of `Session` options can be configured via environment variables, but this doesn't extend to the `Same-Site` attribute which can be an important security tool to tighten.

Options such as `http_only` aren't changed as allowing easier modification of these values would allow a less-secure posture more easily which we don't want to encourage.