### PR TITLE
[12.x] Neutralize DB_URL in default phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_URL" value=""/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/58985 by adding `<env name="DB_URL" value=""/>` to the default `phpunit.xml`. This prevents tests from unintentionally running against production/staging databases when `DB_URL` is defined in `.env`.