### PR TITLE
[11.x] allow to set stack channels using environment variable

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -54,7 +54,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => explode(',', env('LOG_STACK_CHANNELS', 'single')),
             'ignore_exceptions' => false,
         ],
 


### PR DESCRIPTION
This PR adds a `LOG_STACK_CHANNELS` environment variable to set the stack logging channels.