### PR TITLE
Remove extra hourly() method in console.php

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -5,4 +5,4 @@ use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();
+})->purpose('Display an inspiring quote');


### PR DESCRIPTION
See the diff that introduced this: https://github.com/laravel/laravel/commit/dd60315e9ad725c99d883a668f35cfaa6a1aa8e3#diff-c96ad2c3c018fea7d8ea9667a55e8e2fe309bc2a0df81945ab0a65493a4486f0

The console schedule section was removed, but the commit used final line of the file instead of the correct line from the console commands section. This was confusing for a newcomer to both PHP and Laravel :)

<img width="683" alt="kuva" src="https://github.com/user-attachments/assets/b4ff8778-c32f-4bd7-adbe-eed09f4e4d7f" />
