### PR TITLE
Bump `laravel-vite-plugin` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "devDependencies": {
         "axios": "^1.1.2",
-        "laravel-vite-plugin": "^0.7.5",
+        "laravel-vite-plugin": "^0.8.0",
         "vite": "^4.0.0"
     }
 }


### PR DESCRIPTION
Bumps `laravel-vite-plugin` to `v0.8.0`