### PR TITLE
Revert "fix"

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::snake((string) env('APP_NAME', 'laravel')).'_session'
+        Str::slug(env('APP_NAME', 'laravel')).'-session'
     ),
 
     /*


### PR DESCRIPTION
This reverts commit dd473eaddc824aeada037f0dc702a3b68a51946c.

I don't know what this commit was supposed to fix, because the commit message doesn't mention it and neither do the release notes / changelog. This does however cause issues if you have a dot (`.`) in your app name. See laravel/framework#56449 and https://github.com/laravel/framework/issues/16167#issuecomment-257186898

If the app name is set to `myapp.com` then PHP would convert the dot to an underscore. Inspecting the request it would set the cookie `myapp.com_session`, but then dumping the cookies on the server (`$request->cookies`) it would show `myapp_com_session` with the value being `null`