### PR TITLE
Removes Axios Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
         "dev": "vite",
         "build": "vite build"
     },
-    "devDependencies": {
-        "axios": "^1.6.4",
+    "devDependencies": {        
         "laravel-vite-plugin": "^1.0",
         "vite": "^5.0"
     }

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,1 @@
-import axios from 'axios';
-window.axios = axios;
 
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,1 +1,1 @@
-
+// import packages that are needed in the application


### PR DESCRIPTION
Removed the Axios dependency from package.json as well as the Axios code from bootstrap.js. Thought that they're not needed for a fresh project especially if the project is going to be built using the TALL stack. 