### PR TITLE
Add explicit PDO import for consistency with Pdo\Mysql import

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use PDO;
 use Pdo\Mysql;
 
 return [


### PR DESCRIPTION
PR #6760 introduced `use Pdo\Mysql` to use the new OOP PDO API on PHP 8.5+, but the PHP < 8.5 fallback still references `PDO::MYSQL_ATTR_SSL_CA` without an explicit `use PDO` import. While PHP resolves `PDO` from the global namespace correctly, adding the explicit import makes the file consistent and the intent clear.