### PR TITLE
docs(env): update session security settings in example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
+SESSION_SECURE_COOKIE=true  # Only send over HTTPS
+SESSION_HTTP_ONLY=true      # Prevent JavaScript access
+SESSION_SAME_SITE=strict    # Better CSRF protection
+
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database


### PR DESCRIPTION
Add recommended security settings for session cookies including HTTPS-only, HTTP-only, and SameSite strict policies to improve security by default.