### PR TITLE
[12.x] Refactor: Structural improvement for clarity

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -98,7 +98,7 @@ return [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
-            'with' => [
+            'handler_with' => [
                 'stream' => 'php://stderr',
             ],
             'formatter' => env('LOG_STDERR_FORMATTER'),

--- a/config/logging.php
+++ b/config/logging.php
@@ -98,10 +98,10 @@ return [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
-            'formatter' => env('LOG_STDERR_FORMATTER'),
             'with' => [
                 'stream' => 'php://stderr',
             ],
+            'formatter' => env('LOG_STDERR_FORMATTER'),
             'processors' => [PsrLogMessageProcessor::class],
         ],
 


### PR DESCRIPTION
## Improve Readability of `stderr` Log Channel Configuration
This PR updates the structure of the `stderr` logging channel configuration to place the `handler` option before its constructor parameters `with`.

Why?
Laravel's documentation states:

> "Optionally, any constructor parameters the handler needs may be specified using the with configuration option."

Reordering these options makes it clearer that `with` provides parameters for `handler`, improving readability and maintainability.