### PR TITLE
Remove axios due to high severity security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "^1.6.4",
         "laravel-vite-plugin": "^1.0",
         "vite": "^5.0"
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,1 @@
-import './bootstrap';
+

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,0 @@
-import axios from 'axios';
-window.axios = axios;
-
-window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';


### PR DESCRIPTION
Axios is a dangerous package to include by default.

Here is the latest NPM audit report:

```
# npm audit report

axios  >=1.3.2
Severity: high
Server-Side Request Forgery in axios - https://github.com/advisories/GHSA-8hc4-vh64-cxmj
fix available via `npm audit fix --force`
Will install axios@1.3.1, which is a breaking change
node_modules/axios

1 high severity vulnerability
```

We don't need axios, we can use native `fetch`.

This also cleans the `resources` folder, as the extra `bootstrap.js` file was always confusing. Now the `app.js` file is empty just like `app.css`.