### PR TITLE
[10.x] Hash improvements

### DIFF
--- a/config/hashing.php
+++ b/config/hashing.php
@@ -30,6 +30,7 @@ return [
 
     'bcrypt' => [
         'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => true,
     ],
 
     /*
@@ -47,6 +48,7 @@ return [
         'memory' => 65536,
         'threads' => 1,
         'time' => 4,
+        'verify' => true,
     ],
 
 ];


### PR DESCRIPTION
Proposing we make the algorithm check on by default for new applications. This means an exception will be thrown when checking a hash against a driver that did not create the hash.

<img width="704" alt="Screenshot 2023-10-23 at 11 12 27 am" src="https://github.com/laravel/laravel/assets/24803032/53952a96-2282-4dbc-8535-371666b3926b">

If an application decides to change hashing algorithm, then this can be turned off, however I feel having it on is the sensible and expected default.