### PR TITLE
set the default port for url worked in Laravel plugin on vite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en


### PR DESCRIPTION
Set the default port for Vite/Laravel plugin in Laravel APP_URL in .env file on dev mode
## form
![APP_URL](https://github.com/user-attachments/assets/ff10891d-4fb1-4e63-98ca-cfc1c0de0627)
## to
![APP_URL-port](https://github.com/user-attachments/assets/9c2fd4e9-fae1-4630-961f-09a56c3c3908)
