### PR TITLE
Ignore dist folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+/dist


### PR DESCRIPTION
Hello maintainers,

I hope you're doing well. I've made a minor but valuable change to the project. With the **recent addition of NativePHP** in the Laravel ecosystem, **which compiles the build into the dist folder**, it's now generating a substantial number of files. I believe it would be beneficial to ignore these files in the .gitignore, to prevent new developers from accidentally committing them.

**Currently, the dist folder is not being ignored in the .gitignore file, which causes the git logs to display a multitude of changed files. This situation can be a bit overwhelming for contributors and users alike.**

To address this, I've included the necessary entry in the .gitignore file to ignore the dist folder and its contents. By doing so, we can keep the repository cleaner and avoid any unintentional commits of build artifacts.

I've thoroughly tested this modification on my forked copy, and everything is working seamlessly. While it's a small adjustment, I believe it will greatly enhance the development experience for all contributors and newcomers.

Thank you for considering my contribution. I'm excited about the opportunity to improve this amazing open-source Laravel project, and I look forward to your feedback.

Best regards,
Akash Singh