### PR TITLE
Redis maintenance store config example contains an excess space

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -141,7 +141,7 @@ return [
 
     'maintenance' => [
         'driver' => 'file',
-        // 'store'  => 'redis',
+        // 'store' => 'redis',
     ],
 
     /*


### PR DESCRIPTION
Binary operators should be surrounded by space a single space.