### PR TITLE
[10.x] Remove -i in mail.php

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -65,7 +65,7 @@ return [
 
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs'),
         ],
 
         'log' => [


### PR DESCRIPTION
Removed -i as the behaviours is unspecified with -bs, and only relevant wuth -t used in [8.x] 