### PR TITLE
[11.x] add Eloquent strictness

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,8 +21,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         //
-        Model::preventLazyLoading(!$this->app->isProduction());
-        Model::preventSilentlyDiscardingAttributes(!$this->app->isProduction());
-        Model::preventAccessingMissingAttributes(!$this->app->isProduction());
+        Model::preventLazyLoading(! $this->app->isProduction());
+        Model::preventSilentlyDiscardingAttributes(! $this->app->isProduction());
+        Model::preventAccessingMissingAttributes(! $this->app->isProduction());
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,5 +21,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         //
+        Model::preventLazyLoading(!$this->app->isProduction());
+        Model::preventSilentlyDiscardingAttributes(!$this->app->isProduction());
+        Model::preventAccessingMissingAttributes(!$this->app->isProduction());
     }
 }


### PR DESCRIPTION
Make the Eloquent strictness default in non-production environments.

I think this is a safe, sensible default for new applications, for both experienced and new programmers.  Will help teach new programmers best practices for performance, and avoid bugs caused by silent failures. I'm guessing most experienced programmers are already including this in their app anyway, and it can be easily removed/adjusted as needed.

I'm not sure if this has been discussed before, but I could not find any old PRs regarding this, so figured I give it a go.