### PR TITLE
[x10] [x11] Ignore DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+**/.DS_Store


### PR DESCRIPTION
With this configuration, Git will ignore `.DS_Store` files anywhere within the Laravel project. This would be immensely helpful for those of us working on Macs.