### PR TITLE
add support for DB_SCHEMA environment variable for PostgreSQL databases

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -74,7 +74,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'search_path' => 'public',
+            'search_path' => env('DB_SCHEMA', 'public'),
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
PostgreSQL supports the use of schemas within the same database.
To use different schemas, 'search_path' needs to be set.
Laravel default configuration sets 'search_path' to 'public', and any change to the schema requires a change in this file.

With this update, the schema can be defined using a DB_SCHEMA environment variable.