### PR TITLE
Align `composer run dev` output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"npm run dev\" --names=host,jobs,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
Same semantics with a little bit nicer alignment. 
Did this in our composer.json; thought it might be of interest to make this ocd-conform in general.

**Before** 👿
```console
composer run dev
> Composer\Config::disableProcessTimeout
> npx concurrently -c "#93c5fd,#c4b5fd,#fb7185,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "php artisan pail" "npm run dev" --names=host,jobs,logs,vite
[vite] 
[vite] > dev
[vite] > npm run development
[vite] 
[vite] 
[vite] > development
[vite] 
[logs] 
[logs]    INFO  Tailing application logs.                        Press Ctrl+C to exit  
[queue] 
[queue]    INFO  Processing jobs from the [default] queue.  
[queue] 
[logs]                                                Use -v|-vv to show more details  
[server] 
[server]    INFO  Server running on [http://127.0.0.1:8000].  
[server] 
[server]   Press Ctrl+C to stop the server
[server] 
```
**After** 😇
```console
composer run dev
> Composer\Config::disableProcessTimeout
> npx concurrently -c "#93c5fd,#c4b5fd,#fb7185,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "php artisan pail" "npm run dev" --names=host,jobs,logs,vite
[vite] 
[vite] > dev
[vite] > npm run development
[vite] 
[vite] 
[vite] > development
[vite] 
[logs] 
[logs]    INFO  Tailing application logs.                        Press Ctrl+C to exit  
[jobs] 
[jobs]    INFO  Processing jobs from the [default] queue.  
[jobs] 
[logs]                                                Use -v|-vv to show more details  
[host] 
[host]    INFO  Server running on [http://127.0.0.1:8000].  
[host] 
[host]   Press Ctrl+C to stop the server
[host] 
```