### PR TITLE
[10.x] Increase bcrypt rounds to 12

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -29,7 +29,7 @@ return [
     */
 
     'bcrypt' => [
-        'rounds' => env('BCRYPT_ROUNDS', 10),
+        'rounds' => env('BCRYPT_ROUNDS', 12),
     ],
 
     /*


### PR DESCRIPTION
[PHP is increasing the default bcrypt cost](https://wiki.php.net/rfc/bcrypt_cost_2023) to either 11 or 12 to keep up with increases in computing, so we should do the same within Laravel. The current default of 10 was set in PHP 11 years ago, which is no longer a suitable default.

12 appears to be the sweet spot between performance and security, [as confirmed by a member of the Hashcat team](https://phpc.social/@tychotithonus@infosec.exchange/111104389164750098). [Symfony uses a cost of 13](https://github.com/symfony/password-hasher/blob/6.3/Hasher/NativePasswordHasher.php#L36C1-L37C1), however that may be too high for some servers.

Due to the way hashing works, there are no backwards compatibility issues - older passwords with lower rounds will still be handled properly, and code that automatically rehashes passwords will upgrade them over time. It's also worth pointing out that since rounds are defined in `config/hashing.php`, existing projects won't automatically get the new rounds cost and thus won't have any performance impacts. [The RFC contains hash calculation timings](https://wiki.php.net/rfc/bcrypt_cost_2023) if you'd like more information on the impacts.

Increasing rounds to 12 in `config/hashing.php` should be a recommended upgrade step for Laravel 11 (and possibly added to the guide for 10?).

Framework PR: https://github.com/laravel/framework/pull/48494