### PR TITLE
[slim-skeleton-11.x] Uses generic annotation for `User::casts` return type 

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,8 @@ class User extends Authenticatable
 
     /**
      * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
     protected function casts(): array
     {


### PR DESCRIPTION
This pull request uses generic annotation for `User::casts` return type. It's just to be consistent with the rest of the skeleton + starter kits that are all of them using this type of return type in arrays.