### PR TITLE
Preserve X-Xsrf-Token header from .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -11,7 +11,7 @@
 
     # Handle X-Xsrf-Token Header
     RewriteCond %{HTTP:x-xsrf-token} .
-    RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:x-xsrf-token}]
+    RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:X-XSRF-Token}]
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -9,6 +9,10 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+    # Handle X-Xsrf-Token Header
+    RewriteCond %{HTTP:x-xsrf-token} .
+    RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:x-xsrf-token}]
+
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -9,7 +9,7 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-    # Handle X-Xsrf-Token Header
+    # Handle X-XSRF-Token Header
     RewriteCond %{HTTP:x-xsrf-token} .
     RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:X-XSRF-Token}]
 


### PR DESCRIPTION
In [.htaccess](https://github.com/laravel/laravel/blob/11.x/public/.htaccess) file right now we have rewrite rule to preserve **Authorization** header. That commit exists in .htaccess file [since 2016](https://github.com/laravel/laravel/commit/85e8d21ef2320977d6f205ef793dc595ed5638d3), which was [later updated](https://github.com/laravel/laravel/commit/8d1d1e1b94d7b1aedd94416a361db0fa499d0a73). 

Laravel uses [X-XSRF-TOKEN](https://laravel.com/docs/11.x/sanctum#csrf-protection) for session based authentication in API and just like **Authorization** header is sometimes removed by some of the server configurations (Typically on shared hosting) **X-XSRF-TOKEN** is also removed and to properly implement session based authentication with Laravel API, the header needs to be preserved.

I came to this change when I tried to deploy my Laravel API into shared hosting and authorization did not work because **X-XSRF-TOKEN** was removed by server configuration and on shared hosting typically we do not have control on the server configuration.

I think this change will not affect anything else, other than it makes sure that **X-XSRF-TOKEN** header is always preserved and passed to Laravel.

I would be happy to write any tests to support the PR, but I think this particular change is the type of change for which you can not write any tests.


