### PR TITLE
[11.x] Fixes tests failing due database not available

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_STORE" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->


### PR DESCRIPTION
This pull request fixes the tests failing due the following error:

```
1) Tests\Feature\ExampleTest::test_the_application_returns_a_successful_response
Illuminate\Database\QueryException: SQLSTATE[HY000] [2002] Connection refused (Connection: mysql, SQL: select * from `cache` where `key` = laravel_cache_illuminate:foundation:down limit 1)
```

Replaces https://github.com/laravel/laravel/pull/6296.