### PR TITLE
Fix incorrect collation for MySQL 8

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => 'utf8mb4_0900_ai_ci',
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,


### PR DESCRIPTION
The project skeleton still uses the old `utf8mb4_unicode_ci` MySQL v5.x collation. This causes problems with things like emojis when using MySQL 8. `utf8mb4_0900_ai_ci` is the correct collation for MySQL v8.

From the [MySQL v8 reference manual](https://dev.mysql.com/doc/refman/8.0/en/charset.html):

> The default MySQL server character set and collation are `utf8mb4` and `utf8mb4_0900_ai_ci`, but you can specify character sets at the server, database, table, column, and string literal levels.

Example of a problem when using `utf8mb4_unicode_ci` with MySQL v8: https://x.com/reinink/status/1265349317314969605?s=20


