### PR TITLE
Update .gitignore to not ignore auth.json in the lang directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml
-auth.json
 npm-debug.log
 yarn-error.log
+/auth.json
 /.fleet
 /.idea
 /.nova


### PR DESCRIPTION
Hey There, 

I made this pull request for the following. For now if i perform the  `php artisan lang:publish` command i will get the the default english translation files from the framework. 

But if i want to a new language and want to use JSON file. the auth.json file will not be added to my commit due to the `auth.json` entry in the `.gitignore` file. This commit will allow to commit the ´´lang/nl/auth.json´ file but still isgnore the  `auth.json` file. 

