### PR TITLE
Fix vite HMR for Safari

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,9 @@ export default defineConfig({
             refresh: true,
         }),
     ],
+    server: {
+        hmr: {
+            host: 'localhost'
+        }
+    }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,6 @@ export default defineConfig({
     server: {
         hmr: {
             host: 'localhost',
-        }
+        },
     },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     server: {
         hmr: {
-            host: 'localhost'
+            host: 'localhost',
         }
-    }
+    },
 });


### PR DESCRIPTION
Vite doesn't work in Safari without these lines for some reason.