### PR TITLE
[12.x] Remove not necessary tailwindcss source declarations

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,9 +1,6 @@
 @import 'tailwindcss';
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
-@source '../../storage/framework/views/*.php';
-@source '../**/*.blade.php';
-@source '../**/*.js';
 
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',


### PR DESCRIPTION
In PR #6523, the settings ensuring TailwindCSS v4 compatibility were added to version 12.x. However, three of the declared sources are unnecessary and only increase the codebase size.

TailwindCSS v4 automatically detects all sources that are not in `.gitignore` and are not special files. See more details here:
* [TailwindCSS v4 - which files are scanned](https://tailwindcss.com/docs/detecting-classes-in-source-files#which-files-are-scanned)

### Resources

As a result, there is no need to declare `resources/**/*.blade.php` and `resources/**/*.js` as sources.

### Storage Views

Additionally, scanning cached files in `storage/framework/views/*.php` is unnecessary, as TailwindCSS can discover the required classes by mapping the original source files.

Mapping cached files can lead to incorrect results if the developer dynamically constructs class names, e.g., `bg-red-$custom`, where `$custom` might default to `500`. In this case, due to the storage source, `bg-red-500` will be added to the prod, but the other classes won't, and the developer won't understand the explanation.

To avoid this, the TailwindCSS v4 documentation specifically advises developers to avoid such dynamic declarations.
* [TailwindCSS v4 - Dynamic class names](https://tailwindcss.com/docs/detecting-classes-in-source-files#dynamic-class-names)

So, if the classes are properly declared in the source (whether in app, resources, or elsewhere), they will be correctly included in the compiled CSS without the need to consider the storage folder.