### PR TITLE
shorten the npm run dev a bit by concurrency shortcut.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" npm:dev --names=server,queue,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
The concurrency package provides some shortcuts for npm. npm:dev -> npm run dev. 
It will make the composer run command a little bit shorter, not much, but it might be towards betterment. 
