### PR TITLE
Add test to prove TrimStrings and ConvertEmptyStringsToNull leak memory

### DIFF
--- a/tests/Feature/MemoryLeakTest.php
+++ b/tests/Feature/MemoryLeakTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\TrimStrings;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Tests\TestCase;
+
+class MemoryLeakTest extends TestCase
+{
+    private const int NUMBER_OF_ITERATIONS = 100000;
+
+    public function testItDoesntRunOutOfMemory(): void
+    {
+        for ($i = 0; $i < self::NUMBER_OF_ITERATIONS; $i++) {
+            $kernel = $this->app->make(HttpKernel::class);
+
+            TrimStrings::skipWhen(fn (): bool => false);
+            ConvertEmptyStringsToNull::skipWhen(fn (): bool => false);
+
+            $kernel->terminate(new Request(), new Response());
+        }
+    }
+}


### PR DESCRIPTION
Running `php -d memory_limit={low memory limit like 25M} vendor/bin/phpunit tests/Feature/MemoryLeakTest.php` will result in the test running out of memory without a fix.