### PR TITLE
[11.x] Simplify PHP comments

### DIFF
--- a/artisan
+++ b/artisan
@@ -5,29 +5,19 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 define('LARAVEL_START', microtime(true));
 
-/*
-|--------------------------------------------------------------------------
-| Register The Auto Loader
-|--------------------------------------------------------------------------
-|
-| Composer provides a convenient, automatically generated class loader for
-| this application. We just need to utilize it! We'll simply require it
-| into the script here so we don't need to manually load our classes.
-|
-*/
+/**
+ * Composer provides a convenient, automatically generated class loader for
+ * this application. We just need to utilize it! We'll simply require it
+ * into the script here so we don't need to manually load our classes.
+ */
 
 require __DIR__.'/vendor/autoload.php';
 
-/*
-|--------------------------------------------------------------------------
-| Run The Artisan Application
-|--------------------------------------------------------------------------
-|
-| When we run the console application, the current CLI command will be
-| executed by an Artisan command and the exit code is given back to
-| the caller. Once the command is handled, the script terminates.
-|
-*/
+/**
+ * When we run the console application, the current CLI command will be
+ * executed by an Artisan command and the exit code is given back to
+ * the caller. Once the command is handled, the script terminates.
+ */
 
 $app = require_once __DIR__.'/bootstrap/app.php';
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,16 +4,11 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
-/*
-|--------------------------------------------------------------------------
-| Create The Application
-|--------------------------------------------------------------------------
-|
-| The first thing we will do is create a new Laravel application instance
-| which serves as the brain for all of the Laravel components. We will
-| also use the application to configure core, foundational behavior.
-|
-*/
+/**
+ * The first thing we will do is create a new Laravel application instance
+ * which serves as the brain for all of the Laravel components. We will
+ * also use the application to configure core, foundational behavior.
+ */
 
 return Application::configure()
     ->withProviders()

--- a/public/index.php
+++ b/public/index.php
@@ -4,44 +4,30 @@ use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
 
-/*
-|--------------------------------------------------------------------------
-| Check If The Application Is Under Maintenance
-|--------------------------------------------------------------------------
-|
-| If the application is in maintenance / demo mode via the "down" command
-| we will load this file so that any pre-rendered content can be shown
-| instead of starting the framework, which could cause an exception.
-|
-*/
+/**
+ * If the application is in maintenance / demo mode via the "down" command
+ * we will load this file so that any pre-rendered content can be shown
+ * instead of starting the framework, which could cause an exception.
+ */
 
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;
 }
 
-/*
-|--------------------------------------------------------------------------
-| Register The Auto Loader
-|--------------------------------------------------------------------------
-|
-| Composer provides a convenient, automatically generated class loader for
-| this application. We just need to utilize it! We'll simply require it
-| into the script here so we don't need to manually load our classes.
-|
-*/
+/**
+ *
+ * Composer provides a convenient, automatically generated class loader for
+ * this application. We just need to utilize it! We'll simply require it
+ * into the script here so we don't need to manually load our classes.
+ */
 
 require __DIR__.'/../vendor/autoload.php';
 
-/*
-|--------------------------------------------------------------------------
-| Run The Application
-|--------------------------------------------------------------------------
-|
-| Once we have the application, we can handle the incoming request using
-| the application's HTTP kernel. Then, we will send the response back
-| to this client's browser, allowing them to enjoy our application.
-|
-*/
+/**
+ * Once we have the application, we can handle the incoming request using
+ * the application's HTTP kernel. Then, we will send the response back
+ * to this client's browser, allowing them to enjoy our application.
+ */
 
 $app = require_once __DIR__.'/../bootstrap/app.php';
 

--- a/public/index.php
+++ b/public/index.php
@@ -15,7 +15,6 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 }
 
 /**
- *
  * Composer provides a convenient, automatically generated class loader for
  * this application. We just need to utilize it! We'll simply require it
  * into the script here so we don't need to manually load our classes.

--- a/routes/console.php
+++ b/routes/console.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Schedule;
  * commands. Each Closure is bound to a command instance allowing a
  * simple approach to interacting with each command's IO methods.
  */
-
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
@@ -19,5 +18,4 @@ Artisan::command('inspire', function () {
  * or system commands. These tasks will be run automatically when due
  * using Laravel's built-in "schedule:run" Artisan console command.
  */
-
 Schedule::command('inspire')->hourly();

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,20 +2,7 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Schedule;
 
-/**
- * This file is where you may define all of your Closure based console
- * commands. Each Closure is bound to a command instance allowing a
- * simple approach to interacting with each command's IO methods.
- */
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
-
-/**
- * Below you may define your scheduled tasks, including console commands
- * or system commands. These tasks will be run automatically when due
- * using Laravel's built-in "schedule:run" Artisan console command.
- */
-Schedule::command('inspire')->hourly();
+})->purpose('Display an inspiring quote')->hourly();

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,30 +4,20 @@ use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 
-/*
-|--------------------------------------------------------------------------
-| Console Commands
-|--------------------------------------------------------------------------
-|
-| This file is where you may define all of your Closure based console
-| commands. Each Closure is bound to a command instance allowing a
-| simple approach to interacting with each command's IO methods.
-|
-*/
+/**
+ * This file is where you may define all of your Closure based console
+ * commands. Each Closure is bound to a command instance allowing a
+ * simple approach to interacting with each command's IO methods.
+ */
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-/*
-|--------------------------------------------------------------------------
-| Console Schedule
-|--------------------------------------------------------------------------
-|
-| Below you may define your scheduled tasks, including console commands
-| or system commands. These tasks will be run automatically when due
-| using Laravel's built-in "schedule:run" Artisan console command.
-|
-*/
+/**
+ * Below you may define your scheduled tasks, including console commands
+ * or system commands. These tasks will be run automatically when due
+ * using Laravel's built-in "schedule:run" Artisan console command.
+ */
 
 Schedule::command('inspire')->hourly();

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,16 +2,11 @@
 
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded within the "web" middleware group which includes
-| sessions, cookie encryption, and more. Go build something great!
-|
-*/
+/**
+ * Here is where you can register web routes for your application. These
+ * routes are loaded within the "web" middleware group which includes
+ * sessions, cookie encryption, and more. Go build something great!
+ */
 
 Route::get('/', function () {
     return view('welcome');

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Route;
  * routes are loaded within the "web" middleware group which includes
  * sessions, cookie encryption, and more. Go build something great!
  */
-
 Route::get('/', function () {
     return view('welcome');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,6 @@
 
 use Illuminate\Support\Facades\Route;
 
-/**
- * Here is where you can register web routes for your application. These
- * routes are loaded within the "web" middleware group which includes
- * sessions, cookie encryption, and more. Go build something great!
- */
 Route::get('/', function () {
     return view('welcome');
 });


### PR DESCRIPTION
Hi everyone! This pull request proposes a small change the PHP comments in our skeleton. They've been around for a while, and we're all pretty used to them. But, I'm curious about your thoughts on reshaping our docs to align more with the style used in "laravel/framework:" (and in any other repository really), while simultaneously do the three-character rule.

Here is an example:

<img width="1512" alt="Screenshot 2024-01-11 at 17 27 08" src="https://github.com/laravel/laravel/assets/5457236/63b6c8b0-85c2-4d25-97e9-56ca8e1d00e7">


Not that, I am not fully convinced; however, if this pull request gets merged, I will go around to the other repositories and adjust the PHP comments accordingly via PR.