### PR TITLE
Potential Issue fix in Laravel Command Registration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,6 +10,10 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        __DIR__.'/../routes/console.php',
+        __DIR__.'/../app/Console/Commands',
+    ])
     ->withMiddleware(function (Middleware $middleware) {
         //
     })


### PR DESCRIPTION
After applying the recent changes from Pull Request [#52867,](https://github.com/laravel/framework/pull/52867) I have encountered an issue with command registration in Laravel. Specifically, I observed that manually created commands, which were previously auto-registered and functioned as expected, are no longer recognized. For instance, when attempting to use commands in the message-broker namespace, I receive the following [#error](https://youtu.be/U9kr3TtC7Hg): 
`There are no commands defined in the "message-broker" namespace.`

This behavior indicates that the pull request may have inadvertently altered Laravel's standard command registration flow. Given the potential impact of this issue, it could pose a risk to existing applications that rely on the previous auto-registration mechanism for commands. I would urge you to review the changes introduced in this pull request to ensure backward compatibility and prevent unintended disruptions in functionality.