### PR TITLE
[12.x] Reduce redundancy and keeps the .gitignore file cleaner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,4 @@
 /vendor
 Homestead.json
 Homestead.yaml
-npm-debug.log
 Thumbs.db
-yarn-error.log


### PR DESCRIPTION
Description
---
I think the `*.log` already covers `yarn-error.log` and `npm-debug.log`, Since `*.log` matches any file ending in `.log`, including those two, explicitly listing them is unnecessary unless they need special treatment.