### PR TITLE
Add Vite 7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^1.2.0",
+        "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.2.4"
+        "vite": "^7.0.0"
     }
 }


### PR DESCRIPTION
Adds Vite 7 support. Locking to Vite version `^7.0.4` as there is a minor bug in the previous v7 versions.