### PR TITLE
[11.x] Update vite.config.js to ignore storage path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     server: {
         watch: {
-            ignored: ['**/storage/**'],
+            ignored: ['storage/**'],
         },
     },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     server: {
         watch: {
-            ignored: ["**/storage/**"],
+            ignored: ['**/storage/**'],
         },
     },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,9 @@ export default defineConfig({
             refresh: true,
         }),
     ],
+    server: {
+        watch: {
+            ignored: ["**/storage/**"],
+        },
+    },
 });


### PR DESCRIPTION
## Problem

I'm working on an app that downloads HTML and CSS files from various sites and temporarily stores them in `storage/...`.  As each file is downloaded in a development environment, Vite's hot reloading sees these new files and tries to rebuild the `app.js` and `app.css` files for each matching file, causing a ton of unnecessary refreshes and, in some cases, actually breaking the page until I can restart the `npm run dev` process.

## Solution

I don't know if this is the *best* solution (I am certainly all ears if there is a better way to accomplish this) but by adding the storage folder to Vite's server watch ignore list, it means that Vite will only watch developer-generated code for changes, rather than anything user-submitted/ephemeral that lives in the `storage_path()` and its children.  I prevented the unnecessary scanning by setting Vite's `server.watch.ignore` option to include the storage folder.

If this PR is accepted, I will submit a documentation update to explain the change.

## Example

This is what the Vite log looks like prior to this change
<img width="1454" alt="Screenshot 2024-12-05 at 12 31 13 PM" src="https://github.com/user-attachments/assets/26a31b31-57b2-4cf1-b3b0-f9a01f69ea69">