### PR TITLE
Remove `/public/build` from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.phpunit.cache
 /node_modules
-/public/build
 /public/hot
 /public/storage
 /storage/*.key


### PR DESCRIPTION
Hi,

This PR is for removing `/public/build` from the `.gitignore`. This change will prevent errors during deployment when compiled files are missing.

FYR:
- https://github.com/laravel/laravel/pull/3805
- https://github.com/laravel/laravel/commit/86b4b1b65659a7b0f4b3dad1e753aa1efa5a7642#commitcomment-83530235

Thanks!