### PR TITLE
[11.x] fix: wrong redirect from POST to GET

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -10,6 +10,7 @@
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
     # Redirect Trailing Slashes If Not A Folder...
+    RewriteCond %{REQUEST_METHOD} =GET
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]


### PR DESCRIPTION
when I POST domain.com/api/v1/users it ok,
but when I POST domain.com/api/v1/users/ it alway redirect to GET domain.com/api/v1/users (without last slash), It crash my request.

I think feature `redirect Trailing Slashes If Not A Folder` should only work for GET method, not POST PUT PATCH DELETE

