### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "laravel/pail": "^1.1",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
remove pail dependency as `laravel new new-project` is not working with terminal and herd new project creates project but composer update is not working

```
 Creating a "laravel/laravel" project at "./testProject"
    Installing laravel/laravel (v11.3.0)
  - Installing laravel/laravel (v11.3.0): Extracting archive
    Created project in D:\Herd/testProject
Loading composer repositories with package information
    Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - laravel/pail[v1.1.0, ..., v1.1.4] require ext-pcntl * -> it is missing from your system. Install or enable PHP's pcntl extension.
    - Root composer.json requires laravel/pail ^1.1 -> satisfiable by laravel/pail[v1.1.0, ..., v1.1.4].

To enable extensions, verify that they are enabled in your .ini files:
    - C:\Users\Shaz3e\.config\herd\bin\php83\php.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-pcntl` to temporarily ignore these required extensions.
```

Windows 11 Version 24H2 (OS Build 26100.2033

To reproduce this please remove `ext-pcntl` from you php.ini
 - Run the `laravel new project-name`
 - Remove `"laravel/pail": "^1.1",` from project composer.json
 - Run composer update
 - Run `php artisan key:generate`
 - Create database.sqlite file or change DB_CONNECTION=mysql in .env file
 - Run command to serve application `php artisan serve` or `http://project-name.test` from herd

It should work