### PR TITLE
Hint outer scope in console routes

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,11 @@
 <?php
 
 use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Foundation\Console\Kernel;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
+/** @var Kernel $this */
 Artisan::command('inspire', function () {
     /** @var ClosureCommand $this */
     $this->comment(Inspiring::quote());


### PR DESCRIPTION
This is a follow up to https://github.com/laravel/laravel/pull/6559

It restores the `@var Kernel $this` annotation, which was initially included in my original PR but later removed during review. Omitting this annotation causes issues with some developer tools, as they fail to recognize that this file is within the scope of a class. Without it, the inner `$this` overwrites (`@var ClosureCommand $this`) lead to incorrect assumptions by static analyzers and IDEs.

By explicitly declaring `@var Kernel $this`, we ensure proper type inference and improve the developer experience.