### PR TITLE
Unquote `null`

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -27,7 +27,7 @@ return [
     | same cache driver to group types of items stored in your caches.
     |
     | Supported drivers: "array", "database", "file", "memcached",
-    |                    "redis", "dynamodb", "octane", "null"
+    |                    "redis", "dynamodb", "octane", null
     |
     */
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -24,7 +24,7 @@ return [
     | used by your application. An example configuration is provided for
     | each backend supported by Laravel. You're also free to add more.
     |
-    | Drivers: "sync", "database", "beanstalkd", "sqs", "redis", "null"
+    | Drivers: "sync", "database", "beanstalkd", "sqs", "redis", null
     |
     */
 
@@ -99,7 +99,7 @@ return [
     | can control how and where failed jobs are stored. Laravel ships with
     | support for storing failed jobs in a simple file or in a database.
     |
-    | Supported drivers: "database-uuids", "dynamodb", "file", "null"
+    | Supported drivers: "database-uuids", "dynamodb", "file", null
     |
     */
 


### PR DESCRIPTION
- As it stands, [`session.php`](https://github.com/laravel/laravel/blob/4ef5e2f89e987f84b33b62f79e96485dcaa8f209/config/session.php#L197-L199) suggests `null` as an unquoted option.
- I realise I've updated suggested **driver** options but should they too be unquoted? Thought it was worth bringing to your attention for you to take a look. I may be wrong.

https://github.com/laravel/laravel/blob/4ef5e2f89e987f84b33b62f79e96485dcaa8f209/config/session.php#L197-L199
