### PR TITLE
Omit default values for suffix in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,15 +6,15 @@
 >
     <testsuites>
         <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
+            <directory>./tests/Unit</directory>
         </testsuite>
         <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
+            <directory>./tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory suffix=".php">./app</directory>
+            <directory>./app</directory>
         </include>
     </source>
     <php>


### PR DESCRIPTION
The values specified for `suffix` are their respective defaults and can be omitted.