### PR TITLE
[12.x] Explicitly bind Console Kernel in bootstrap/app.php for …

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,8 +3,10 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use App\Console\Kernel as AppConsoleKernel;
 
-return Application::configure(basePath: dirname(__DIR__))
+$app = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
@@ -15,4 +17,12 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //
-    })->create();
+    })
+    ->create();
+
+// Register the binding for the Kernel Console
+$app->singleton(ConsoleKernelContract::class, function ($app) {
+    return $app->make(AppConsoleKernel::class);
+});
+
+return $app;


### PR DESCRIPTION
…proper Artisan command and schedule handling

### Issue

With the new fluent configuration API introduced in Laravel 12 for `bootstrap/app.php`, the Console Kernel is not automatically registered in the service container. This causes scheduled commands and Artisan commands to fail silently or report messages like:

> No scheduled commands are ready to run.

and prevents proper execution of Artisan commands.

---

### Solution

This pull request explicitly binds the `Illuminate\Contracts\Console\Kernel` interface to the `App\Console\Kernel` implementation inside `bootstrap/app.php`. This ensures that the framework can correctly resolve the Console Kernel when handling scheduled tasks and Artisan commands.

---

### Changes made

Added the following binding in `bootstrap/app.php`:

```php
use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
use App\Console\Kernel as AppConsoleKernel;

$app->singleton(ConsoleKernelContract::class, function ($app) {
    return $app->make(AppConsoleKernel::class);
});