### PR TITLE
Add comment for performance monitoring start time

### DIFF
--- a/artisan
+++ b/artisan
@@ -3,6 +3,7 @@
 
 use Symfony\Component\Console\Input\ArgvInput;
 
+// Define the start time for performance monitoring...
 define('LARAVEL_START', microtime(true));
 
 // Register the Composer autoloader...

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 
+// Define the start time for performance monitoring...
 define('LARAVEL_START', microtime(true));
 
 // Determine if the application is in maintenance mode...


### PR DESCRIPTION
Added a comment to define the start time for performance monitoring, which will help with understanding the code better for new contributors.