### PR TITLE
Avoid mention ses-v2 in config/mail.php docblock

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -28,7 +28,7 @@ return [
     | sending an e-mail. You will specify which one you are using for your
     | mailers below. You are free to add additional mailers as required.
     |
-    | Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2",
+    | Supported: "smtp", "sendmail", "mailgun", "ses",
     |            "postmark", "log", "array", "failover"
     |
     */


### PR DESCRIPTION
I'm not sure why Taylor removed ses-v2 from mail.php (see link below) but since it is removed, I also remove via the docblock as I got a gotcha trying to specify ses-v2 for my MAIL_MAILER today

See:
https://github.com/laravel/laravel/pull/6115