### PR TITLE
Vite config HMR Hostname Update

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,23 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
-export default defineConfig({
-    plugins: [
-        laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
-            refresh: true,
-        }),
-    ],
+export default defineConfig(({ mode }) => {
+    // Load env file based on `mode` (dev, serve or build) in the current working directory.
+    // Set the 3rd parameter to '' to load all env variables regardless of the `VITE_` prefix.
+    const env = loadEnv(mode, process.cwd(), '')
+    const host = env.APP_URL.match(/\/\/([\w.]+)/)[1]
+
+    return {
+        server: {
+            hmr: {
+                host,
+            },
+        },
+        plugins: [
+            laravel({
+                input: ['resources/css/app.css', 'resources/js/app.js'],
+                refresh: true,
+            }),
+        ],
+    }
 });


### PR DESCRIPTION
This updates the default vite.config file to use the defined APP_URL (from the appropriate .env file, depending on what 'mode' the app is set up to use) as the HMR hostname.

I use Laravel in a dockerised setup (specifically, Laradock), and HMR requests always fail without this.

Hosts also need to be exposed via --hosts, i.e. `npx vite --hosts`