### PR TITLE
Add missing condition check availability of dashboard route to welcome.blade.php to prevent unintended output

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -24,12 +24,14 @@
             @if (Route::has('login'))
                 <nav class="flex items-center justify-end gap-4">
                     @auth
-                        <a
-                            href="{{ url('/dashboard') }}"
-                            class="inline-block px-5 py-1.5 dark:text-[#EDEDEC] border-[#19140035] hover:border-[#1915014a] border text-[#1b1b18] dark:border-[#3E3E3A] dark:hover:border-[#62605b] rounded-sm text-sm leading-normal"
-                        >
-                            Dashboard
-                        </a>
+                        @if (Route::has('dashboard'))
+                            <a
+                                href="{{ url('/dashboard') }}"
+                                class="inline-block px-5 py-1.5 dark:text-[#EDEDEC] border-[#19140035] hover:border-[#1915014a] border text-[#1b1b18] dark:border-[#3E3E3A] dark:hover:border-[#62605b] rounded-sm text-sm leading-normal"
+                            >
+                                Dashboard
+                            </a>
+                        @endif
                     @else
                         <a
                             href="{{ route('login') }}"


### PR DESCRIPTION
### 🔧 Description

This pull request adds a missing `Route::has('dashboard')` condition around the **Dashboard** anchor tag in the `welcome.blade.php` file.

In a fresh Laravel installation, the `login` and `register` buttons are already conditionally displayed using `Route::has(...)` checks. However, the **Dashboard** link is currently shown unconditionally. This can cause confusion or render a broken link if the `dashboard` route hasn't been defined yet (e.g., when Laravel Breeze, Jetstream, or custom auth systems are not installed).

This update brings consistency and better UX to the default welcome page.

---

### ✅ Before

```blade
<a
    href="{{ url('/dashboard') }}"
    class="inline-block px-5 py-1.5 dark:text-[#EDEDEC] border-[#19140035] hover:border-[#1915014a] border text-[#1b1b18] dark:border-[#3E3E3A] dark:hover:border-[#62605b] rounded-sm text-sm leading-normal"
>
    Dashboard
</a>
```

---

### ✅ After

```blade
@if (Route::has('dashboard'))
    <a
        href="{{ url('/dashboard') }}"
        class="inline-block px-5 py-1.5 dark:text-[#EDEDEC] border-[#19140035] hover:border-[#1915014a] border text-[#1b1b18] dark:border-[#3E3E3A] dark:hover:border-[#62605b] rounded-sm text-sm leading-normal"
    >
        Dashboard
    </a>
@endif
```

---

### 📌 Why This Is Useful

- Prevents broken links in projects that don’t define a `dashboard` route.
- Keeps the logic consistent with the existing checks for `login` and `register` routes.
- Improves Developer Experience (DX), especially for beginners setting up Laravel.

---

### 🧪 Testing

- ✅ Verified that the dashboard link is hidden when the `dashboard` route is not defined.
- ✅ Confirmed that the link shows properly when the user is authenticated and the route exists.

---

### 💬 Additional Notes

No functionality has been removed or changed — only a conditional check has been added to avoid potential confusion or UI inconsistencies.
