### PR TITLE
[10.x] Reverts `assertOk` change

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertOk();
+        $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
This pull request puts back the `assertStatus(200)` for the simply fact that `assertStatus(200)` speaks to all developers, while `assertOk` is Laravel specific. Also, if we were to `assertOk`, all the stubs (including ones used on starter kits) need to be updated.