### PR TITLE
[11.x] Bumps versions on `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,17 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^11.0",
         "laravel/tinker": "dev-develop"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.9.1",
-        "laravel/pint": "^1.0",
+        "fakerphp/faker": "^1.23",
+        "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
-        "mockery/mockery": "^1.4.4",
+        "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^10.1"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "^1.6.1",
-        "laravel-vite-plugin": "^1.0.0",
-        "vite": "^5.0.0"
+        "axios": "^1.6",
+        "laravel-vite-plugin": "^1.0",
+        "vite": "^5.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "^1.6",
+        "axios": "^1.6.3",
         "laravel-vite-plugin": "^1.0",
         "vite": "^5.0"
     }


### PR DESCRIPTION
This pull request concerns L11, and updates all versions in `composer.json` for aesthetic reasons. Primarily to display the latest versions of those packages in the `composer.json` file.

In addition, it *always* use the pattern `Major.Minor` for all requirements. I've kept 1.6.3 for `axios`, because: https://github.com/laravel/laravel/pull/6306.