### PR TITLE
[12.x] Fix: Add void return type to satisfy Rector analysis

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,9 +10,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
-    ->withMiddleware(function (Middleware $middleware) {
+    ->withMiddleware(function (Middleware $middleware): void {
         //
     })
-    ->withExceptions(function (Exceptions $exceptions) {
+    ->withExceptions(function (Exceptions $exceptions): void {
         //
     })->create();


### PR DESCRIPTION
Rector modifies the bootstrap/app.php file by declaring the return types of the withMiddleware and withExceptions functions as void. This PR adds those return type declarations to ensure new installations comply with Rector.