### PR TITLE
Bump vite from 6.0.11 to 6.0.12 - Vulnerability patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.0.11"
+        "vite": "^6.0.12"
     }
 }


### PR DESCRIPTION
Not sure if we want to go higher, but I upgraded to the nearest patched version
security issue https://github.com/vitejs/vite/security/advisories/GHSA-x574-m823-4x7w