### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Laravel is accessible, powerful, and provides tools required for large, robust a
 
 Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
-
 If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+
+You can also watch bite-sized lessons with real-world projects on [Laravel Learn](https://laravel.com/learn), where you will be guided through building a Laravel application from scratch while learning PHP fundamentals.
 
 ## Laravel Sponsors
 


### PR DESCRIPTION
self-explanatory, bootcamp.laravel.com domain no longer exist, and it's redirects to laravel.com/learn

just like laravel/framework README.md

https://github.com/laravel/framework/pull/57176/files