### PR TITLE
[12.x] Update composer dev script to ensure no timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
         ],
         "test": [
             "@php artisan config:clear --ansi",


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/58178

This is simply because without the timeout set, it's defaulting to 60 - so when you close your laptop etc the child process times out.

This aligns it with the pail timeout :) 

TLDR - 

If you run: 

```
laravel new demo
cd demo 
// run...
composer run dev
// Close your laptop for a min or 2
```

You get: 
```
[queue]   The process "'/opt/homebrew/Cellar/php/8.4.14/bin/php' 'artisan' 'queue:work' '--once' '--name=default' '--queue=default' '--backoff=0' '--memory=128' '--sleep=3' '--tries=1'" exceeded the timeout of 60 seconds.
[queue] 
[queue]   at vendor/symfony/process/Process.php:1191
[logs] ┌ 15:46:33 Symfony\Component\...\ProcessTimedOutException ── vendor/symfony/pro... ┐
[logs] │ The process "'/opt/homebrew/Cellar/php/8.4.14/bin/php' 'artisan' 'queue:wor... │
[logs] └──────────────────────────────────────────────────────── artisan queue:listen ┘
[queue]     1187▕ 
[queue]     1188▕         if (null !== $this->timeout && $this->timeout < microtime(true) - $this->starttime) {
[queue]     1189▕             $this->stop(0);
[queue]     1190▕ 
[queue]   ➜ 1191▕             throw new ProcessTimedOutException($this, ProcessTimedOutException::TYPE_GENERAL);
[queue]     1192▕         }
[queue]     1193▕ 
[queue]     1194▕         if (null !== $this->idleTimeout && $this->idleTimeout < microtime(true) - $this->lastOutputTime) {
[queue]     1195▕             $this->stop(0);
[queue] 
[queue]       +18 vendor frames 
[queue] 
[queue]   19  artisan:16
[queue]       Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
[queue] 
[queue] php artisan queue:listen --tries=1 --timeout=60 exited with code 1
```

