### PR TITLE
fix: do not exclude .vscode/mcp.json, .vscode/settings.json, .vscode/extensions.json, .vscode/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@
 /.idea
 /.nova
 /.phpunit.cache
-/.vscode
+/.vscode/*
+!/.vscode/settings.json
+!/.vscode/extensions.json
+!/.vscode/launch.json
+!/.vscode/mcp.json
 /.zed
 /auth.json
 /node_modules


### PR DESCRIPTION
This PR is aimed to prevent Git from ignoring VSCode files that should actually be committed:

 - `mcp.json`: coming from amazing Laravel Boost 🚀 
 - `settings.json`: https://code.visualstudio.com/docs/configure/settings#_settings-json-file
 - `extensions.json`: https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_workspace-recommended-extensions
 - `launch.json`: https://code.visualstudio.com/docs/debugtest/debugging-configuration
