### PR TITLE
[10.x] Update minimum `laravel/sanctum`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
-        "laravel/sanctum": "^3.2",
+        "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8"
     },
     "require-dev": {


### PR DESCRIPTION
PR #6234 updated the configuration but it depends on Sanctum 3.3. This PR avoids installing Sanctum 3.2 with the new config.