### PR TITLE
[12.x] Fix type casting for environment variables in config files

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -129,7 +129,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel')).'-session'
+        Str::slug((string) env('APP_NAME', 'laravel')).'-session'
     ),
 
     /*


### PR DESCRIPTION
Continuation of: #6637