### PR TITLE
Fix: PostgreSQL default username in database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -90,7 +90,7 @@ return [
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
             'database' => env('DB_DATABASE', 'laravel'),
-            'username' => env('DB_USERNAME', 'root'),
+            'username' => env('DB_USERNAME', 'postgres'),
             'password' => env('DB_PASSWORD', ''),
             'charset' => env('DB_CHARSET', 'utf8'),
             'prefix' => '',


### PR DESCRIPTION
The PostgreSQL connection was using 'root' as default username, but the actual default user is 'postgres'. 
MySQL/MariaDB use 'root', but not PostgreSQL. This change aligns the default with PostgreSQL's actual user.