### PR TITLE
[13.x] Ensure setup script creates SQLite database file before migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
             "composer install",
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate",
+            "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --force",
             "npm install",
             "npm run build"


### PR DESCRIPTION
## Summary

Ensure `composer setup` creates `database/database.sqlite` before running migrations.

## Problem

On fresh installs using the default SQLite setup, `composer setup` may run `php artisan migrate --force` before `database/database.sqlite` exists, which can cause setup to fail.

## Solution

Add a pre-migration step in the `setup` script:

- Create `database/database.sqlite` if it does not exist.

This mirrors the safeguard already used in `post-create-project-cmd`.

## Validation

- `composer validate --no-check-publish --strict`
- Confirmed the setup script now guarantees SQLite file presence before migration.