### PR TITLE
[12.x] Default to `testing` channel in unit tests

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -126,6 +126,7 @@ return [
 
         'testing' => [
             'driver' => 'monolog',
+            'level' => 'debug',
             'handler' => TestHandler::class,
         ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -3,6 +3,7 @@
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Handler\TestHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
@@ -121,6 +122,11 @@ return [
         'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,
+        ],
+
+        'testing' => [
+            'driver' => 'monolog',
+            'handler' => TestHandler::class,
         ],
 
         'emergency' => [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="CACHE_STORE" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
         <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="LOG_CHANNEL" value="testing" />
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
It's not very easy to test logging in Laravel. Monolog's `TestHandler` is ideal for this scenario.

Additionally, logs from tests end up in my Laravel logs locally, which is not ideal.

## Followup
Add some helper utility to the `Log` facade where the fake swaps in and out to use the `testing` handler, allowing for assertions against log writes.

<details>
<summary>How I am testing it in our app</summary>

I added the code from this PR into our codebase.

I created a trait to simplify access.

```php
declare(strict_types=1);

namespace Tests\Concerns;

use Log;
use Monolog\Handler\TestHandler;
use Monolog\LogRecord;

trait InteractsWithLoggingTrait
{
    protected function getLogHandler(): TestHandler
    {
        return Log::getLogger()->getHandlers()[0]; // @phpstan-ignore method.notFound
    }

    /**
     * @return array<LogRecord>
     */
    protected function getLogRecords(): array
    {
        return $this->getLogHandler()->getRecords();
    }
}
```

And then inside of a test
```php
public function test_it_writes_channel_name(): void
{
        Log::debug("Hello!", ['value1' => 'a', 'value2' => 'z']);
        $logRecords = $this->getLogRecords();
        self::assertCount(1, $logRecords);
        self::assertSame('contexttest', $logRecords[0]->channel);
        self::assertSame([
            'value1' => 'a',
            'value2' => 'z',
        ], $logRecords[0]->context);
}
```

</details>
