### PR TITLE
Migration key was too long issue.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
Whenever I install a fresh Laravel project and run migrations with any MySQL version, I face the issue of the unique key being too long. To avoid manually adding the schema every time, I have added it in the App Service Provider. I am facing this issue on Windows OS.