### PR TITLE
Remove unused import

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 php:
   preset: laravel
-  disabled:
-    - no_unused_imports
   finder:
     not-name:
       - index.php

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
A change/bugfix in PHP-CS-Fixer `3.18` will now remove this line. See https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6909

For Laravel Pint I created a PR which upgrades to the new PHP-CS-Fixer version: See https://github.com/laravel/pint/pull/188

This line is responsible for a failing formatting Test in my package `jubeki/laravel-code-style`
See https://github.com/Jubeki/laravel-code-style/actions/runs/5306386155

Other options would be:
- Using a case sensitive `Event` somewhere in the file.
- To comment the line, instead of removing it.