### PR TITLE
Updated SMTP mail config to use a valid EHLO domain

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -46,7 +46,7 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'local_domain' => env('MAIL_EHLO_DOMAIN'),
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 
         'ses' => [


### PR DESCRIPTION
Hi,

It took me forever to figure out what's suddenly wrong with my Google SMTP Relay service mail sending. After a few hours on Google support and additional googling I came across this, and it actually works:

[Laracasts forum subject](https://laracasts.com/discuss/channels/laravel/laravel-incorrectly-handling-ehlo-for-smtp-from-artisancli-issues-with-gmails-smtp-relay-resolved)

Pretty much other clients disregard this and only Google takes it into account (don't know why tho).

Without it you receive something like this when trying to send mail:
```
Expected response code "250" but got code "421", with message "421-4.7.0 Try again later, closing connection. (EHLO)
421-4.7.0  For more information, go to
421 4.7.0  https://support.google.com/a/answer/3221692 ffacd0b85a97d-3502bbc50d2sm584496f8f.87 - gsmtp
```