### PR TITLE
[10.x] Let database handle default collation

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => null,
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,


### PR DESCRIPTION
I tested with Laravel Sail both MySQL and MariaDB both seem to accept the null value and then each use their own default collation.

Here  what I did:

<details><summary>MySQL</summary>
<p>

```
laravel new mysql-collation-test
cd mysql-collation-test

# Edit config/database.php and update collation in mysql to null

php artisan sail:insall
# Select only MySQL

sail up

# In another terminal
sail artisan migrate
sail artisan db

# SQL Command for showing collation defaults
SHOW VARIABLES LIKE 'collation%';
```

Result:

```
+----------------------+--------------------+
| Variable_name        | Value              |
+----------------------+--------------------+
| collation_connection | utf8mb4_0900_ai_ci |
| collation_database   | utf8mb4_0900_ai_ci |
| collation_server     | utf8mb4_0900_ai_ci |
+----------------------+--------------------+
3 rows in set (0.00 sec)
```

</p>
</details> 


<details><summary>MariaDB</summary>
<p>

```
laravel new mariadb-collation-test
cd mariadb-collation-test

# Edit config/database.php and update collation in mysql to null

php artisan sail:insall
# Select only MariaDB

sail up

# In another terminal
sail artisan migrate
sail artisan db

# SQL Command for showing collation defaults
SHOW VARIABLES LIKE 'collation%';
```

Result:
```
+----------------------+--------------------+
| Variable_name        | Value              |
+----------------------+--------------------+
| collation_connection | utf8mb4_general_ci |
| collation_database   | utf8mb4_general_ci |
| collation_server     | utf8mb4_general_ci |
+----------------------+--------------------+
3 rows in set (0.00 sec)
```

</p>
</details> 

You can so configure your defaults outside of Laravel if wanted, while still having the option to explicitly set a default for your application.


Risks:
- You have upgraded your Database and may have not updated your default collation. This could result in unexpected behaviour.
- Different collations between development / production environments

Alternative: Duplicate the mysql entry to mariadb and then change the default collation.
- Remaining TODOS: Update Docs and Sail installation for MariaDB
- while this is not a breaking change for existing applications, some developers may be confused if mysql is suddenly changed to mariadb

@binaryfire does this solution also work in your case?