### PR TITLE
[11.x] Uses `CACHE_STORE` instead of `CACHE_DRIVER`

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,7 +20,7 @@
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
+        <env name="CACHE_STORE" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
         <!-- <env name="DB_DATABASE" value=":memory:"/> -->
         <env name="MAIL_MAILER" value="array"/>


### PR DESCRIPTION
This pull request fixes `phpunit.xml`'s environment variable, as we are now using `CACHE_STORE` instead of `CACHE_DRIVER`.