### PR TITLE
[10.x] Don't install unnecessary symfony polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,20 @@
         "phpunit/phpunit": "^10.1",
         "spatie/laravel-ignition": "^2.0"
     },
+    "replace": {
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-mbstring": "*",
+        "symfony/polyfill-php54": "*",
+        "symfony/polyfill-php55": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php73": "*",
+        "symfony/polyfill-php74": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "app/",


### PR DESCRIPTION
At the time of writing, when creating a fresh Laravel app the following symfony polyfill packages end up being installed:

* `symfony/polyfill-ctype`
* `symfony/polyfill-intl-grapheme`
* `symfony/polyfill-intl-idn`
* `symfony/polyfill-intl-normalizer`
* `symfony/polyfill-mbstring`
* `symfony/polyfill-php72`
* `symfony/polyfill-php80`
* `symfony/polyfill-php83`
* `symfony/polyfill-uuid`

The project's `composer.json` requires a minimum of PHP 8.1, and according to https://laravel.com/docs/10.x/deployment#server-requirements both the `ctype` and the `mbstring` extension are required, meaning that there is no need to polyfill those extensions or PHP <= 8.1. The others should continue to be polyfilled.

For the PHP version polyfills, we could just just add the `php72` and `php80` polyfills to the `"replace"` section, as they are the only ones that end up being installed on a fresh project, but that felt incomplete and also doesn't future proof for the future when installing a new package that happens to pull in e.g. `polyfill-php56` which would be installed if we didn't explicitly add it here.

From https://github.com/symfony/polyfill#design:

> If your project requires a minimum PHP version it is advisable to add polyfills for lower PHP versions to the replace section of your `composer.json`. This removes any overhead from these polyfills as they are no longer part of your project. The same can be done for polyfills for extensions that you require.