### PR TITLE
[10.x] Remove unused import from EventServiceProvider

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Latest version of Pint with the Laravel preset removes the `Event` facade import from the `EventServiceProvider` since it's unused.

This PR removes the import from the skeleton, since there's not much use in having the import when it gets removed on first run of Pint anyway.