### PR TITLE
Add PHPStan for Static Analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit
+
+      - name: Execute type checking
+        run: vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^11.5.3"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+    level: 3
+    tmpDir: storage/framework/cache
+    paths:
+        - ./app
+        - ./artisan
+        - ./bootstrap
+        - ./config
+        - ./database
+        - ./public
+        - ./tests


### PR DESCRIPTION
### Summary
This PR introduces PHPStan to Laravel's default application template, ensuring static analysis and type checking for improved code quality and early detection of potential issues. By integrating PHPStan, we help maintain the integrity of the Laravel application skeleton while also enabling developers to catch errors early and encourage best practices in Laravel projects.

### What’s Included?
- **PHPStan Installation**: Added `phpstan/phpstan` as a development dependency in `composer.json`.
- **GitHub Workflow**: Modified `.github/workflows/tests.yml` to run PHPStan as part of CI checks.
- **Configuration**: Configured PHPStan to analyze core directories with [level 3](https://phpstan.org/user-guide/rule-levels). By choosing level 3, we ensure that Laravel’s default application template remains in good condition without requiring modifications. This also avoids the need for installing any extensions like [Larastan](https://github.com/larastan/larastan) or [Bladestan](https://github.com/bladestan/bladestan).


### Why This Change?
By adding PHPStan, we enable static analysis by default, which brings several benefits:

- **Ensuring Laravel’s Default Application Integrity**: Running PHPStan on the skeleton itself helps prevent issues from creeping into the default template, ensuring new projects start with a solid foundation.
- **Improved Code Quality**: Developers can catch potential issues before they become runtime errors.
- **Enhances Developer Experience**: Identifies problematic code areas without requiring execution, making debugging easier.
- **Long-Term Maintainability**: By encouraging developers to address issues early on, we avoid the buildup of technical debt and reduce the risk of chasing bugs in production.
- **Helps Developers Upgrade**: Static analysis can help catch issues when dependencies change, which may otherwise go unnoticed during normal testing. It can also be helpful for migrating applications step by step.

### Testing and Backward Compatibility
- By doing this early in the development cycle we allow for it to be well tested before it is rolled out to end users.
- No existing features are changed or removed; this is a development-time enhancement.
- The inclusion of PHPStan ensures the Laravel application template remains in a healthy state, making it easier to maintain.
- Developers who do not wish to use PHPStan can simply remove the dependency or ignore the output.