### PR TITLE
[11.x] Use list instead of array<int, string>

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $fillable = [
         'name',
@@ -25,7 +25,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $hidden = [
         'password',


### PR DESCRIPTION
Instead of writing `array<int, Type>` one can take advantage of `list<Type>` if index is starting at 0 (like if the index is generated automatically).

This is both supported by [PHPStan](https://phpstan.org/writing-php-code/phpdoc-types#lists) and [Psalm](https://psalm.dev/docs/annotating_code/type_syntax/array_types/#lists).