### PR TITLE
Update .editorconfig to target compose.yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
-[docker-compose.yml]
+[compose.yaml]
 indent_size = 4


### PR DESCRIPTION
Since Laravel Sail [renamed its Compose file](https://github.com/laravel/sail/pull/818) from `docker-compose.yml` to `compose.yaml`, 
this PR updates the `.editorconfig` in the Laravel framework to match.

This ensures consistency across Laravel projects and aligns with the Compose specification, 
which recommends `compose.yaml` as the canonical filename.