### PR TITLE
[12.x] Add default Redis retry configuration

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -158,12 +158,10 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
-            ...extension_loaded('redis') ? [
-                'max_retries' => env('REDIS_MAX_RETRIES', 3),
-                'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
-                'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-                'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
-            ] : [],
+            'max_retries' => env('REDIS_MAX_RETRIES', 3),
+            'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
+            'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+            'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
         ],
 
         'cache' => [
@@ -173,12 +171,10 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
-            ...extension_loaded('redis') ? [
-                'max_retries' => env('REDIS_MAX_RETRIES', 3),
-                'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
-                'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-                'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
-            ] : [],
+            'max_retries' => env('REDIS_MAX_RETRIES', 3),
+            'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
+            'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+            'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -158,19 +158,12 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
-            ...extension_loaded('redis')
-                ? [
-                    'max_retries' => env('REDIS_MAX_RETRIES', 3),
-                    'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {
-                        'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
-                        'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
-                        'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
-                        'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
-                        'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
-                    },
-                    'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-                    'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
-                ] : [],
+            ...extension_loaded('redis') ? [
+                'max_retries' => env('REDIS_MAX_RETRIES', 3),
+                'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
+                'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+                'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+            ] : [],
         ],
 
         'cache' => [
@@ -180,19 +173,12 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
-            ...extension_loaded('redis')
-                ? [
-                    'max_retries' => env('REDIS_MAX_RETRIES', 3),
-                    'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {
-                        'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
-                        'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
-                        'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
-                        'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
-                        'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
-                    },
-                    'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-                    'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
-                ] : [],
+            ...extension_loaded('redis') ? [
+                'max_retries' => env('REDIS_MAX_RETRIES', 3),
+                'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
+                'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+                'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+            ] : [],
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -158,6 +158,19 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
+            ...env('REDIS_CLIENT', 'phpredis') === 'phpredis' && extension_loaded('redis')
+                ? [
+                    'max_retries' => env('REDIS_MAX_RETRIES', 3),
+                    'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {
+                        'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
+                        'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
+                        'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
+                        'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
+                        'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
+                    },
+                    'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+                    'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+                ] : [],
         ],
 
         'cache' => [
@@ -167,6 +180,19 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
+            ...env('REDIS_CLIENT', 'phpredis') === 'phpredis' && extension_loaded('redis')
+                ? [
+                    'max_retries' => env('REDIS_MAX_RETRIES', 3),
+                    'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {
+                        'default' => Redis::BACKOFF_ALGORITHM_DEFAULT,
+                        'exponential' => Redis::BACKOFF_ALGORITHM_EXPONENTIAL,
+                        'full_jitter' => Redis::BACKOFF_ALGORITHM_FULL_JITTER,
+                        'equal_jitter' => Redis::BACKOFF_ALGORITHM_EQUAL_JITTER,
+                        'decorrelated_jitter' => Redis::BACKOFF_ALGORITHM_DECORRELATED_JITTER,
+                    },
+                    'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
+                    'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+                ] : [],
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -158,7 +158,7 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
-            ...env('REDIS_CLIENT', 'phpredis') === 'phpredis' && extension_loaded('redis')
+            ...extension_loaded('redis')
                 ? [
                     'max_retries' => env('REDIS_MAX_RETRIES', 3),
                     'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {
@@ -180,7 +180,7 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
-            ...env('REDIS_CLIENT', 'phpredis') === 'phpredis' && extension_loaded('redis')
+            ...extension_loaded('redis')
                 ? [
                     'max_retries' => env('REDIS_MAX_RETRIES', 3),
                     'backoff_algorithm' => match (env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter')) {


### PR DESCRIPTION
Allows Redis connections to be retried automatically. 

The additional configuration is only applied if the `phpredis` extension is loaded. It depends on constants that are not available without it — for users running other cache drivers, or running Predis, nothing changes.

`decorrelated_jitter` is used by default to avoid "retry storms" — [Here's an AWS article](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)

With the default configuration, retry delays would be ~300ms, ~600ms, ~1000ms, for a ~2 second total retry window.

This is a bit of a beefy config, mostly because of that `match` statement — maybe we could pass strings and parse them on `framework` — that'd also solve having to be careful with calling the `Redis` namespace