### PR TITLE
feat: add type hints for $this in routes/console.php

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
+/** @var Illuminate\Console\Command $this */
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');


### PR DESCRIPTION
## Summary
This PR adds a type hint for `$this` in `routes/console.php`, ensuring better IDE support and improved static analysis when working with console commands.

## Why This Change?
- **Improves Developer Experience**: IDEs can now provide autocompletion and proper type inference for `$this` within console command closures.
- **Enhances Static Analysis**: Helps tools like PHPStan understand the type of `$this`, reducing potential false positives in type checks.
- **Better Code Readability**: Explicitly declaring `$this` as an instance of `Illuminate\Console\Command` makes the code easier to understand for new developers.

## Testing & Compatibility
- No runtime behavior changes; this is a documentation-level improvement.
- Fully backward compatible with existing Laravel applications.
