### PR TITLE
[11.x] npm check in composer run dev command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "[ -f package-lock.json ] || npm install",
+            "[ -f package-lock.json ] || npm ci",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "[ -f package-lock.json ] || npm ci",
+            "@php -r \"file_exists('package-lock.json') || system('npm install');\"",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
+            "[ -f package-lock.json ] || npm install",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },


### PR DESCRIPTION
I installed a fresh Laravel app and tried to run the composer run dev command, but it showed an error saying 'vite not found,' indicating that npm is not installed. I have added a check to see if npm is installed, and if not, it will automatically install npm.

![laravel](https://github.com/user-attachments/assets/60983982-1068-4c91-bdff-1387c396783f)

