### PR TITLE
[11.x]: Use `ses-v2` as default `ses` mail transport

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -47,7 +47,7 @@ return [
         ],
 
         'ses' => [
-            'transport' => 'ses',
+            'transport' => 'ses-v2',
         ],
 
         'mailgun' => [


### PR DESCRIPTION
This PR defines `ses-v2` as default `ses` mail transport.