### PR TITLE
[10.x] Fixes missing property description

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
-     * The current password being used for the factory.
+     * The current password being used by the factory.
      */
     protected static ?string $password;
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -11,6 +11,9 @@ use Illuminate\Support\Str;
  */
 class UserFactory extends Factory
 {
+    /**
+     * The current password being used for the factory.
+     */
     protected static ?string $password;
 
     /**


### PR DESCRIPTION
This pull request adds a property description to the new `password` property on user's factory. The reason is simply to ensure consistency that all properties have a comment.