### PR TITLE
[10.x] Add `:8000` to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null


### PR DESCRIPTION
"Why not enhance Laravel experience by including `:8000` to the `APP_URL=http://localhost` configuration? 
After all, these settings are conveniently provided as default values in the .env.example file."