### PR TITLE
[12.x] Bump Vite to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",
-        "vite": "^7.0.7"
+        "vite": "^8.0.0"
     }
 }


### PR DESCRIPTION
Vite 8 was released with Rolldown replacing esbuild and Rollup under the hood. The default Laravel config requires no changes, follow up https://github.com/laravel/vite-plugin/pull/341

https://vite.dev/guide/migration