### PR TITLE
[11.x] factory-generics-in-user-model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
+    /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
 
     /**


### PR DESCRIPTION
Based on this https://github.com/laravel/framework/pull/52005, we always need to add a generic notation to make PHPStan pass. 

If we can't add PHPStan, we should at least add a doc-block to ensure the code passes without issues. This will also help developers learn how to define it properly. Even though some may already know, I’ve received questions from a few developers on how to resolve this specific PHPStan error.

I'm simply adding the following in the `User` model:

```php
/** @use HasFactory<\Database\Factories\UserFactory> */
use HasFactory, Notifiable;
```