### PR TITLE
[slim-skeleton-11.x] Adds `abstract` keyword on Controller class

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-class Controller
+abstract class Controller
 {
     //
 }


### PR DESCRIPTION
This pull request adds the `abstract` keyword on Controller class for Laravel 11.x.