### PR TITLE
Change composer post-autoload-dump script to Artisan command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "@php artisan optimize:clear",
+            "@php artisan config:clear",
+            "@php artisan clear-compiled",
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan optimize:clear",
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [


### PR DESCRIPTION
This is a suggestion to help solve an issue with the OpenTelemetry PHP SDK package but may also help other packages from falling into the same trap.  There is an open issue here: https://github.com/open-telemetry/opentelemetry-php/issues/1673

Laravel adds a PHP callback script to the post-autoload-dump event in composer.json

https://github.com/laravel/laravel/blob/12.x/composer.json#L36
```json
"scripts": {
        "post-autoload-dump": [
            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
```

https://getcomposer.org/doc/articles/scripts.md#scripts
When Composer runs PHP callback scripts it means you are inheriting all the dependencies of the composer.phar.  This is not normally an issue if the script is fairly simple however the Laravel postAutoloadDump function calls the Composer autoload.php to load all dependencies necessary for Laravel to run.  This means any packages that include any code in autoloaded files also gets run.  In the case of the OpenTelemetry SDK it is instantiating a v3 Psr/Log/NullLogger instance in the autoload however Composer is using an older version of the Psr/Log package causing the script to fail.

If the intention is for the script to call Laravel with the correct dependencies it would make more sense to call it as an artisan command as this will create a dedicated PHP process and ensure the correct dependencies are being loaded for the command.

My suggested change is to swap the postAutoloadDump to use the `config:clear` and `clear-compiled` commands as they are a direct replacement to the original script.

I'm open to suggestions on a better command that would be more appropriate or if there are undesired consequences to this change.  I initially tried `optimize:clear` however the tests failed as it assumes the cache layer exists using sqlite but the sqlite database doesn't exist unless you create a project instead so the command fails.  Should `optimize:clear` fail if the cache layer is not available? Alternatively we could consider adding the `config:clear` to the `clear-compiled` command so we only have the one command to run?

Thanks