### PR TITLE
set default scheme for smtp mailer

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -39,7 +39,7 @@ return [
 
         'smtp' => [
             'transport' => 'smtp',
-            'scheme' => env('MAIL_SCHEME'),
+            'scheme' => env('MAIL_SCHEME', 'smtp'),
             'url' => env('MAIL_URL'),
             'host' => env('MAIL_HOST', '127.0.0.1'),
             'port' => env('MAIL_PORT', 2525),


### PR DESCRIPTION
This PR addresses an issue where the smtp mailer fails with the message `The "" scheme is not supported; supported schemes for mailer "smtp" are: "smtp", "smtps".`