### PR TITLE
[11.x] Update phpunit.xml to Remove Default SQLite Configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,6 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## Description:  
This PR proposes removing the default `DB_CONNECTION` and `DB_DATABASE` configuration from the `phpunit.xml` file. These lines are commonly used to set up an SQLite in-memory database for testing but **are not required in every use case**. By removing them, the `phpunit.xml` file becomes **cleaner and less opinionated**, while still allowing developers to easily override their testing environment as needed.

## Proposed Changes:  
Remove the following lines from `phpunit.xml`:  
```xml
<!-- <env name="DB_CONNECTION" value="sqlite"/> -->  
<!-- <env name="DB_DATABASE" value=":memory:"/> --> 
```

## Rationale:

- **Streamlined Configuration**: 
  - The removal of these lines makes `phpunit.xml` less opinionated, aligning better with Laravel’s flexibility.
  - Provides a cleaner & leaner setup for those not utilizing database-backed tests (mostly unit tests).

- **Customization on Demand**: 
  - For projects that need database testing, developers can easily add these lines back.
  - Encourages an "opt-in" model rather than imposing defaults.

- **Environment Inheritance**: 
  - Laravel already defaults to using values from the .env file. Developers can manage their testing environment configurations there.
  - This ensures a consistent approach across local, testing, and production environments.

## Pros of the Change:

- **Cleaner Configuration**: 
  - Removes unnecessary lines for projects that don’t rely on database testing.

- **Improved Flexibility**: 
  - Allows developers to set up their testing environment as per their project’s unique requirements.

- **Reduced Redundancy**: 
  - Utilizes `.env` for configurations, minimizing overlap and confusion.

## Cons/Challenges:

- **Slight Learning Curve**: 
  - Beginners unfamiliar with configuring database tests may need additional guidance on setting up these variables manually.

## How to Mitigate Cons:

- **Documentation Update**: 
  - Update Laravel’s testing documentation to include a section on configuring phpunit.xml for database-backed tests, including the removed lines as an example.

- **Code Comment Suggestion**: 
  - Can add a comment to `phpunit.xml` advising users to set up the variables if database tests are needed.

## Checklist:

- [x] Removed unnecessary default configurations in `phpunit.xml`.
- [x] Ensured no breaking changes.
- [x] Tested with .env fallback for various configurations.
- [ ] Suggested documentation updates upon PR approval.

## Conclusion:

This update sustains Laravel's flexibility, delivers a cleaner & slim configuration while preserving ease of use for developers who rely on environment-based testing configurations.

