### PR TITLE
Fix laravel/framework constraints for Default Service Providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^10.0",
+        "laravel/framework": "^10.8",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8"
     },


### PR DESCRIPTION
It seems like the constraints where not updated.

But the class `DefaultProviders` only exists since 10.8