### PR TITLE
AllowLanguages middleware

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -9,4 +9,9 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;
+
+    public function allowLanguages() : array
+    {
+        return ['en', 'ar'];
+    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,7 +10,7 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;
 
-    public function allowLanguages() : array
+    public function allowLanguages(): array
     {
         return ['en', 'ar'];
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'allow.languages' => \App\Http\Middleware\AllowLanguages::class,
     ];
 }

--- a/app/Http/Middleware/AllowLanguages.php
+++ b/app/Http/Middleware/AllowLanguages.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AllowLanguages
 {
     private $controller;
-    
+
     public function __construct(Controller $controller)
     {
         $this->controller = $controller;
@@ -23,10 +23,10 @@ class AllowLanguages
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $default_lang_code  =   app()->getLocale() ?? 'en';
-        $language_allowed   =   $this->controller->allowLanguages();
-        $language           =   request()->header()['x-language'][0] ?? $default_lang_code;
-        $language           =   in_array($language, $language_allowed) ? $language : $default_lang_code;
+        $default_lang_code = app()->getLocale() ?? 'en';
+        $language_allowed = $this->controller->allowLanguages();
+        $language = request()->header()['x-language'][0] ?? $default_lang_code;
+        $language = in_array($language, $language_allowed) ? $language : $default_lang_code;
         app()->setLocale($language);
 
         return $next($request);

--- a/app/Http/Middleware/AllowLanguages.php
+++ b/app/Http/Middleware/AllowLanguages.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Controllers\Controller;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AllowLanguages
+{
+    private $controller;
+    
+    public function __construct(Controller $controller)
+    {
+        $this->controller = $controller;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $default_lang_code  =   app()->getLocale() ?? 'en';
+        $language_allowed   =   $this->controller->allowLanguages();
+        $language           =   request()->header()['x-language'][0] ?? $default_lang_code;
+        $language           =   in_array($language, $language_allowed) ? $language : $default_lang_code;
+        app()->setLocale($language);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
The AllowLanguages middleware dynamically sets the application's language based on the request's preferred language.
It retrieves the allowed languages from the controller and checks the request's x-language header to determine the language to use.
If the requested language is allowed, it sets the application's locale to that language; otherwise, it defaults to the default language.