### PR TITLE
Use `getAuthIdentifier()` instead of `id`

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -25,7 +25,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot(): void
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(60)->by($request->user()?->getAuthIdentifier() ?: $request->ip());
         });
 
         $this->routes(function () {


### PR DESCRIPTION
This will make sure a custom `UserProvider` implementation with a custom `Authenticatable` implementation will still work. This because, when using a custom `Authenticatable` implementation, the authenticated user won't always have an `id` property because the interface cannot force to use an `id` property.

Motivation for changing the default rate limiter:

> This interface allows the authentication system to work with any "user" class, regardless of what ORM or storage abstraction layer you are using. By default, Laravel includes a App\Models\User class in the app/Models directory which implements this interface.

See https://laravel.com/docs/10.x/authentication#the-authenticatable-contract for more information.