### PR TITLE
feat: add type hints for $this in routes/console.php

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -3,7 +3,6 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
-/** @var Illuminate\Foundation\Console\Kernel $this */
 Artisan::command('inspire', function () {
     /** @var Illuminate\Foundation\Console\ClosureCommand $this */
     $this->comment(Inspiring::quote());

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,10 @@
 <?php
 
+use Illuminate\Foundation\Console\ClosureCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
-    /** @var Illuminate\Foundation\Console\ClosureCommand $this */
+    /** @var ClosureCommand $this */
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
+/** @var Illuminate\Foundation\Console\Kernel $this */
 Artisan::command('inspire', function () {
+    /** @var Illuminate\Foundation\Console\ClosureCommand $this */
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');


### PR DESCRIPTION
## Summary
This PR adds a type hint for `$this` in `routes/console.php`, ensuring better IDE support and improved static analysis when working with console commands.

## Why This Change?
- **Improves Developer Experience**: IDEs can now provide autocompletion and proper type inference for `$this` within console command closures.
- **Enhances Static Analysis**: Helps tools like PHPStan understand the type of `$this`, reducing potential false positives in type checks.
- **Better Code Readability**: Explicitly declaring `$this` as an instance of `Illuminate\Console\Command` makes the code easier to understand for new developers.

## Testing & Compatibility
- No runtime behavior changes; this is a documentation-level improvement.
- Fully backward compatible with existing Laravel applications.

Note: This replaces #6554, which I closed before realizing it was possible to properly hint the rebound scope. Thanks to @timacdonald for highlighting the dependency.

This further reinforces the importance of explicitly hinting both scopes, as they don’t seem to be well-documented elsewhere.