### PR TITLE
Decouple TailwindCSS from Default Laravel Installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,9 @@
         "dev": "vite"
     },
     "devDependencies": {
-        "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.11.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
-        "tailwindcss": "^4.0.0",
         "vite": "^7.0.7"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
     plugins: [
@@ -8,6 +7,5 @@ export default defineConfig({
             input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
-        tailwindcss(),
     ],
 });


### PR DESCRIPTION
## Summary

This pull request updates the default Laravel installation process to remove TailwindCSS as a mandatory dependency. The goal is to preserve Laravel’s core philosophy of developer freedom and provide a cleaner, more neutral starting point for all project types.

## Motivation

Not all Laravel applications require TailwindCSS or any frontend styling framework. Many projects are:

- API-only, or backend-driven
- Using Vue, React, or custom SCSS setups
- Minimal services that don’t need compiled CSS at all

Bundling TailwindCSS by default adds unnecessary dependencies, configuration files, and build steps for these cases.

Fix: https://github.com/laravel/framework/issues/57415