### PR TITLE
propose database seeder change

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,9 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+
+        // $this->call([
+            //
+        //]);
     }
 }


### PR DESCRIPTION
In 7+ Years working with Laravel, there are no projects that I see without the `call` method in the database seeder, and in many cases, this is the only method invoked.

This PR adds a comment to make this as easy to use as the `User` factory comment that is added as some kind of boilerplate.