### PR TITLE
[11.x] Add `limiter` cache configuration to `config/cache.php`

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'limiter' => env('LIMITER_CACHE_STORE'),
+    'limiter' => env('CACHE_LIMITER_STORE'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/cache.php
+++ b/config/cache.php
@@ -19,6 +19,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Rate Limiter Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the cache store that will be used by the rate limiter.
+    | This can be helpful if you want to separate the rate limiter cache from other
+    | cache data.
+    |
+    */
+
+    'limiter' => env('LIMITER_CACHE_STORE', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Stores
     |--------------------------------------------------------------------------
     |

--- a/config/cache.php
+++ b/config/cache.php
@@ -22,10 +22,9 @@ return [
     | Rate Limiter Cache Store
     |--------------------------------------------------------------------------
     |
-    | This option controls the cache store that will be used by the rate limiter.
-    | If this is not set, the default cache store will be used instead. This
-    | can be helpful if you want to separate the rate limiter cache from other
-    | cache data.
+    | Defines the cache store used specifically for rate limiting.
+    | If this option is not set, the default cache store will be used.
+    | This helps in isolating rate limiter data from other cache data.
     |
     */
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -22,9 +22,9 @@ return [
     | Rate Limiter Cache Store
     |--------------------------------------------------------------------------
     |
-    | Defines the cache store used specifically for rate limiting.
-    | If this option is not set, the default cache store will be used.
-    | This helps in isolating rate limiter data from other cache data.
+    | This option specifies the cache store for rate limiting operations. If this
+    | key is not set, the default cache store will be used. Useful for keeping
+    | rate limiter cache separate from other data for better organization.
     |
     */
 

--- a/config/cache.php
+++ b/config/cache.php
@@ -23,12 +23,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option controls the cache store that will be used by the rate limiter.
-    | This can be helpful if you want to separate the rate limiter cache from other
+    | If this is not set or null, the default cache store will be used instead. This
+    | can be helpful if you want to separate the rate limiter cache from other
     | cache data.
     |
     */
 
-    'limiter' => env('LIMITER_CACHE_STORE', 'database'),
+    'limiter' => env('LIMITER_CACHE_STORE', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/cache.php
+++ b/config/cache.php
@@ -23,13 +23,13 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option controls the cache store that will be used by the rate limiter.
-    | If this is not set or null, the default cache store will be used instead. This
+    | If this is not set, the default cache store will be used instead. This
     | can be helpful if you want to separate the rate limiter cache from other
     | cache data.
     |
     */
 
-    'limiter' => env('LIMITER_CACHE_STORE', null),
+    'limiter' => env('LIMITER_CACHE_STORE'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The `limiter` key is already utilized in the [source code](https://github.com/laravel/framework/blob/b18f33340ca5a691132bccb3ad5de59c7fbdfdd9/src/Illuminate/Cache/CacheServiceProvider.php#L34-L38) and referenced in the [documentation](https://github.com/laravel/docs/blob/0672b9354731561a93107f3ece894804fbd9dcc1/rate-limiting.md#cache-configuration), but it was missing from the `config/cache.php` configuration file. This omission can lead to confusion, especially for beginners.

**Changes**:
- Added the `limiter` key to `config/cache.php` with a clear description of its purpose.

**Benefits**:
- **Clarity**: Makes users aware of the `limiter` cache store configuration option.
- **Consistency**: Aligns the configuration file with the existing documentation and source code.
- **Ease of Use**: Simplifies the process of configuring a separate cache store for rate limiting.

This update makes the cache configuration easier to understand and use. Please review and merge this change to improve the setup for everyone. Thanks!