### PR TITLE
chore: Set app debug to always false when in production

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,7 +39,7 @@ return [
     |
     */
 
-    'debug' => (bool) env('APP_DEBUG', false),
+    'debug' => (bool) env('APP_ENV') === 'production' ? false : env('APP_DEBUG', false),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR aims at enforcing strict security practice in production.

In production, app debug must never be true; it can only be overridden if env is not production.