### PR TITLE
Added the color-scheme meta tag to get dark scrollbars when using prefers-color-scheme: dark

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="light dark">
 
         <title>Laravel</title>
 


### PR DESCRIPTION
Currently, on the Laravel welcome page, when using dark mode (prefers-color-scheme: dark), on some systems, like Windows, the scrollbar uses its default theme (light):

![current](https://github.com/laravel/laravel/assets/45177590/67fc6aa6-d767-468c-863b-7cbaf936a96b)

But it is possible, using the color-scheme meta tag, to make it use a dark themed scrollbar when prefers-color-scheme: dark is set, usually by the system when using dark mode, resulting in this which in my opninion makes the welcome page look much better

![fixed](https://github.com/laravel/laravel/assets/45177590/fa9e5a88-b866-4749-af27-630f0fbe426a)

Of course, when using prefers-color-scheme: light, the scrollbar turns white again

If necessary i can PR this changes to other starter kit stubs, like Breeze or Jetstream, i dont know if the new welcome page is being used in any other repository

Thanks!
