### PR TITLE
fix css whitespace invalid-calc

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -83,7 +83,7 @@
                                         class="hidden aspect-video h-full w-full flex-1 rounded-[10px] object-top object-cover drop-shadow-[0px_4px_34px_rgba(0,0,0,0.25)] dark:block"
                                     />
                                     <div
-                                        class="absolute -bottom-16 -left-16 h-40 w-[calc(100%+8rem)] bg-gradient-to-b from-transparent via-white to-white dark:via-zinc-900 dark:to-zinc-900"
+                                        class="absolute -bottom-16 -left-16 h-40 w-[calc(100% + 8rem)] bg-gradient-to-b from-transparent via-white to-white dark:via-zinc-900 dark:to-zinc-900"
                                     ></div>
                                 </div>
 


### PR DESCRIPTION
**Issue**:
 Warning in Tailwind CSS Version 4 Beta When Using the + Operator Without Surrounding Whitespace

**Description:**
 When the + operator in Tailwind CSS does not have whitespace on both sides, it triggers a warning in Tailwind CSS version 4 Beta.

```
▲ [WARNING] The "+" operator only works if there is whitespace on both sides [invalid-calc]

    <stdin>:371:42:
      371 │ .w-\[calc\(100\%\+8rem\)\]{width:calc(100%+8rem);}
          ╵                                           ^


▲ [WARNING] The "+" operator only works if there is whitespace on both sides [invalid-calc]

    <stdin>:831:695:
      831 │ ...100\%\+8rem\)\]{width:calc(100%+8rem);}.w-auto{width:auto;}.w-...
          ╵                                   ^
```

** To Reproduce:**

Use the `+` operator in a calc function without adding whitespace around it,`calc(100%+8rem`).

Per [mdn web docs css rules](https://developer.mozilla.org/en-US/docs/Web/CSS/calc#rules_and_best_practices_while_using_calc) white space is required