### PR TITLE
ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /public/storage
 /storage/*.key
 /vendor
+composer.lock
 .env
 .env.backup
 .env.production


### PR DESCRIPTION
When cloning the repository and performing a composer update, the composer.lock file is included in the pull request submission for the project.