### PR TITLE
[12.x] Add cache lock_table default

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -43,7 +43,7 @@ return [
             'connection' => env('DB_CACHE_CONNECTION'),
             'table' => env('DB_CACHE_TABLE', 'cache'),
             'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),
-            'lock_table' => env('DB_CACHE_LOCK_TABLE'),
+            'lock_table' => env('DB_CACHE_LOCK_TABLE','cache_locks'),
         ],
 
         'file' => [

--- a/config/cache.php
+++ b/config/cache.php
@@ -43,7 +43,7 @@ return [
             'connection' => env('DB_CACHE_CONNECTION'),
             'table' => env('DB_CACHE_TABLE', 'cache'),
             'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),
-            'lock_table' => env('DB_CACHE_LOCK_TABLE','cache_locks'),
+            'lock_table' => env('DB_CACHE_LOCK_TABLE', 'cache_locks'),
         ],
 
         'file' => [


### PR DESCRIPTION
It would be nice to have a default here, so then it's possible to do:

 `config('cache.stores.database.lock_table')` 
 
As we can already do: `config('cache.stores.database.table') // returns cache `

The default is like for like as it is [here](https://github.com/laravel/framework/blob/44e6a294e4441e9e3338008af0288979b3f677e8/src/Illuminate/Cache/CacheManager.php#L251)

If this is merged I'm happy to also add it into the framework repo, but thought I'd target the skeleton first 🤷🏻 
