### PR TITLE
[11.x] Bump framework version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^11.9",
+        "laravel/framework": "^11.31",
         "laravel/tinker": "^2.9"
     },
     "require-dev": {


### PR DESCRIPTION
We might bump the framework version to `11.31` to address https://github.com/laravel/framework/security/advisories/GHSA-gv7v-rgg6-548h.