### PR TITLE
[11.x] Remove laravel sail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require-dev": {
         "fakerphp/faker": "^1.23",
         "laravel/pint": "^1.13",
-        "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
         "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Now that we have herd for mac and windows, I think that this is the easiest way to create a local environment.

If you still prefer docker you can still install sail via composer (I wonder how many people actually use docker...)
