### PR TITLE
Correct typo and remove "filler" words

### DIFF
--- a/artisan
+++ b/artisan
@@ -10,8 +10,8 @@ define('LARAVEL_START', microtime(true));
 |
 | Composer provides a convenient, automatically generated class loader
 | for our application. We just need to utilize it! We'll require it
-| into the script here so that we do not have to worry about the
-| loading of any of our classes manually. It's great to relax.
+| into the script here, so we do not have to worry about the
+| loading of our classes manually. It's great to relax.
 |
 */
 


### PR DESCRIPTION
1. Remove "that", as it feels like talked language.

2. "of any of" suggestion by [LanguageTool](https://languagetool.org/)

> Consider simply using of instead. 
Incorrect:  He was the worst of any of the dancers 
Correct:  He was the worst of the dancers 