### PR TITLE
Format the first letter of `drivers`  to lowercase

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -24,7 +24,7 @@ return [
     | may even configure multiple disks for the same driver. Examples for
     | most supported storage drivers are configured here for reference.
     |
-    | Supported Drivers: "local", "ftp", "sftp", "s3"
+    | Supported drivers: "local", "ftp", "sftp", "s3"
     |
     */
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -45,7 +45,7 @@ return [
     | utilizes the Monolog PHP logging library, which includes a variety
     | of powerful log handlers and formatters that you're free to use.
     |
-    | Available Drivers: "single", "daily", "slack", "syslog",
+    | Available drivers: "single", "daily", "slack", "syslog",
     |                    "errorlog", "monolog", "custom", "stack"
     |
     */


### PR DESCRIPTION
I noticed that the word `Drivers` appears inconsistently in the config files' PHPDoc, sometimes as camel case and sometimes in lowercase.

For consistency, I changed all instances of `Drivers` to `drivers`.

---

Other occurrences of lowercase `drivers` can be found here:

https://github.com/laravel/laravel/blob/b6d55576d1c9fcf15adebc76bcb6d8cb476a4418/config/app.php#L117
https://github.com/laravel/laravel/blob/b6d55576d1c9fcf15adebc76bcb6d8cb476a4418/config/cache.php#L29
https://github.com/laravel/laravel/blob/b6d55576d1c9fcf15adebc76bcb6d8cb476a4418/config/queue.php#L102

