### PR TITLE
[10.x] Adds `phpunit/phpunit@10.1` support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.1",
         "spatie/laravel-ignition": "^2.0"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,11 +12,11 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./app</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>


### PR DESCRIPTION
This pull request adds `phpunit/phpunit@10.1` support, and it should be merged, and released, once PHPUnit 10.1 is out. 

At this moment, because the `phpunit.xml` contains deprecated options, users will see:

```
Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
```