### PR TITLE
Add `composer run test` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,10 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+        ],
+        "test": [
+            "@php artisan config:clear --ansi",
+            "@php artisan test"
         ]
     },
     "extra": {


### PR DESCRIPTION
This prevents the application from running tests with cached config.

- https://github.com/laravel/vue-starter-kit/pull/103
- https://github.com/laravel/livewire-starter-kit/pull/81
- https://github.com/laravel/react-starter-kit/pull/98