### PR TITLE
[11.x] Fixes build of `dev-master`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,14 @@
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^11.0",
-        "laravel/sanctum": "dev-develop",
-        "laravel/tinker": "dev-develop"
+        "laravel/sanctum": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "dev-develop",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^7.0",
+        "nunomaduro/collision": "^8.0",
         "phpunit/phpunit": "^10.1"
     },
     "autoload": {


### PR DESCRIPTION
This pull request fixes build of `dev-master`, and removes tinker for now, while Symfony 7 is not supported on Tinker.