### PR TITLE
Bring back postAutoloadDump script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "@php artisan config:clear",
-            "@php artisan clear-compiled",
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
         "post-update-cmd": [


### PR DESCRIPTION
This PR reverts #6647 which unfortunately broke things.

If you do a `composer update` which results in a service provider being *removed*, the `artisan config:clear` fails with an error about the service provider not being found.

```
- Upgrading intervention/image (2.7.2 => 3.11.4): Extracting archive

...

Generating optimized autoload files
> @php artisan config:clear

In Application.php line 960:
                                                             
  Class "Intervention\Image\ImageServiceProvider" not found  
                                                             
Script @php artisan config:clear handling the post-autoload-dump event returned with error code 1
```

This is because `artisan` is now running before the package manifest is updated. 

The `postAutoloadDump` would clear the cached files without booting Laravel. It being a composer script and not just an artisan command was probably exactly for this reason.

Obviously this doesn't fix @lmjhs 's original issue (sorry!) but I figure you'd rather have an existing thing continue working.