### PR TITLE
Slim composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,13 +53,11 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
         }
     },
-    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
There are fields in `composer.json` that have a default value. I think it would be better to remove them in order for the file to have fewer lines. The `minimum-stability` field is changed only when developing on the `master` branch.

See [preferred-install](https://getcomposer.org/doc/06-config.md#preferred-install) and [minimum-stability](https://getcomposer.org/doc/04-schema.md#minimum-stability).