### PR TITLE
[12.x]: fix CSRF token mismatch #56275

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug((string) env('APP_NAME', 'laravel')).'_session'
     ),
 
     /*


### PR DESCRIPTION
based on issue [#56275](https://github.com/laravel/framework/issues/56275)

the actual problem is Taylow was mistaken use `Str::snake` in https://github.com/laravel/laravel/commit/dd473eaddc824aeada037f0dc702a3b68a51946c instead of `Str::slug` so that was the problem since the rest config is using :

`'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),` in database.php

and

`'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-cache-'),` in cache.php