### PR TITLE
Add AWS_ENDPOINT for SQS queue

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -60,6 +60,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'endpoint' => env('AWS_ENDPOINT'),
             'after_commit' => false,
         ],
 


### PR DESCRIPTION
- https://github.com/aws/aws-sdk-php/issues/2846
- https://github.com/aws/aws-sdk-php/issues/2947

After SQS migrated from query to JSON protocol, Laravel lost the ability to change the host with `SQS_PREFIX`.

To reproduce:

1. `composer require aws/aws-sdk-php`
2. set this in `.env`:
	```dotenv
    QUEUE_CONNECTION=sqs
	SQS_PREFIX=http://foobar/000000000000
	```
3. try to run a job, see this error (the endpoint is not overridden):
    ```
	Error executing "SendMessage" on "https://sqs.us-east-1.amazonaws.com";`
	```
	It worked fine with SDK <3.286.2:
	```
	composer require aws/aws-sdk-php:3.286.1
	```
	With 3.286.1 you see what you expect:
	```
	Error executing "SendMessage" on "http://foobar/000000000000/default"
	```

This PR adds a missing endpoint (see related issues for further explanation).