### PR TITLE
Add missing Markdown Mail Settings

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -113,4 +113,23 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Markdown Mail Settings
+    |--------------------------------------------------------------------------
+    |
+    | If you are using Markdown based email rendering, you may configure your
+    | theme and component paths here, allowing you to customize the design
+    | of the emails. Or, you may simply stick with the Laravel defaults!
+    |
+    */
+
+    'markdown' => [
+        'theme' => env('MAIL_MARKDOWN_THEME', 'default'),
+
+        'paths' => [
+            resource_path('views/vendor/mail'),
+        ],
+    ],
+
 ];


### PR DESCRIPTION
> _Not sure why some stuff was removed like the Markdown stuff._

I guess by [the above comment](https://github.com/laravel/framework/pull/51382#issuecomment-2108312123) it wasn't intentional to remove the Markdown settings during the [L11 slimming exercise](https://github.com/laravel/laravel/commit/f437205#diff-af6ac21d51218ff8f16692c0c8a9bf2fb420d3cc0de12458049dd1ed9c5ec244L121-L139).

This PR re-adds the settings.

