### PR TITLE
Remove .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /public/storage
 /storage/*.key
 /vendor
+.DS_Store
 .env
 .env.backup
 .env.production


### PR DESCRIPTION
This pull request adds `.DS_Store` files to the `.gitignore` file to prevent unwanted macOS Finder metadata from being tracked in the repository. `.DS_Store` files are automatically generated by macOS to store folder metadata and are not relevant to the project. This update ensures these files are ignored across all directories.