### PR TITLE
Update welcome.blade.php

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,7 +8,7 @@
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet" />
+        <link href="https://fonts.bunny.net/css?family=figtree:400,600&display=swap" rel="stylesheet">
 
         <!-- Styles -->
         <style>


### PR DESCRIPTION
In modern web development, the HTML5 convention of omitting the self-closing slash (/>) is generally considered better practice.

Also, changed it for better consistency of the link tags, since the first tag is without `/` and the second tag was with `/`.