### PR TITLE
Bump vite from 6.0.11 to 6.2.3 - Vulnerability patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.0.11"
+        "vite": "^6.2.3"
     }
 }


### PR DESCRIPTION
Not sure how high we want to go, but the only unaffected versions are
6.0.12  (latest version of 6.0)
6.1.2 (latest release of 6.1)
6.2.3 (latest release)

Security issue: https://github.com/vitejs/vite/security/advisories/GHSA-x574-m823-4x7w