### PR TITLE
[12.x] Remove Unnecessarily @source

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -4,7 +4,6 @@
 @source '../../storage/framework/views/*.php';
 @source '../**/*.blade.php';
 @source '../**/*.js';
-@source '../**/*.vue';
 
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',


### PR DESCRIPTION
I think that the `@source` for `.vue` is not important because if we need to use Vue we will use the Vue starter kit