### PR TITLE
Remove reverted change from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ## [v12.0.2](https://github.com/laravel/laravel/compare/v12.0.1...v12.0.2) - 2025-03-04
 
 * Make the github test action run out of the box independent of the choice of testing framework by [@ndeblauw](https://github.com/ndeblauw) in https://github.com/laravel/laravel/pull/6555
-* feat: add type hints for $this in routes/console.php by [@AJenbo](https://github.com/AJenbo) in https://github.com/laravel/laravel/pull/6559
 
 ## [v12.0.1](https://github.com/laravel/laravel/compare/v12.0.0...v12.0.1) - 2025-02-24
 


### PR DESCRIPTION
This was only partially merged and then reverted in https://github.com/laravel/laravel/commit/27348b7c9030388a2db7be57c3775fc9fd2a1ced (which I approve of), so lets not mention it in the changelog.