### PR TITLE
[13.x] Fixes PHP version used on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 


### PR DESCRIPTION
We no longer supporting PHP 8.2, so this pull request drops it on the Github workflow + adds tests against PHP 8.5