### PR TITLE
[11.x] Add missing roundrobin transport driver config

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -82,6 +82,14 @@ return [
             ],
         ],
 
+        'roundrobin' => [
+            'transport' => 'roundrobin',
+            'mailers' => [
+                'ses',
+                'postmark',
+            ],
+        ],
+
     ],
 
     /*

--- a/config/session.php
+++ b/config/session.php
@@ -125,7 +125,6 @@ return [
     | the framework. Typically, you should not need to change this value
     | since doing so does not grant a meaningful security improvement.
     |
-    |
     */
 
     'cookie' => env(


### PR DESCRIPTION
Looks like this got missed during the slimming exercise - see PR #6301 from `10.x`

If it's been purposely omitted, `roundrobin` is still mentioned in the comment.

https://github.com/laravel/laravel/blob/708fdb1a36fd4567a2b7fd7557436536005fe4d2/config/mail.php#L33