### PR TITLE
Fix  419 | PAGE EXPIRED with ob_start(); on index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+ob_start();
+
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 


### PR DESCRIPTION
I added ob_start(); to index resolve the issue of 419 | PAGE EXPIRED

The issue of expired page happened on multiple Laravel versions.
It is a common issue, see:

https://stackoverflow.com/a/69458738