### PR TITLE
Make the github test action run out of the box independent of the choice of testing framework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: php artisan test


### PR DESCRIPTION
# Summary
This PR changes the test runner for the github action to `php artisan test`

# Why This Change?
The included github testing action executes `./vendor/bin/phpunit` but when pest is chosen, this results in an error. 
I know it's easy to fix (and the error message tells you exactly what to do, that is, run `./vendor/bin/pest`), but wouldn't it be nicer if it would just work out of the box?

# Testing & Compatibility
No runtime behavior changes
Compatible with existing Laravel applications.