### PR TITLE
[10.x] Add suggestion to enable AddLinkHeadersForPreloadedAssets middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        // \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
     ];
 
     /**


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/44096 the `AddLinkHeadersForPreloadedAssets` middleware was added. It might provide a small performance bonus over using just the html headers when enabled. Therefore I propose to add it as a hint to the skeleton so people are more aware of it (I only encountered it while explicitly looking for this feature, which I doubt too many will do).

An alternative might be to even enable it by default within the skeleton, as I see basically no downsides to enabling it.

Note: I think this should be in the global stack, but possibly the `web` stack might be more appropriate.