### PR TITLE
[13.x] Add session driver to cache config

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -39,6 +39,11 @@ return [
             'serialize' => false,
         ],
 
+        'session' => [
+            'driver' => 'session',
+            'key' => env('SESSION_CACHE_KEY', '_cache'),
+        ],
+
         'database' => [
             'driver' => 'database',
             'connection' => env('DB_CACHE_CONNECTION'),


### PR DESCRIPTION
upgrading some open source stuff.

I tend to go to the Framework as the source of truth rather than the skeleton and noticed a bit of drift. 

Perhaps this was done for a reason, but I dont imagine it was?

This copies the same as laravel/framework.