### PR TITLE
Add schema property to enhance autocompletion for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://getcomposer.org/schema.json",
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",


### PR DESCRIPTION
This PR introduces a quality of life improvement by adding `"$schema": "https://getcomposer.org/schema.json"` to `composer.json` in order to have autocompletion in editors like VS Code, PhpStorm etc. 