### PR TITLE
[11.x] make password resets use the "cache driver" by default

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -92,8 +92,8 @@ return [
 
     'passwords' => [
         'users' => [
+            'driver' => 'cache',
             'provider' => 'users',
-            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
             'expire' => 60,
             'throttle' => 60,
         ],

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -21,12 +21,6 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        Schema::create('password_reset_tokens', function (Blueprint $table) {
-            $table->string('email')->primary();
-            $table->string('token');
-            $table->timestamp('created_at')->nullable();
-        });
-
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
@@ -43,7 +37,6 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('users');
-        Schema::dropIfExists('password_reset_tokens');
         Schema::dropIfExists('sessions');
     }
 };


### PR DESCRIPTION
my intent with https://github.com/laravel/framework/pull/53428 was to make the Cache driver the default for password resets, as I think it's the better option. if on board, this should not be merged until that PR is released.

wondering if we should add a dedicated cache store by default?

- drop the `password_reset_tokens` migration.
- update the auth config to use the 'cache' driver by default