### PR TITLE
Re-add nunomaduro/collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.1",
+        "nunomaduro/collision": "^8.6",
         "phpunit/phpunit": "^11.5.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
+        "nunomaduro/collision": "^8.1",
         "phpunit/phpunit": "^11.5.3"
     },
     "autoload": {


### PR DESCRIPTION
In preparing for the Laravel 12.x Shift, I noticed the dependency on `nunomaduro/collision` was removed. But I don't see it within `laravel/framework` or another first-party dependency. So I'm assuming maybe this was accidently removed when resolving [this merge conflict](https://github.com/laravel/laravel/commit/295bdfeee961c760425a392942273febe1eb6cc9), and should be re-added. 😅 