### PR TITLE
Made require calls to app bootstrap cleaner

### DIFF
--- a/artisan
+++ b/artisan
@@ -9,7 +9,7 @@ define('LARAVEL_START', microtime(true));
 require __DIR__.'/vendor/autoload.php';
 
 // Bootstrap Laravel and handle the command...
-$status = (require_once __DIR__.'/bootstrap/app.php')
-    ->handleCommand(new ArgvInput);
+$app = (require_once __DIR__.'/bootstrap/app.php');
+$status = $app->handleCommand(new ArgvInput);
 
 exit($status);

--- a/public/index.php
+++ b/public/index.php
@@ -13,5 +13,5 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 require __DIR__.'/../vendor/autoload.php';
 
 // Bootstrap Laravel and handle the request...
-(require_once __DIR__.'/../bootstrap/app.php')
-    ->handleRequest(Request::capture());
+$app = (require_once __DIR__.'/../bootstrap/app.php');
+$app->handleRequest(Request::capture());


### PR DESCRIPTION
First time pull-requester on Laravel here. Thanks for the amazing work the team has done.

When using Prettier with https://github.com/prettier/plugin-php on my new Laravel 11.x project, I noticed that the formatting changes cause some errors.

**artisan**

```php
// artisan.php after formatting on L11
$status = require_once __DIR__ .
  ('/bootstrap/app.php')->handleCommand(new ArgvInput());

// formatting after this PR
$app = require_once __DIR__ . '/bootstrap/app.php';
$status = $app->handleCommand(new ArgvInput());
```

**public/index.php**

```php
// public/index.php after formatting on L18
require_once __DIR__ . '/../bootstrap/app.php'->handleRequest(
  Request::capture()
);

// formatting after this PR
$app = require_once __DIR__ . '/../bootstrap/app.php';
$app->handleRequest(Request::capture());
```

Following the formatting, the code is no longer the same, so I totally get that the argument here is with the parser for the Prettier plugin, but when I checked out why, I thought the code could be slightly improved.

As for the error, in both cases the resulting changes leave us trying to call a method on a string due to how the expression is evaluated.

I wanted to offer up this PR in case it would be considered useful. I understand some thought must have gone into this originally, and that you opted for shorter code, however if it confuses some parsers, and maybe some people, going the slightly more verbose way but cleaner way, may be worthwhile considering.