### PR TITLE
Add hashed cast to user password

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,5 +40,6 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'password' => 'hashed',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/framework": "^10.8",
+        "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.2",
         "laravel/tinker": "^2.8"
     },


### PR DESCRIPTION
This PR adds the new `hashed` cast to the user password field.

I left the user factory with the already hashed password since this cast first checks if the field needs rehash (this check doesn't affect the performance).