### PR TITLE
Bump vite from 6.2.3 to 6.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.2.3"
+        "vite": "^6.2.4"
     }
 }


### PR DESCRIPTION
Another CVE was published for Vite recommending updating `<=6.2.3` to `6.2.4` or greater. Not sure if this affects Laravel, but better save that sorry.

https://github.com/vitejs/vite/security/advisories/GHSA-4r4m-qw57-chr8