### PR TITLE
Use static middleware methods in api routes file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^10.8",
+        "laravel/framework": "^10.9",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8"
     },

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\Authenticate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -14,6 +15,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+Route::middleware(Authenticate::using('sanctum'))->get('/user', function (Request $request) {
     return $request->user();
 });


### PR DESCRIPTION
Uses syntax introduced in https://github.com/laravel/framework/pull/46362 within this skeleton, to promote the use of more modern syntax.