### PR TITLE
[12.x] Reverts #6613

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-    "$schema": "https://json.schemastore.org/package.json",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Description
---
In practice, editors provide autocomplete and validation for `package.json` without explicitly specifying the `$schema`.

Validation
---
![Screenshot (820)](https://github.com/user-attachments/assets/0c4ca14f-0647-4241-9a6f-134c60aeb6f4)

Autocomplete
---
![Screenshot (822)](https://github.com/user-attachments/assets/ca6aec36-9d07-4702-8cdb-f143b11a1716)
