### PR TITLE
Add jdd() helper function to make api debugging easier

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,11 +1,11 @@
 <?php
-if (!function_exists('jdd')) {
+if (! function_exists('jdd')) {
 	/**
 	 * JSON Dump and Die.
 	 * Return a JSON response and immediately stops program execution.
 	 *
-	 * @param mixed $data The data to convert to JSON and send as response.
-	 * @param int|null $status HTTP status code (default is 200).
+	 * @param  mixed  $data  The data to convert to JSON and send as response.
+	 * @param  int|null  $status  HTTP status code (default is 200).
 	 * @return void
 	 */
 	function jdd($data, $status = 200): void

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,0 +1,19 @@
+<?php
+if (!function_exists('jdd')) {
+	/**
+	 * JSON Dump and Die.
+	 * Return a JSON response and immediately stops program execution.
+	 *
+	 * @param mixed $data The data to convert to JSON and send as response.
+	 * @param int|null $status HTTP status code (default is 200).
+	 * @return void
+	 */
+	function jdd($data, $status = 200): void
+	{
+		while (ob_get_level()) {
+			ob_end_clean();
+		}
+		response()->json($data, $status)->send();
+		exit;
+	}
+}

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,19 +1,21 @@
 <?php
+
 if (! function_exists('jdd')) {
-	/**
-	 * JSON Dump and Die.
-	 * Return a JSON response and immediately stops program execution.
-	 *
-	 * @param  mixed  $data  The data to convert to JSON and send as response.
-	 * @param  int|null  $status  HTTP status code (default is 200).
-	 * @return void
-	 */
-	function jdd($data, $status = 200): void
-	{
-		while (ob_get_level()) {
-			ob_end_clean();
-		}
-		response()->json($data, $status)->send();
-		exit;
-	}
+    /**
+     * JSON Dump and Die.
+     * Return a JSON response and immediately stops program execution.
+     *
+     * @param  mixed  $data  The data to convert to JSON and send as response.
+     * @param  int|null  $status  HTTP status code (default is 200).
+     * @return void
+     */
+    function jdd($data, $status = 200): void
+    {
+        while (ob_get_level()) {
+            ob_end_clean();
+        }
+
+        response()->json($data, $status)->send();
+        exit;
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Blade::directive('jdd', function ($expression) {
+            return "<?php jdd(...[$expression]); ?>";
+        });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Helpers/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
## What is the `jdd()` Function?

The `jdd()` function stands for *JSON Dump and Die*. It works similarly to Laravel's `dd()` function, but instead of returning an HTML debug page, it returns a *JSON response*.

This helper is especially useful for debugging *APIs*, where JSON responses are more suitable than HTML output.

---

### Example Usage

*Before using `jdd()`:*
```
Route::get('/test', function () 
    return response()->json("ok");
);
```

After using `jdd()`:
```
Route::get('/test', function () {
    jdd("ok");
});
```

Both return the same response, but `jdd()` is shorter and simpler for debugging purposes.

---

### Using in Blade

You can also use `jdd()` inside Blade templates:
```
@jdd("ok")
```

---

### Parameters

The `jdd()` function accepts two parameters (one optional):
```
jdd(data, status = 200)
```

- data (mixed): The data to return as a JSON response.
- status (int, optional): HTTP status code (default is 200).

---

### Why Add This?

- Writing return `response()->json()` is too verbose for quick debugging.
- `dd()` returns HTML, which is not ideal for API development.
- `jdd()` simplifies and speeds up debugging during API development.

---

### Closing

Thank you for reading!  
This is my first contribution — I hope it helps others working with APIs in Laravel. 😊