### PR TITLE
Set default broadcast driver to 'log' in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,7 @@
         <!-- <env name="DB_DATABASE" value=":memory:"/> -->
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="BROADCAST_DRIVER" value="log"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
     </php>


### PR DESCRIPTION
Prevents events being pushed to a live broadcast driver when running tests.
In case a different broadcast driver is set in .env