### PR TITLE
Add mysql_attr_persistent config to mysql and mariadb

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,6 +59,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::ATTR_PERSISTENT => env('MYSQL_ATTR_PERSISTENT', true),
             ]) : [],
         ],
 
@@ -79,6 +80,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::ATTR_PERSISTENT => env('MYSQL_ATTR_PERSISTENT', true),
             ]) : [],
         ],
 


### PR DESCRIPTION
Laravel re create new connection to MySQL / MariaDB every request and slow down the first query. So I add `mysql_attr_persistent` to `mysql options` to keep connection alive.

Here is before config, the first query  from `auth:sanctum` middleware, select 1 record from `personal_access_tokens` table took about 20ms.

![Screenshot 2025-02-04 132717](https://github.com/user-attachments/assets/8a040d05-7884-4942-91c9-2c02151f6798)

And here is after config`mysql_attr_persistent`, the first query took about 2ms.

![Screenshot 2025-02-04 132555](https://github.com/user-attachments/assets/f4239f52-9551-4040-8c34-b15b713d07da)

I tested it on free hosting provider (InfinityFree) and it work fine, also fine with `mod_php` on Apache and `PHP-FPM` on docker in my machine.

