### PR TITLE
[11.x] Narrow down array types to lists

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $fillable = [
         'name',
@@ -26,7 +26,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $hidden = [
         'password',


### PR DESCRIPTION
With the new version of PHPStan (2) / Larastan (3) you now get the "type array<int, string> is not covariant with type list<string> of overridden property" error on anything above level 2 (default/proposed is 5) on a clean project.

https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants#list-type

The list type is also supported by Psalm: https://psalm.dev/docs/annotating_code/type_syntax/array_types/