### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+/composer.lock
+/package-lock.json


### PR DESCRIPTION
We don't require these two lines with fresh Laravel. even not from anyone. We need the versions that match with our system. so, that we don't face difference problems before setup laravel sail and so on