### PR TITLE
Add `precognitive` key to $middlewareAliases

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
+        'precognitive' => \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,


### PR DESCRIPTION
This PR adds a `precognitive` to the middleware aliases array so we can use `precognitive` in the route instead of the fully qualified class name.