### PR TITLE
Add job batching options to Queue configuration file

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -78,9 +78,9 @@ return [
     | Job Batching
     |--------------------------------------------------------------------------
     |
-    | These options configure the behaviour of job batching so you can
-    | control which database and table are used to store the batches.
-    | You may change them to any database / table you wish.
+    | The following options configure the database and table that store job
+    | batching information. These options can be updated to any database
+    | connection and table which has been defined by your application.
     |
     */
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -75,6 +75,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Job Batching
+    |--------------------------------------------------------------------------
+    |
+    | These options configure the behaviour of job batching so you can
+    | control which database and table are used to store the batches.
+    | You may change them to any database / table you wish.
+    |
+    */
+
+    'batching' => [
+        'database' => env('DB_CONNECTION', 'mysql'),
+        'table' => 'job_batches',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Failed Queue Jobs
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Hey there 👋 

This PR adds the job batching configuration options to the queue configuration skeleton, so it's easier to tell that it's possible to customize which database connection and table name is used.

I have several applications which are all using the same database, and today I was changing which table they were using for their failed jobs, as they were all using the default  `failed_jobs` table.

I thought that job batching was going to be a problem, but I found that it was already possible to customize by looking inside the BusServiceProvider [here](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Bus/BusServiceProvider.php#L49).

I should also mention that I did not find anything in the [docs](https://laravel.com/docs/10.x/queues#job-batching) describing this.

Unfortunately I do not have Taylor's wording skills, so the comment describing the section is pretty horrific... 😊