### PR TITLE
[11.x] Add PHPStan / Larastan

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,11 @@ use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    /**
+     * @use \Illuminate\Database\Eloquent\Factories\HasFactory<\Database\Factories\UserFactory>
+     */
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "larastan/larastan": "^2.9",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,18 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+
+    paths:
+        - app/
+
+    # Level 9 is the highest level
+    level: 7
+
+#    ignoreErrors:
+#        - '#PHPDoc tag @var#'
+#
+#    excludePaths:
+#        - ./*/*/FileToBeExcluded.php
+#
+#    checkMissingIterableValueType: false


### PR DESCRIPTION
I was surprised that the boilerplate application did not include PHPStan (Larastan) by default. We should point developers towards the right direction to write correct and working code, and this is one way that helps with that.

I also wanted to add the `routes/` directory to the `phpstan.neon` paths (since Laravel 11 people will now start dumping application code into these files as well, so it wouldn't be bad to have it included in the phpstan scan also), but it introduced an error with the current placeholder code in `routes/console.php`:

```php
Artisan::command('inspire', function () {
    $this->comment(Inspiring::quote());
})->purpose('Display an inspiring quote')->hourly();
```

The `$this` context is undefined here and I can't properly typehint it using phpstan.