### PR TITLE
[12.x] Use application name from configuration

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Laravel</title>
+        <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
Description
---
Update the `title` tag in `welcome.blade.php` to use the `config()` helper instead of a hardcoded the "Laravel" value.
This makes the title consistent with Laravel’s **Vue** and **React** starter kits and automatically reflects the application name defined in `config/app.php`.

See
---
https://github.com/laravel/vue-starter-kit/blob/e6cd4ded892621ea24cd3519fe2ab5539481c616/resources/views/app.blade.php#L33C24-L33C47

https://github.com/laravel/react-starter-kit/blob/322194c278b73ecf6a042f2960fa8e700bdc57ef/resources/views/app.blade.php#L33C24-L33C47