### PR TITLE
[13.x] Uses PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/pint": "^1.27",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^11.5.50"
+        "phpunit/phpunit": "^12.5.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since we are dropping PHP 8.2, we can safely move to PHPUnit 12.