### PR TITLE
Add validation rules directly to model for consistency

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,4 +44,18 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    /**
+     * Get the rules for the model.
+     *
+     * @return array<string, string>
+     */
+    public static function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:4'],
+        ];
+    }
 }


### PR DESCRIPTION
Adding validation rules directly to the model helps make the validation rules consistent throughout the application.

Developers can access the rules faster using the `rules()` method and from a single code base rather than update all the validation rules in their entire application.

This method would be used like so:

```php
use App\Models\User;
use Illuminate\Support\Facades\Validator;

$validated = Validator::make([
    'name' => 'John Smith',
    'email' => 'user@example.com',
    'password' => 'secret',
], User::rules());
```

Or using the request method if the keys are consistent

```php
  $validated = $request->validate(User::rules());
  ```

Optionally, validation can be added to the saving event for models if the rules function is present to validate the input before its stored to the database. However, this would be a more forced approach.