### PR TITLE
Use `assertOk()` instead of `assertStatus(200)` in tests

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 }


### PR DESCRIPTION
I think it's a better way for Laravel 11.x concepts