### PR TITLE
[12.x] Refactor default migration tables to use datetime instead of timestamp

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,13 +18,13 @@ return new class extends Migration
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
-            $table->timestamps();
+            $table->datetimes();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
             $table->string('email')->primary();
             $table->string('token');
-            $table->timestamp('created_at')->nullable();
+            $table->dateTime('created_at')->nullable();
         });
 
         Schema::create('sessions', function (Blueprint $table) {

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -41,7 +41,7 @@ return new class extends Migration
             $table->text('queue');
             $table->longText('payload');
             $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
+            $table->dateTime('failed_at')->useCurrent();
         });
     }
 


### PR DESCRIPTION
## Summary

This PR updates the default migration files to use `datetime()` columns instead of the default `timestamp()` helper.

- `users` table
- `password_reset_tokens` table
- `failed_jobs` table

## Why?

The change is motivated by the approaching Year 2038 problem, where 32-bit UNIX timestamps may overflow and cause unexpected behavior.

By switching to `datetime`, we ensure a broader date range and better long-term compatibility—especially for applications that may store historical or future-dated records.

## Impact

- Enhances date robustness going forward.
- Aligns better with best practices for long-lived systems.
- It may serve as a reference for other tables where long-term timestamp precision is critical.

