### PR TITLE
[12.x] Clean up URL formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ We would like to extend our thanks to the following sponsors for funding Laravel
 
 ### Premium Partners
 
-- **[Vehikl](https://vehikl.com/)**
+- **[Vehikl](https://vehikl.com)**
 - **[Tighten Co.](https://tighten.co)**
 - **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
 - **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
+- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
 - **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development/)**
+- **[Redberry](https://redberry.international/laravel-development)**
 - **[Active Logic](https://activelogic.com)**
 
 ## Contributing


### PR DESCRIPTION
**Description:**
This PR updates a few URLs in the README.md to remove unnecessary trailing slashes. This helps maintain a clean style. All updated URLs still point to the correct destinations.