### PR TITLE
Default mysql storage engine

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -54,10 +54,10 @@ return [
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
-            'prefix' => 'InnoDB',
+            'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB',
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],

--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
-            'prefix' => '',
+            'prefix' => 'InnoDB',
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,


### PR DESCRIPTION
Some versions of mysql, even though they support InnoDB, have the MyISAM storage system by default, so we always have to set the engine to InnoDB in these cases.
I added the InnoDB engine as a default for MySQL.