### PR TITLE
[11.x] Fixed  undefined variable error from larastan or phpstan on fresh installation of laravel

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
+    $output = new ConsoleOutput();
+    $output->writeln(Inspiring::quote());
 })->purpose('Display an inspiring quote');


### PR DESCRIPTION
Hey Laravel Team
I encountered an "undefined $this variable" error in a fresh installation of Laravel while running PHPStan 11.x. I have identified the issue and successfully resolved it. Please review the fix.

`Undefined variable: $this
         🪪  variable.undefined`

