### PR TITLE
Improve static analysis by adding type hints for $app in artisan and public/index.php

### DIFF
--- a/artisan
+++ b/artisan
@@ -12,6 +12,7 @@ require __DIR__.'/vendor/autoload.php';
 // Bootstrap Laravel and handle the command...
 /** @var Application $app */
 $app = require_once __DIR__.'/bootstrap/app.php';
+
 $status = $app->handleCommand(new ArgvInput);
 
 exit($status);

--- a/artisan
+++ b/artisan
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Illuminate\Foundation\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
 define('LARAVEL_START', microtime(true));
@@ -9,7 +10,8 @@ define('LARAVEL_START', microtime(true));
 require __DIR__.'/vendor/autoload.php';
 
 // Bootstrap Laravel and handle the command...
-$status = (require_once __DIR__.'/bootstrap/app.php')
-    ->handleCommand(new ArgvInput);
+/** @var Application $app */
+$app = require_once __DIR__.'/bootstrap/app.php';
+$status = $app->handleCommand(new ArgvInput);
 
 exit($status);

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 
 define('LARAVEL_START', microtime(true));
@@ -13,5 +14,6 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 require __DIR__.'/../vendor/autoload.php';
 
 // Bootstrap Laravel and handle the request...
-(require_once __DIR__.'/../bootstrap/app.php')
-    ->handleRequest(Request::capture());
+/** @var Application $app */
+$app = require_once __DIR__.'/../bootstrap/app.php';
+$app->handleRequest(Request::capture());

--- a/public/index.php
+++ b/public/index.php
@@ -16,4 +16,5 @@ require __DIR__.'/../vendor/autoload.php';
 // Bootstrap Laravel and handle the request...
 /** @var Application $app */
 $app = require_once __DIR__.'/../bootstrap/app.php';
+
 $app->handleRequest(Request::capture());


### PR DESCRIPTION
This PR adds explicit type hints for the $app variable in artisan and public/index.php using PHPDoc comments.
Why?
-  Improves static analysis by tools like PHPStan and PHPStorm, allowing them to correctly infer the type.
- Prevents unnecessary warnings or incorrect suggestions in IDEs.
- Enhances code readability by making it clear that $app is an instance of Illuminate\Foundation\Application.

**Impact**
- No runtime behavior changes.
- Does not introduce breaking changes.
- Strictly improves developer experience.

**Testing**

Since this change only affects static analysis, no functional tests are included. However, I can set up PHPStan within the test suite if desired.