### PR TITLE
moving `laravel/pail` from 'require-dev' to 'require'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.31",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "laravel/pail": "^1.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "laravel/pail": "^1.1",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
`laravel/pail` can be useful for digging into production issues like tinker. Normally we don't install dev dependency on production.