### PR TITLE
Revert "Fix incorrect collation for MySQL 8"

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_0900_ai_ci',
+            'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,


### PR DESCRIPTION
Reverts laravel/laravel#6239

It seems this collation is not supported for MariaDB:  
https://mariadb.com/kb/en/supported-character-sets-and-collations/

I also tested it with Laravel Sail + MariaDB and it doesn't work:

![Screenshot 2023-09-15 at 16 22 29](https://github.com/laravel/laravel/assets/15707543/f376876f-2b62-45da-80c4-99d2eab7a101)

In the original PR, @binaryfire asked if it possible to add a new config section for mariadb.
