### PR TITLE
Updating BCRYPTS ROUNDS from 4 to 12 in phpunit.xml file

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,7 +20,7 @@
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BCRYPT_ROUNDS" value="12"/>
         <env name="CACHE_STORE" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
         <!-- <env name="DB_DATABASE" value=":memory:"/> -->


### PR DESCRIPTION
I am updated one of my project from 10.x to 11.x and after updating everything works fine except pest tests.
Pest tests are failing with error mentioned in screen shot
 
![image](https://github.com/laravel/laravel/assets/49219252/13bc8cd5-9b75-4082-b6a3-db474e001d37)

and I found a solution on internet that there is mismatch in BCRYPTS_ROUNDS in .env.example and phpunit.xml and that  difference is still in 11.x branch and because of that difference pest test cases are failing and that's why I  am submitting  this pull request.

