### PR TITLE
Feat: add LOG_CHANNEL=null to phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,7 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="DB_URL" value=""/>
+        <env name="LOG_CHANNEL" value="null"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
Tests were writing to storage/logs/laravel.log instead of discarding logs. Other test drivers (CACHE_STORE, MAIL_MAILER, QUEUE_CONNECTION, SESSION_DRIVER) are already configured for testing. LOG_CHANNEL should also be set to 'null' to prevent disk I/O and keep test logs clean.