### PR TITLE
Fix queue timeout leading to hanging processes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -k -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -k -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -k -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --timeout=0 --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -k --kill-others-on-fail -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --timeout=0 --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -k -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -k -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --timeout=0 --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -k --kill-others-on-fail -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --timeout=0 --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
I woke up to some strange errors after leaving `composer run dev` running all night. 

```bash
$ composer run dev
> Composer\Config::disableProcessTimeout
> npx concurrently -c "#93c5fd,#c4b5fd,#fb7185,#fdba74" "php artisan serve" "php artisan queue:listen --tries=1" "php artisan pail --timeout=0" "npm run dev" --names=server,queue,logs,vite
[logs] 
[logs]    INFO  Tailing application logs.                        Press Ctrl+C to exit  
[logs]                                                Use -v|-vv to show more details  
[queue] 
[queue]    INFO  Processing jobs from the [default] queue.  
[queue] 
[vite] 
[vite] > dev
[vite] > vite
[vite] 
[server] 
[server]    INFO  Server running on [http://127.0.0.1:8000].  
[server] 
[server]   Press Ctrl+C to stop the server
[server] 
[vite] Re-optimizing dependencies because lockfile has changed
[vite] 
[vite]   VITE v5.4.10  ready in 641 ms
[vite] 
[vite]   ➜  Local:   http://localhost:5173/
[vite]   ➜  Network: use --host to expose
[vite] 
[vite]   LARAVEL v11.29.0  plugin v1.0.5
[vite] 
[vite]   ➜  APP_URL: http://localhost
[queue] 
[queue]    Symfony\Component\Process\Exception\ProcessTimedOutException 
[queue] 
[queue]   The process "'/usr/bin/php8.3' 'artisan' 'queue:work' '--once' '--name=default' '--queue=default' '--backoff=0' '--memory=128' '--sleep=3' '--tries=1'" exceeded the timeout of 60 seconds.
[queue] 
[queue]   at vendor/symfony/process/Process.php:1181
[queue]     1177▕ 
[queue]     1178▕         if (null !== $this->timeout && $this->timeout < microtime(true) - $this->starttime) {
[queue]     1179▕             $this->stop(0);
[queue]     1180▕ 
[queue]   ➜ 1181▕             throw new ProcessTimedOutException($this, ProcessTimedOutException::TYPE_GENERAL);
[queue]     1182▕         }
[queue]     1183▕ 
[queue]     1184▕         if (null !== $this->idleTimeout && $this->idleTimeout < microtime(true) - $this->lastOutputTime) {
[queue]     1185▕             $this->stop(0);
[queue] 
[queue]       +18 vendor frames 
[queue] 
[queue]   19  artisan:13
[queue]       Illuminate\Foundation\Application::handleCommand()
[queue] 
[queue] php artisan queue:listen --tries=1 exited with code 1
[logs] 
[logs]    JsonException 
[logs] 
[logs]   Syntax error
[logs] 
[logs]   at vendor/laravel/pail/src/ValueObjects/MessageLogged.php:30
[logs]      26▕      */
[logs]      27▕     public static function fromJson(string $json): static
[logs]      28▕     {
[logs]      29▕         /** @var array{message: string, context: array{__pail: array{origin: array{trace: array<int, array{file: string, line: int}>|null, type: string, queue: string, job: string, command: string, method: string, path: string, auth_id: ?string, auth_email: ?string}}, exception: array{class: string, file: string}}, level_name: string, datetime: string} $array */
[logs]   ➜  30▕         $array = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
[logs]      31▕ 
[logs]      32▕         [
[logs]      33▕             'message' => $message,
[logs]      34▕             'datetime' => $datetime,
[logs] 
[logs]       +2 vendor frames 
[logs] 
[logs]   3   [internal]:0
[logs]       Laravel\Pail\ProcessFactory::Laravel\Pail\{closure}()
[logs]       +24 vendor frames 
[logs] 
[logs]   28  artisan:13
[logs]       Illuminate\Foundation\Application::handleCommand()
[logs] 
[logs] php artisan pail --timeout=0 exited with code 1
^C[vite] npm run dev exited with code SIGINT
[server] php artisan serve exited with code SIGINT
```

I disabled the timeout on `php artisan queue:listen` and ensured processes and child processes are killed on fail and manual termination with `-k --kill-others-on-fail` on the `npx concurrently` command.