### PR TITLE
[10.x] Fix typo in the comment for token prefix (sanctum config)

### DIFF
--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -53,9 +53,9 @@ return [
     | Token Prefix
     |--------------------------------------------------------------------------
     |
-    | Sanctum can prefix new tokens in order to take advantage of various
-    | security scanning initiaives maintained by open source platforms
-    | that alert developers if they commit tokens into repositories.
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
     |
     | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
     |


### PR DESCRIPTION
This pull request fixes a simple typo in a recently added comment, as well as change some other words in order to not break the secret rule.