### PR TITLE
Update php platform in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "platform": {
+            "php": "8.3.0"
         }
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
I recently created a Laravel app in a new computer using the beginner friendly route with the Laravel installer in `php.new`, etc. However, that installed php 8.5, and when I ran `composer install`, composer chose the 8.5 version of symfony and other dependencies.

That in itself is not "a problem", but the [tests github actions workflow](https://github.com/laravel/laravel/blob/13.x/.github/workflows/tests.yml) runs a test matrix using 8.3, 8.4, 8.5. Of course, it fails because the dependencies in composer.lock are not compatible with php 8.3.

One solution would be to simply remove php 8.3 from the matrix (maybe even 8.4 as well), and that is what I did initially. But I also found out it's possible to use this `platform` config in composer.json to force it to install dependencies for an older platform.

Now, maybe you don't like this solution, and you can close this PR. But the issue remains that the default path for a beginner in Laravel is currently broken. If someone just creates an app and push it to github, they're going to face a broken CI. I figured, rather than open just an issue I would open a PR with a possible solution :).

Also, note that this is an issue in all the starter kits as well, so I guess you'll have to propagate whatever fix you decide to apply (if you decide to fix it).