### PR TITLE
Update .gitignore to add .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+.DS_Store


### PR DESCRIPTION
It is really annoying when macOS creates `.DS_Store` files and you always have to edit the `.gitignore` to include them.