### PR TITLE
[12.x] Add `APP_NAME` fallback in mail config

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -112,7 +112,7 @@ return [
 
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'name' => env('MAIL_FROM_NAME', env('APP_NAME', 'Laravel')),
     ],
 
 ];


### PR DESCRIPTION
## Summary

- The `MAIL_FROM_NAME` config value currently falls back to the generic `"Example"` when unset, which is not meaningful for any application.
- This updates the fallback to use `APP_NAME` instead, consistent with `.env.example` where `MAIL_FROM_NAME` already references `${APP_NAME}`.
- Follows the same pattern as #6742 which added an `APP_URL` fallback in the filesystems config.