### PR TITLE
[12.x] Add `APP_NAME` fallback in Slack log channel username

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -76,7 +76,7 @@ return [
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+            'username' => env('LOG_SLACK_USERNAME', env('APP_NAME', 'Laravel')),
             'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
             'level' => env('LOG_LEVEL', 'critical'),
             'replace_placeholders' => true,


### PR DESCRIPTION
The `LOG_SLACK_USERNAME` config value currently falls back to the generic `"Laravel Log"` when unset, which doesn't help identify which application is sending logs when multiple Laravel apps post to the same Slack channel.

This updates the fallback to use `APP_NAME` instead, consistent with `.env.example` where `APP_NAME` is already defined and used as the application identifier.

Follows the same pattern as #6755 which added an `APP_NAME` fallback in the mail config.