### PR TITLE
fix: change must-verify-email import in user model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+// use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;


### PR DESCRIPTION
When uncommenting the `MustVerifyEmail` and adding it as trait to the `User` model, results in the following error: `App\Models\User cannot use Illuminate\Contracts\Auth\MustVerifyEmail - it is not a trait`.

This PR changes the import to the `MustVerifyEmail` trait.