### PR TITLE
Postmark mailer configuraiton update.

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -59,7 +59,7 @@ return [
 
         'postmark' => [
             'transport' => 'postmark',
-            // 'message_stream_id' => null
+            // 'message_stream_id' => null,
             // 'client' => [
             //     'timeout' => 5,
             // ],

--- a/config/mail.php
+++ b/config/mail.php
@@ -59,6 +59,7 @@ return [
 
         'postmark' => [
             'transport' => 'postmark',
+            // 'message_stream_id' => null
             // 'client' => [
             //     'timeout' => 5,
             // ],


### PR DESCRIPTION
as mentioned in the following
ref https://github.com/craigpaul/laravel-postmark/issues/141

Postmark allows the mailer configuration to accept the `stream_id`, this is helpful if you sent transaction and broadcast notifications from Laravel with Postmark.
