### PR TITLE
[10.x] Clean up user model traits

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,9 @@ use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.


### PR DESCRIPTION
This PR puts each trait used in the user model on their own line.

In a lot of applications you end up adding additional traits like `HasUlids` or Cashier's `Billable`.
Having about 5 traits on a single line gets quite unreadable.
Obviously, devs can manually put them on their own line or create a Pint rule for it, but having this set up in a clean way in the skeleton just reduces that friction on new projects.

If we decide to go this route, we might also add some additional rules to the Pint Laravel preset.

Doing everything for a better DX. 🧘
Let me know your thoughts!