### PR TITLE
[11.x] match `HidesAttributes` docblocks

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,7 +26,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array<int, string>
+     * @var array<string>
      */
     protected $hidden = [
         'password',


### PR DESCRIPTION
the docblock in `HidesAttributes` was updated in #42512, so this child class should be using the same.

otherwise PHPStan throws a "PHPDoc type array<int, string> of property App\Models\User::$hidden is not covariant with PHPDoc type list<string> of  property Illuminate\Database\Eloquent\Model::$hidden" error