### PR TITLE
[11.x] Collision Version Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.0",
+        "nunomaduro/collision": "^8.1",
         "phpunit/phpunit": "^11.0.1"
     },
     "autoload": {


### PR DESCRIPTION
Laravel Upgrade Doc suggest to upgrade [nunomaduro/collision version to ^8.1](https://github.com/laravel/docs/blob/358fd26b3a81359b6e5f54d263f50083e82f525b/upgrade.md?plain=1#L74) but default laravel/laravel composer.json version is ^8.0. That's the reason i submitted this PR.

Thanks