### PR TITLE
Update 0001_01_01_000000_create_users_table.php

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -29,7 +29,7 @@ return new class extends Migration
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
+            $table->string(column: 'user_id', length: 40)->nullable()->index()->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');


### PR DESCRIPTION
This change fixes an issue, where authentication succeeds, but subsequently the user is left unauthenticated.

It happens only when the ID of the user not an integer (i.e. string) and the session driver is set to database (in my case MySQL).

The reason it occurs is the current setup generates a column of type bigint of length 20. As a result the database session driver is unable to update the session entry, and silently fails.

My current workaround is another migration to fix this:

```php
Schema::table('sessions', function (Blueprint $table) {
    $table->dropIndex('sessions_user_id_index');
});
Schema::table('sessions', function (Blueprint $table) {
    $table->string(column: 'user_id', length: 40)->nullable()->index()->nullable()->change();
});
```

But of course its best to be fixed at the origin, other than having to resolve to black magic :)

Also it would be good to have a fix to the silent failure to update the session table, probably add an entry to the logs.