### PR TITLE
fix: fixed the lenght of the columns

### DIFF
--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -12,14 +12,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('cache', function (Blueprint $table) {
-            $table->string('key')->primary();
-            $table->mediumText('value');
+            $table->longText('key')->primary();
+            $table->longText('value');
             $table->integer('expiration');
         });
 
         Schema::create('cache_locks', function (Blueprint $table) {
-            $table->string('key')->primary();
-            $table->string('owner');
+            $table->longText('key')->primary();
+            $table->longText('owner');
             $table->integer('expiration');
         });
     }


### PR DESCRIPTION
## Description

When Running really large  caches got overflow on the cache  table  I think might be handy to have on default it as longtext

