### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /storage/*.key
 /storage/pail
 /vendor
+_ide_helper.php
 Homestead.json
 Homestead.yaml
 Thumbs.db


### PR DESCRIPTION
Laravel ide helper is the most used IDE support package for laravel more than 120M download and without in VScode and PHPstorm isn't getting a Powerfull Facades helper.