### PR TITLE
Preserve X-Xsrf-Token header from .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -9,6 +9,10 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+    # Handle X-Xsrf-Token Header
+    RewriteCond %{HTTP:x-xsrf-token} .
+    RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:x-xsrf-token}]
+
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$


### PR DESCRIPTION
Preserve X-Xsrf-Token header for session based authentication when building API in Laravel