### PR TITLE
Tweak for consistency: use env()'s $default parameter for fallback

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,7 +37,7 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'host' => env('PUSHER_HOST', 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com'),
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),
                 'encrypted' => true,


### PR DESCRIPTION
This fixes a minor consistency issue, replacing the use of the ternary operator with the use of env()'s $default parameter.