### PR TITLE
[13.x] Update `postmark` Config Key

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -15,7 +15,7 @@ return [
     */
 
     'postmark' => [
-        'key' => env('POSTMARK_API_KEY'),
+        'token' => env('POSTMARK_TOKEN', env('POSTMARK_API_KEY')),
     ],
 
     'resend' => [


### PR DESCRIPTION
According to the latest version of the Postmark Laravel package, the correct value is `services.postmark.token`. We can confirm it here: https://github.com/craigpaul/laravel-postmark/blob/3.x/src/PostmarkServiceProvider.php#L28