### PR TITLE
Add directories for those using NetBeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/


### PR DESCRIPTION
Add the following NetBeans-specific directories to .gitignore:

build/
nbbuild/
dist/
nbdist/
.nb-gradle/