### PR TITLE
[11.x] Make meta color scheme follow user theme preference

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="dark white">
 
         <title>Laravel</title>
 


### PR DESCRIPTION
Minor contribution here! I think we should use color scheme to suit the user's theme preferences. In this case, for the welcome view, if user prefers dark, scrollbar will be dark.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/laravel/laravel/assets/60661635/1e15d86f-2365-44c6-ba90-cb0ea7fcf647" width="700">  | <img src="https://github.com/laravel/laravel/assets/60661635/0d68122a-3af0-4440-89fb-361aaecd7385" width="700">  |
