### PR TITLE
[10.x] Bring back pusher cluster config option

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -36,6 +36,7 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
+                'cluster' => env('PUSHER_APP_CLUSTER'),
                 'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),


### PR DESCRIPTION
We use Laravel Echo and Pusher in our first party Statamic Collaboration Addon https://github.com/statamic/collaboration, and notice that users are having problems connecting via Laravel Echo websocket in newer Laravel versions where `cluster` no longer exists in the default Pusher config.

We notice it was [added to the example in bootstrap.js](https://github.com/laravel/laravel/pull/6059) because pusher-js 8.0 now requires `cluster`. With this requirement, and with our Collaboration Addon reading from the users' Laravel config, we're thinking that it should be accessible through the default Laravel config as well, and so that the config can be cached, etc.

Your thoughts?