### PR TITLE
Optional PORT & HOST in composer run dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve ${HOST:+--host=$HOST} ${PORT:+--port=$PORT}\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
Allows PORT and HOST on laravel serve through composer run dev.

i know that it's too early, but i was thinking in add a port and host optionals on composer run dev, it is an amazing tool and i think it could by more versatil.

Propuse to use:

╰─➤  HOST=localhost  composer run dev // runs on default port
╰─➤  PORT=8082  composer run dev // runs default host port 8082
╰─➤  HOST=localhost PORT=8084 composer run dev // runs on port 8084 and host localhost
╰─➤  composer run dev   // runs without --port and --host params                                                                   

Any ideas to make it better? @msamgan