### PR TITLE
Use str helper function for app locale formatting

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str(app()->getLocale())->replace('_', '-') }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This PR replaces the use of `str_replace()` for formatting the app locale in `welcome.blade.php` with the `str` helper / strings API version.