### PR TITLE
[10.x] Use null default for batch database connection

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -85,7 +85,7 @@ return [
     */
 
     'batching' => [
-        'database' => env('DB_CONNECTION', 'mysql'),
+        'database' => env('DB_CONNECTION'),
         'table' => 'job_batches',
     ],
 


### PR DESCRIPTION
This will make sure the DB connection isn't set to mysql by default which indirectly affects Testbench and test suites who test batching but weren't counting on the batching database connection to be mysql.

Fixes a bug caused by https://github.com/laravel/laravel/pull/6149. 

Testbench can adopt this change and in turn tests on Telescope will pass again: https://github.com/laravel/telescope/actions/runs/4684132537/jobs/8308220330