### PR TITLE
Improve Default Unit Test

### DIFF
--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Models\User;
 use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
@@ -9,8 +10,10 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_that_true_is_true(): void
+    public function test_user_has_a_name(): void
     {
-        $this->assertTrue(true);
+        $user = new User(['name' => 'John Doe']);
+
+        $this->assertEquals('John Doe', $user->name);
     }
 }


### PR DESCRIPTION
This PR updates the default unit test to validate an actual part of the Laravel skeleton. Instead of asserting `true === true`, it now tests that the `User` model correctly handles attribute assignment.

#### Why?

- The original test fails PHPStan because it performs a redundant check.
- Ensures the test can actually fail, making it a better example.

Together with my two other PRs, this resolves all reported issues from PHPStan on a default Laravel installation.