### PR TITLE
[12.x] Use config values for queue table names in migrations

### DIFF
--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('jobs', function (Blueprint $table) {
+        Schema::create(config('queue.connections.database.table'), function (Blueprint $table) {
             $table->id();
             $table->string('queue')->index();
             $table->longText('payload');
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->unsignedInteger('created_at');
         });
 
-        Schema::create('job_batches', function (Blueprint $table) {
+        Schema::create(config('queue.batching.table'), function (Blueprint $table) {
             $table->string('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
@@ -34,7 +34,7 @@ return new class extends Migration
             $table->integer('finished_at')->nullable();
         });
 
-        Schema::create('failed_jobs', function (Blueprint $table) {
+        Schema::create(config('queue.failed.table'), function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');
@@ -50,8 +50,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('jobs');
-        Schema::dropIfExists('job_batches');
-        Schema::dropIfExists('failed_jobs');
+        Schema::dropIfExists(config('queue.connections.database.table'));
+        Schema::dropIfExists(config('queue.batching.table'));
+        Schema::dropIfExists(config('queue.failed.table'));
     }
 };


### PR DESCRIPTION
This PR updates the queue-related database migration to use table names from the configuration files instead of hardcoded values.

I don't like the original table names because it can conflict with names that I might use for the project itself I am working on so I always end up changing it in multiple places, this will make sure you only need to define it in the config or .env file.

## Changes
- Modified create_jobs_table.php migration to use config('queue.connections.database.table') instead of hardcoded 'jobs'
- Modified job batches table creation to use config('queue.batching.table') instead of hardcoded 'job_batches'
- Modified failed jobs table creation to use config('queue.failed.table') instead of hardcoded 'failed_jobs'
- Updated the corresponding down() method to use the same config values when dropping tables

## Benefits
- Improves flexibility by respecting custom table names defined in configuration
- Ensures consistency between config settings and actual database structure
- Makes the application more maintainable when queue table names need to be customized

## Testing
The migration has been tested to ensure it correctly creates and drops tables using the configured names.