### PR TITLE
Add debounceable queued jobs

### DIFF
--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -38,13 +38,11 @@ class DebounceLock
     {
         $debounceFor = method_exists($job, 'debounceFor')
             ? $job->debounceFor()
-            : ($this->getAttributeValue($job, DebounceFor::class, 'debounceFor') ?? 0);
-
-        $ttl = max($debounceFor * 2, 10);
+            : $this->getAttributeValue($job, DebounceFor::class, 'debounceFor');
 
         $cache = $this->resolveCache($job);
 
-        $lock = $cache->lock(static::getKey($job), $ttl);
+        $lock = $cache->lock(static::getKey($job), $debounceFor);
 
         $lock->forceRelease();
         $lock->get();

--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Bus;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Queue\Attributes\ReadsQueueAttributes;
+
+class DebounceLock
+{
+    use ReadsQueueAttributes;
+
+    /**
+     * The cache repository implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * Create a new debounce lock manager instance.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     */
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Acquire a debounce lock for the given job.
+     *
+     * Force-releases any existing lock and acquires a new one,
+     * implementing last-writer-wins semantics.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    public function acquire($job): string
+    {
+        $debounceFor = method_exists($job, 'debounceFor')
+            ? $job->debounceFor()
+            : ($this->getAttributeValue($job, DebounceFor::class, 'debounceFor') ?? 0);
+
+        $ttl = max($debounceFor * 2, 10);
+
+        $cache = $this->resolveCache($job);
+
+        $lock = $cache->lock(static::getKey($job), $ttl);
+
+        $lock->forceRelease();
+        $lock->get();
+
+        return $lock->owner();
+    }
+
+    /**
+     * Determine if the given owner is the current lock owner.
+     *
+     * @param  mixed  $job
+     * @param  string  $owner
+     * @return bool
+     */
+    public function isCurrentOwner($job, string $owner): bool
+    {
+        $cache = $this->resolveCache($job);
+
+        return $cache->restoreLock(static::getKey($job), $owner)
+            ->isOwnedByCurrentProcess();
+    }
+
+    /**
+     * Release the debounce lock for the given job.
+     *
+     * @param  mixed  $job
+     * @return void
+     */
+    public function release($job): void
+    {
+        $cache = $this->resolveCache($job);
+
+        $cache->lock(static::getKey($job))->forceRelease();
+    }
+
+    /**
+     * Generate the lock key for the given job.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    public static function getKey($job): string
+    {
+        $debounceId = method_exists($job, 'debounceId')
+            ? $job->debounceId()
+            : ($job->debounceId ?? '');
+
+        $jobName = method_exists($job, 'displayName')
+            ? hash('xxh128', $job->displayName())
+            : get_class($job);
+
+        return 'laravel_debounced_job:'.$jobName.':'.$debounceId;
+    }
+
+    /**
+     * Resolve the cache store for the given job.
+     *
+     * @param  mixed  $job
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    protected function resolveCache($job): Cache
+    {
+        return method_exists($job, 'debounceVia')
+            ? ($job->debounceVia() ?? $this->cache)
+            : $this->cache;
+    }
+}

--- a/src/Illuminate/Bus/DebounceLock.php
+++ b/src/Illuminate/Bus/DebounceLock.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Bus;
 
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Queue\Attributes\DebounceFor;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
@@ -13,14 +14,12 @@ class DebounceLock
     /**
      * The cache repository implementation.
      *
-     * @var \Illuminate\Contracts\Cache\Repository
+     * @var Repository
      */
     protected $cache;
 
     /**
      * Create a new debounce lock manager instance.
-     *
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      */
     public function __construct(Cache $cache)
     {
@@ -34,7 +33,6 @@ class DebounceLock
      * implementing last-writer-wins semantics.
      *
      * @param  mixed  $job
-     * @return string
      */
     public function acquire($job): string
     {
@@ -58,8 +56,6 @@ class DebounceLock
      * Determine if the given owner is the current lock owner.
      *
      * @param  mixed  $job
-     * @param  string  $owner
-     * @return bool
      */
     public function isCurrentOwner($job, string $owner): bool
     {
@@ -73,7 +69,6 @@ class DebounceLock
      * Release the debounce lock for the given job.
      *
      * @param  mixed  $job
-     * @return void
      */
     public function release($job): void
     {
@@ -86,7 +81,6 @@ class DebounceLock
      * Generate the lock key for the given job.
      *
      * @param  mixed  $job
-     * @return string
      */
     public static function getKey($job): string
     {
@@ -105,7 +99,6 @@ class DebounceLock
      * Resolve the cache store for the given job.
      *
      * @param  mixed  $job
-     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function resolveCache($job): Cache
     {

--- a/src/Illuminate/Contracts/Queue/ShouldBeDebounced.php
+++ b/src/Illuminate/Contracts/Queue/ShouldBeDebounced.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface ShouldBeDebounced
+{
+    //
+}

--- a/src/Illuminate/Foundation/Bus/InteractsWithDebouncedJobs.php
+++ b/src/Illuminate/Foundation/Bus/InteractsWithDebouncedJobs.php
@@ -18,7 +18,7 @@ use ReflectionClass;
  * $this->acquireDebounceLock() in __destruct() AFTER the
  * shouldDispatch() check but BEFORE the actual dispatch.
  *
- * @see \Illuminate\Foundation\Bus\PendingDispatch::__destruct()
+ * @see PendingDispatch::__destruct()
  */
 trait InteractsWithDebouncedJobs
 {
@@ -30,9 +30,8 @@ trait InteractsWithDebouncedJobs
      * It replaces any existing debounce lock for this job identity,
      * stores the owner token on the job, and sets the delay.
      *
-     * @return void
      *
-     * @throws \LogicException
+     * @throws LogicException
      */
     protected function acquireDebounceLock(): void
     {
@@ -63,8 +62,6 @@ trait InteractsWithDebouncedJobs
 
     /**
      * Read the debounceFor value from a DebounceFor PHP attribute.
-     *
-     * @return int
      */
     private function getDebounceForFromAttribute(): int
     {

--- a/src/Illuminate/Foundation/Bus/InteractsWithDebouncedJobs.php
+++ b/src/Illuminate/Foundation/Bus/InteractsWithDebouncedJobs.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Foundation\Bus;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\Attributes\DebounceFor;
+use LogicException;
+use ReflectionClass;
+
+/**
+ * Adds debounce lock acquisition to PendingDispatch.
+ *
+ * Integration: Use this trait in PendingDispatch and call
+ * $this->acquireDebounceLock() in __destruct() AFTER the
+ * shouldDispatch() check but BEFORE the actual dispatch.
+ *
+ * @see \Illuminate\Foundation\Bus\PendingDispatch::__destruct()
+ */
+trait InteractsWithDebouncedJobs
+{
+    /**
+     * Acquire a debounce lock for the job and set its delay.
+     *
+     * This method should be called in PendingDispatch::__destruct()
+     * AFTER the shouldDispatch() check but BEFORE the actual dispatch.
+     * It replaces any existing debounce lock for this job identity,
+     * stores the owner token on the job, and sets the delay.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    protected function acquireDebounceLock(): void
+    {
+        if (! $this->job instanceof ShouldBeDebounced) {
+            return;
+        }
+
+        if ($this->job instanceof ShouldBeUnique) {
+            throw new LogicException(
+                'A job cannot implement both ShouldBeDebounced and ShouldBeUnique. '.
+                'Debounce (last wins) and unique (first wins) are mutually exclusive.'
+            );
+        }
+
+        $lock = new DebounceLock(Container::getInstance()->make(Cache::class));
+        $this->job->debounceOwner = $lock->acquire($this->job);
+
+        if (is_null($this->job->delay)) {
+            $debounceFor = method_exists($this->job, 'debounceFor')
+                ? $this->job->debounceFor()
+                : $this->getDebounceForFromAttribute();
+
+            if ($debounceFor > 0) {
+                $this->job->delay = $debounceFor;
+            }
+        }
+    }
+
+    /**
+     * Read the debounceFor value from a DebounceFor PHP attribute.
+     *
+     * @return int
+     */
+    private function getDebounceForFromAttribute(): int
+    {
+        $attributes = (new ReflectionClass($this->job))
+            ->getAttributes(DebounceFor::class);
+
+        if (! empty($attributes)) {
+            return $attributes[0]->newInstance()->debounceFor;
+        }
+
+        return 0;
+    }
+}

--- a/src/Illuminate/Queue/Attributes/DebounceFor.php
+++ b/src/Illuminate/Queue/Attributes/DebounceFor.php
@@ -9,8 +9,6 @@ class DebounceFor
 {
     /**
      * Create a new attribute instance.
-     *
-     * @param  int  $debounceFor
      */
     public function __construct(public int $debounceFor)
     {

--- a/src/Illuminate/Queue/Attributes/DebounceFor.php
+++ b/src/Illuminate/Queue/Attributes/DebounceFor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Queue\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DebounceFor
+{
+    /**
+     * Create a new attribute instance.
+     *
+     * @param  int  $debounceFor
+     */
+    public function __construct(public int $debounceFor)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Queue/ChecksDebouncedJobs.php
+++ b/src/Illuminate/Queue/ChecksDebouncedJobs.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+use Illuminate\Queue\Events\JobDebounced;
+
+/**
+ * Adds debounce ownership checking to CallQueuedHandler.
+ *
+ * Integration: Use this trait in CallQueuedHandler and:
+ * 1. Call commandWasDebounced($command) in call() AFTER deserializing
+ *    the command but BEFORE dispatchThroughMiddleware().
+ *    If true, call handleDebouncedJob($job, $command) and return.
+ * 2. Call ensureDebounceLockIsReleased($command) after successful
+ *    execution (when job is not released).
+ *
+ * @see \Illuminate\Queue\CallQueuedHandler::call()
+ */
+trait ChecksDebouncedJobs
+{
+    /**
+     * Determine if the debounced command was superseded by a newer dispatch.
+     *
+     * @param  mixed  $command
+     * @return bool
+     */
+    protected function commandWasDebounced($command): bool
+    {
+        if (! $command instanceof ShouldBeDebounced) {
+            return false;
+        }
+
+        $owner = $command->debounceOwner ?? '';
+
+        if (empty($owner)) {
+            return false;
+        }
+
+        return ! (new DebounceLock(
+            $this->container->make(Cache::class)
+        ))->isCurrentOwner($command, $owner);
+    }
+
+    /**
+     * Handle a debounced (superseded) job.
+     *
+     * Fires the JobDebounced event and deletes the job from the queue.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  mixed  $command
+     * @return void
+     */
+    protected function handleDebouncedJob($job, $command): void
+    {
+        $this->container->make('events')->dispatch(
+            new JobDebounced($job->getConnectionName(), $job, $command)
+        );
+
+        $job->delete();
+    }
+
+    /**
+     * Release the debounce lock after a job finishes execution.
+     *
+     * @param  mixed  $command
+     * @return void
+     */
+    protected function ensureDebounceLockIsReleased($command): void
+    {
+        if (! $command instanceof ShouldBeDebounced) {
+            return;
+        }
+
+        (new DebounceLock(
+            $this->container->make(Cache::class)
+        ))->release($command);
+    }
+}

--- a/src/Illuminate/Queue/ChecksDebouncedJobs.php
+++ b/src/Illuminate/Queue/ChecksDebouncedJobs.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Illuminate\Bus\DebounceLock;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldBeDebounced;
 use Illuminate\Queue\Events\JobDebounced;
 
@@ -17,7 +18,7 @@ use Illuminate\Queue\Events\JobDebounced;
  * 2. Call ensureDebounceLockIsReleased($command) after successful
  *    execution (when job is not released).
  *
- * @see \Illuminate\Queue\CallQueuedHandler::call()
+ * @see CallQueuedHandler::call()
  */
 trait ChecksDebouncedJobs
 {
@@ -25,7 +26,6 @@ trait ChecksDebouncedJobs
      * Determine if the debounced command was superseded by a newer dispatch.
      *
      * @param  mixed  $command
-     * @return bool
      */
     protected function commandWasDebounced($command): bool
     {
@@ -49,9 +49,8 @@ trait ChecksDebouncedJobs
      *
      * Fires the JobDebounced event and deletes the job from the queue.
      *
-     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  Job  $job
      * @param  mixed  $command
-     * @return void
      */
     protected function handleDebouncedJob($job, $command): void
     {
@@ -66,7 +65,6 @@ trait ChecksDebouncedJobs
      * Release the debounce lock after a job finishes execution.
      *
      * @param  mixed  $command
-     * @return void
      */
     protected function ensureDebounceLockIsReleased($command): void
     {

--- a/src/Illuminate/Queue/Events/JobDebounced.php
+++ b/src/Illuminate/Queue/Events/JobDebounced.php
@@ -2,19 +2,20 @@
 
 namespace Illuminate\Queue\Events;
 
+use Illuminate\Contracts\Queue\Job;
+
 class JobDebounced
 {
     /**
      * Create a new event instance.
      *
      * @param  string  $connectionName  The connection name.
-     * @param  \Illuminate\Contracts\Queue\Job  $job  The queue job instance.
+     * @param  Job  $job  The queue job instance.
      * @param  mixed  $command  The deserialized command object.
      */
     public function __construct(
         public $connectionName,
         public $job,
         public $command,
-    ) {
-    }
+    ) {}
 }

--- a/src/Illuminate/Queue/Events/JobDebounced.php
+++ b/src/Illuminate/Queue/Events/JobDebounced.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobDebounced
+{
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName  The connection name.
+     * @param  \Illuminate\Contracts\Queue\Job  $job  The queue job instance.
+     * @param  mixed  $command  The deserialized command object.
+     */
+    public function __construct(
+        public $connectionName,
+        public $job,
+        public $command,
+    ) {
+    }
+}

--- a/src/Illuminate/Queue/HandlesDebouncedJobTransactions.php
+++ b/src/Illuminate/Queue/HandlesDebouncedJobTransactions.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Queue\ShouldBeDebounced;
  * $this->registerDebounceLockRollback($job) in enqueueUsing()
  * alongside the existing ShouldBeUnique rollback handler.
  *
- * @see \Illuminate\Queue\Queue::enqueueUsing()
+ * @see Queue::enqueueUsing()
  */
 trait HandlesDebouncedJobTransactions
 {
@@ -25,7 +25,6 @@ trait HandlesDebouncedJobTransactions
      * in Queue::enqueueUsing().
      *
      * @param  mixed  $job
-     * @return void
      */
     protected function registerDebounceLockRollback($job): void
     {

--- a/src/Illuminate/Queue/HandlesDebouncedJobTransactions.php
+++ b/src/Illuminate/Queue/HandlesDebouncedJobTransactions.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+
+/**
+ * Adds debounce lock rollback handling to the Queue base class.
+ *
+ * Integration: Use this trait in Queue and call
+ * $this->registerDebounceLockRollback($job) in enqueueUsing()
+ * alongside the existing ShouldBeUnique rollback handler.
+ *
+ * @see \Illuminate\Queue\Queue::enqueueUsing()
+ */
+trait HandlesDebouncedJobTransactions
+{
+    /**
+     * Register a rollback handler to release the debounce lock
+     * if the database transaction rolls back.
+     *
+     * This mirrors the existing ShouldBeUnique rollback pattern
+     * in Queue::enqueueUsing().
+     *
+     * @param  mixed  $job
+     * @return void
+     */
+    protected function registerDebounceLockRollback($job): void
+    {
+        if (! $job instanceof ShouldBeDebounced) {
+            return;
+        }
+
+        if ($this->shouldDispatchAfterCommit($job) &&
+            $this->container->bound('db.transactions')) {
+            $this->container->make('db.transactions')->addCallbackForRollback(
+                function () use ($job) {
+                    (new DebounceLock(
+                        $this->container->make(Cache::class)
+                    ))->release($job);
+                }
+            );
+        }
+    }
+}

--- a/src/Illuminate/Queue/Middleware/Debounced.php
+++ b/src/Illuminate/Queue/Middleware/Debounced.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class Debounced
+{
+    /**
+     * The debounce key.
+     *
+     * @var string
+     */
+    public string $key;
+
+    /**
+     * The debounce window in seconds.
+     *
+     * @var int
+     */
+    public int $debounceFor;
+
+    /**
+     * The lock owner token acquired at dispatch time.
+     *
+     * @var string
+     */
+    public string $owner;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * The constructor runs at dispatch time and acquires the debounce lock.
+     *
+     * @param  string  $key
+     * @param  int  $debounceFor
+     */
+    public function __construct(string $key = '', int $debounceFor = 60)
+    {
+        $this->key = $key;
+        $this->debounceFor = $debounceFor;
+
+        $debounceLock = new DebounceLock(
+            Container::getInstance()->make(Cache::class)
+        );
+
+        $this->owner = $debounceLock->acquire($this->createProxyJob());
+    }
+
+    /**
+     * Handle the job.
+     *
+     * Runs at execution time. Checks if this dispatch is still the current
+     * owner. If not, the job has been superseded and is deleted.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        $debounceLock = new DebounceLock(
+            Container::getInstance()->make(Cache::class)
+        );
+
+        $proxyJob = $this->createProxyJob();
+
+        if (! $debounceLock->isCurrentOwner($proxyJob, $this->owner)) {
+            $job->delete();
+
+            return;
+        }
+
+        try {
+            return $next($job);
+        } finally {
+            $debounceLock->release($proxyJob);
+        }
+    }
+
+    /**
+     * Create a proxy job object that provides the interface DebounceLock expects.
+     *
+     * @return object
+     */
+    protected function createProxyJob(): object
+    {
+        $key = $this->key;
+        $debounceFor = $this->debounceFor;
+
+        return new class($key, $debounceFor)
+        {
+            public function __construct(
+                private string $key,
+                private int $debounceFor,
+            ) {
+            }
+
+            public function debounceId(): string
+            {
+                return $this->key;
+            }
+
+            public function debounceFor(): int
+            {
+                return $this->debounceFor;
+            }
+
+            public function displayName(): string
+            {
+                return $this->key;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Queue/Middleware/Debounced.php
+++ b/src/Illuminate/Queue/Middleware/Debounced.php
@@ -28,7 +28,7 @@ class Debounced
      *
      * The constructor runs at dispatch time and acquires the debounce lock.
      */
-    public function __construct(string $key = '', int $debounceFor = 60)
+    public function __construct(string $key = '', int $debounceFor = 0)
     {
         $this->key = $key;
         $this->debounceFor = $debounceFor;

--- a/src/Illuminate/Queue/Middleware/Debounced.php
+++ b/src/Illuminate/Queue/Middleware/Debounced.php
@@ -10,22 +10,16 @@ class Debounced
 {
     /**
      * The debounce key.
-     *
-     * @var string
      */
     public string $key;
 
     /**
      * The debounce window in seconds.
-     *
-     * @var int
      */
     public int $debounceFor;
 
     /**
      * The lock owner token acquired at dispatch time.
-     *
-     * @var string
      */
     public string $owner;
 
@@ -33,9 +27,6 @@ class Debounced
      * Create a new middleware instance.
      *
      * The constructor runs at dispatch time and acquires the debounce lock.
-     *
-     * @param  string  $key
-     * @param  int  $debounceFor
      */
     public function __construct(string $key = '', int $debounceFor = 60)
     {
@@ -82,8 +73,6 @@ class Debounced
 
     /**
      * Create a proxy job object that provides the interface DebounceLock expects.
-     *
-     * @return object
      */
     protected function createProxyJob(): object
     {
@@ -95,8 +84,7 @@ class Debounced
             public function __construct(
                 private string $key,
                 private int $debounceFor,
-            ) {
-            }
+            ) {}
 
             public function debounceId(): string
             {

--- a/tests/Feature/Queue/DebouncedJobIntegrationTest.php
+++ b/tests/Feature/Queue/DebouncedJobIntegrationTest.php
@@ -43,9 +43,9 @@ class DebouncedJobIntegrationTest extends TestCase
     }
 }
 
-class FakeableDebouncedJob implements ShouldQueue, ShouldBeDebounced
+class FakeableDebouncedJob implements ShouldBeDebounced, ShouldQueue
 {
-    use Dispatchable, Queueable, InteractsWithQueue;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public string $debounceOwner = '';
 
@@ -59,14 +59,12 @@ class FakeableDebouncedJob implements ShouldQueue, ShouldBeDebounced
         return 30;
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
-class SyncDebouncedJob implements ShouldQueue, ShouldBeDebounced
+class SyncDebouncedJob implements ShouldBeDebounced, ShouldQueue
 {
-    use Dispatchable, Queueable, InteractsWithQueue;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public static bool $handled = false;
 

--- a/tests/Feature/Queue/DebouncedJobIntegrationTest.php
+++ b/tests/Feature/Queue/DebouncedJobIntegrationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DebouncedJobIntegrationTest extends TestCase
+{
+    public function test_queue_fake_captures_debounced_job_dispatches(): void
+    {
+        Queue::fake();
+
+        dispatch(new FakeableDebouncedJob);
+
+        Queue::assertPushed(FakeableDebouncedJob::class);
+    }
+
+    public function test_bus_fake_captures_debounced_job_dispatches(): void
+    {
+        Bus::fake();
+
+        FakeableDebouncedJob::dispatch();
+
+        Bus::assertDispatched(FakeableDebouncedJob::class);
+    }
+
+    public function test_sync_driver_executes_debounced_job_immediately(): void
+    {
+        config(['queue.default' => 'sync']);
+
+        SyncDebouncedJob::$handled = false;
+
+        dispatch(new SyncDebouncedJob);
+
+        $this->assertTrue(SyncDebouncedJob::$handled);
+    }
+}
+
+class FakeableDebouncedJob implements ShouldQueue, ShouldBeDebounced
+{
+    use Dispatchable, Queueable, InteractsWithQueue;
+
+    public string $debounceOwner = '';
+
+    public function debounceId(): string
+    {
+        return 'fakeable-test';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class SyncDebouncedJob implements ShouldQueue, ShouldBeDebounced
+{
+    use Dispatchable, Queueable, InteractsWithQueue;
+
+    public static bool $handled = false;
+
+    public string $debounceOwner = '';
+
+    public function debounceId(): string
+    {
+        return 'sync-test';
+    }
+
+    public function debounceFor(): int
+    {
+        return 0;
+    }
+
+    public function handle(): void
+    {
+        static::$handled = true;
+    }
+}

--- a/tests/Unit/Bus/DebounceLockTest.php
+++ b/tests/Unit/Bus/DebounceLockTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Tests\Unit\Bus;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Attributes\DebounceFor;
+use Illuminate\Queue\InteractsWithQueue;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class DebounceLockTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function test_acquire_returns_non_empty_owner_token(): void
+    {
+        $lock = $this->createMockLock('test-owner-token-123');
+        $cache = $this->createMockCacheForAcquire($lock, 60);
+
+        $debounceLock = new DebounceLock($cache);
+        $job = new DebounceLockTestJob;
+
+        $owner = $debounceLock->acquire($job);
+
+        $this->assertNotEmpty($owner);
+        $this->assertSame('test-owner-token-123', $owner);
+    }
+
+    public function test_acquire_force_releases_prior_lock_and_acquires_new(): void
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease')->once()->ordered();
+        $lock->shouldReceive('get')->once()->ordered();
+        $lock->shouldReceive('owner')->once()->andReturn('owner-1');
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 60)
+            ->once()
+            ->andReturn($lock);
+
+        $debounceLock = new DebounceLock($cache);
+        $owner1 = $debounceLock->acquire(new DebounceLockTestJob);
+
+        $lock2 = Mockery::mock(Lock::class);
+        $lock2->shouldReceive('forceRelease')->once()->ordered();
+        $lock2->shouldReceive('get')->once()->ordered();
+        $lock2->shouldReceive('owner')->once()->andReturn('owner-2');
+
+        $cache2 = Mockery::mock(Cache::class);
+        $cache2->shouldReceive('lock')
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 60)
+            ->once()
+            ->andReturn($lock2);
+
+        $debounceLock2 = new DebounceLock($cache2);
+        $owner2 = $debounceLock2->acquire(new DebounceLockTestJob);
+
+        $this->assertNotSame($owner1, $owner2);
+    }
+
+    public function test_is_current_owner_returns_true_for_current_owner(): void
+    {
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->once()->andReturn(true);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 'owner-token')
+            ->once()
+            ->andReturn($restoredLock);
+
+        $debounceLock = new DebounceLock($cache);
+        $result = $debounceLock->isCurrentOwner(new DebounceLockTestJob, 'owner-token');
+
+        $this->assertTrue($result);
+    }
+
+    public function test_is_current_owner_returns_false_after_another_acquire(): void
+    {
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->once()->andReturn(false);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 'old-owner')
+            ->once()
+            ->andReturn($restoredLock);
+
+        $debounceLock = new DebounceLock($cache);
+        $result = $debounceLock->isCurrentOwner(new DebounceLockTestJob, 'old-owner');
+
+        $this->assertFalse($result);
+    }
+
+    public function test_release_removes_the_lock(): void
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease')->once();
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')
+            ->with(DebounceLock::getKey(new DebounceLockTestJob))
+            ->once()
+            ->andReturn($lock);
+
+        $debounceLock = new DebounceLock($cache);
+        $debounceLock->release(new DebounceLockTestJob);
+
+        // Mockery verifies forceRelease was called; explicit assertion for PHPUnit
+        $this->assertTrue(true);
+    }
+
+    public function test_get_key_returns_correct_format(): void
+    {
+        $job = new DebounceLockTestJob;
+        $key = DebounceLock::getKey($job);
+
+        $expectedHash = hash('xxh128', $job->displayName());
+        $this->assertSame('laravel_debounced_job:'.$expectedHash.':test-entity-1', $key);
+    }
+
+    public function test_get_key_uses_empty_string_when_no_debounce_id(): void
+    {
+        $job = new DebounceLockTestJobNoId;
+        $key = DebounceLock::getKey($job);
+
+        $expectedHash = hash('xxh128', $job->displayName());
+        $this->assertSame('laravel_debounced_job:'.$expectedHash.':', $key);
+    }
+
+    public function test_acquire_uses_debounce_via_custom_cache_store(): void
+    {
+        $customLock = $this->createMockLock('custom-owner');
+        $customCache = Mockery::mock(Cache::class);
+        $customCache->shouldReceive('lock')
+            ->once()
+            ->andReturn($customLock);
+
+        $defaultCache = Mockery::mock(Cache::class);
+        $defaultCache->shouldNotReceive('lock');
+
+        $job = new DebounceLockTestJobWithVia($customCache);
+
+        $debounceLock = new DebounceLock($defaultCache);
+        $owner = $debounceLock->acquire($job);
+
+        $this->assertSame('custom-owner', $owner);
+    }
+
+    public function test_acquire_reads_debounce_for_from_attribute(): void
+    {
+        $lock = $this->createMockLock('attr-owner');
+        $cache = Mockery::mock(Cache::class);
+
+        // DebounceFor(45) -> TTL = max(45 * 2, 10) = 90
+        $cache->shouldReceive('lock')
+            ->with(Mockery::any(), 90)
+            ->once()
+            ->andReturn($lock);
+
+        $debounceLock = new DebounceLock($cache);
+        $job = new DebounceLockTestJobWithAttribute;
+
+        $owner = $debounceLock->acquire($job);
+        $this->assertSame('attr-owner', $owner);
+    }
+
+    public function test_acquire_prefers_method_over_attribute(): void
+    {
+        $lock = $this->createMockLock('method-owner');
+        $cache = Mockery::mock(Cache::class);
+
+        // debounceFor() method returns 30, so TTL = max(30 * 2, 10) = 60
+        // The attribute says 45, but the method should win
+        $cache->shouldReceive('lock')
+            ->with(Mockery::any(), 60)
+            ->once()
+            ->andReturn($lock);
+
+        $debounceLock = new DebounceLock($cache);
+        $job = new DebounceLockTestJobMethodAndAttribute;
+
+        $owner = $debounceLock->acquire($job);
+        $this->assertSame('method-owner', $owner);
+    }
+
+    /**
+     * Create a mock lock with standard behavior.
+     */
+    private function createMockLock(string $ownerToken): Lock
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease')->once();
+        $lock->shouldReceive('get')->once();
+        $lock->shouldReceive('owner')->once()->andReturn($ownerToken);
+
+        return $lock;
+    }
+
+    /**
+     * Create a mock cache that returns the given lock for acquire().
+     */
+    private function createMockCacheForAcquire(Lock $lock, int $expectedTtl): Cache
+    {
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')
+            ->with(Mockery::any(), $expectedTtl)
+            ->once()
+            ->andReturn($lock);
+
+        return $cache;
+    }
+}
+
+class DebounceLockTestJob implements ShouldQueue, ShouldBeDebounced
+{
+    use Queueable, InteractsWithQueue;
+
+    public function debounceId(): string
+    {
+        return 'test-entity-1';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function displayName(): string
+    {
+        return 'DebounceLockTestJob';
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class DebounceLockTestJobNoId implements ShouldQueue, ShouldBeDebounced
+{
+    use Queueable, InteractsWithQueue;
+
+    public function displayName(): string
+    {
+        return 'DebounceLockTestJobNoId';
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class DebounceLockTestJobWithVia implements ShouldQueue, ShouldBeDebounced
+{
+    use Queueable, InteractsWithQueue;
+
+    private Cache $customCache;
+
+    public function __construct(Cache $customCache)
+    {
+        $this->customCache = $customCache;
+    }
+
+    public function debounceId(): string
+    {
+        return 'via-test';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function displayName(): string
+    {
+        return 'DebounceLockTestJobWithVia';
+    }
+
+    public function debounceVia(): Cache
+    {
+        return $this->customCache;
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+#[DebounceFor(45)]
+class DebounceLockTestJobWithAttribute implements ShouldQueue, ShouldBeDebounced
+{
+    use Queueable, InteractsWithQueue;
+
+    public function debounceId(): string
+    {
+        return 'attr-test';
+    }
+
+    public function displayName(): string
+    {
+        return 'DebounceLockTestJobWithAttribute';
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+#[DebounceFor(45)]
+class DebounceLockTestJobMethodAndAttribute implements ShouldQueue, ShouldBeDebounced
+{
+    use Queueable, InteractsWithQueue;
+
+    public function debounceId(): string
+    {
+        return 'both-test';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function displayName(): string
+    {
+        return 'DebounceLockTestJobMethodAndAttribute';
+    }
+
+    public function handle(): void
+    {
+    }
+}

--- a/tests/Unit/Bus/DebounceLockTest.php
+++ b/tests/Unit/Bus/DebounceLockTest.php
@@ -23,7 +23,7 @@ class DebounceLockTest extends TestCase
     public function test_acquire_returns_non_empty_owner_token(): void
     {
         $lock = $this->createMockLock('test-owner-token-123');
-        $cache = $this->createMockCacheForAcquire($lock, 60);
+        $cache = $this->createMockCacheForAcquire($lock, 30);
 
         $debounceLock = new DebounceLock($cache);
         $job = new DebounceLockTestJob;
@@ -43,7 +43,7 @@ class DebounceLockTest extends TestCase
 
         $cache = Mockery::mock(Cache::class);
         $cache->shouldReceive('lock')
-            ->with(DebounceLock::getKey(new DebounceLockTestJob), 60)
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 30)
             ->once()
             ->andReturn($lock);
 
@@ -57,7 +57,7 @@ class DebounceLockTest extends TestCase
 
         $cache2 = Mockery::mock(Cache::class);
         $cache2->shouldReceive('lock')
-            ->with(DebounceLock::getKey(new DebounceLockTestJob), 60)
+            ->with(DebounceLock::getKey(new DebounceLockTestJob), 30)
             ->once()
             ->andReturn($lock2);
 
@@ -161,9 +161,9 @@ class DebounceLockTest extends TestCase
         $lock = $this->createMockLock('attr-owner');
         $cache = Mockery::mock(Cache::class);
 
-        // DebounceFor(45) -> TTL = max(45 * 2, 10) = 90
+        // DebounceFor(45) -> TTL = 45
         $cache->shouldReceive('lock')
-            ->with(Mockery::any(), 90)
+            ->with(Mockery::any(), 45)
             ->once()
             ->andReturn($lock);
 
@@ -179,10 +179,9 @@ class DebounceLockTest extends TestCase
         $lock = $this->createMockLock('method-owner');
         $cache = Mockery::mock(Cache::class);
 
-        // debounceFor() method returns 30, so TTL = max(30 * 2, 10) = 60
-        // The attribute says 45, but the method should win
+        // debounceFor() method returns 30 — method wins over attribute (45)
         $cache->shouldReceive('lock')
-            ->with(Mockery::any(), 60)
+            ->with(Mockery::any(), 30)
             ->once()
             ->andReturn($lock);
 

--- a/tests/Unit/Bus/DebounceLockTest.php
+++ b/tests/Unit/Bus/DebounceLockTest.php
@@ -221,9 +221,9 @@ class DebounceLockTest extends TestCase
     }
 }
 
-class DebounceLockTestJob implements ShouldQueue, ShouldBeDebounced
+class DebounceLockTestJob implements ShouldBeDebounced, ShouldQueue
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     public function debounceId(): string
     {
@@ -240,28 +240,24 @@ class DebounceLockTestJob implements ShouldQueue, ShouldBeDebounced
         return 'DebounceLockTestJob';
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
-class DebounceLockTestJobNoId implements ShouldQueue, ShouldBeDebounced
+class DebounceLockTestJobNoId implements ShouldBeDebounced, ShouldQueue
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     public function displayName(): string
     {
         return 'DebounceLockTestJobNoId';
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
-class DebounceLockTestJobWithVia implements ShouldQueue, ShouldBeDebounced
+class DebounceLockTestJobWithVia implements ShouldBeDebounced, ShouldQueue
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     private Cache $customCache;
 
@@ -290,15 +286,13 @@ class DebounceLockTestJobWithVia implements ShouldQueue, ShouldBeDebounced
         return $this->customCache;
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
 #[DebounceFor(45)]
-class DebounceLockTestJobWithAttribute implements ShouldQueue, ShouldBeDebounced
+class DebounceLockTestJobWithAttribute implements ShouldBeDebounced, ShouldQueue
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     public function debounceId(): string
     {
@@ -310,15 +304,13 @@ class DebounceLockTestJobWithAttribute implements ShouldQueue, ShouldBeDebounced
         return 'DebounceLockTestJobWithAttribute';
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
 #[DebounceFor(45)]
-class DebounceLockTestJobMethodAndAttribute implements ShouldQueue, ShouldBeDebounced
+class DebounceLockTestJobMethodAndAttribute implements ShouldBeDebounced, ShouldQueue
 {
-    use Queueable, InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     public function debounceId(): string
     {
@@ -335,7 +327,5 @@ class DebounceLockTestJobMethodAndAttribute implements ShouldQueue, ShouldBeDebo
         return 'DebounceLockTestJobMethodAndAttribute';
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }

--- a/tests/Unit/Queue/DebouncedJobTest.php
+++ b/tests/Unit/Queue/DebouncedJobTest.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace Tests\Unit\Queue;
+
+use Illuminate\Bus\DebounceLock;
+use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Contracts\Queue\ShouldBeDebounced;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\InteractsWithDebouncedJobs;
+use Illuminate\Queue\ChecksDebouncedJobs;
+use Illuminate\Queue\Events\JobDebounced;
+use Illuminate\Queue\InteractsWithQueue;
+use LogicException;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class DebouncedJobTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        Container::setInstance(null);
+    }
+
+    public function test_dispatching_debounced_job_sets_debounce_owner(): void
+    {
+        $cache = $this->setupContainerWithMockCache('dispatch-owner');
+        $job = new DebouncedTestJob;
+
+        $harness = new PendingDispatchHarness($job);
+        $harness->callAcquireDebounceLock();
+
+        $this->assertSame('dispatch-owner', $job->debounceOwner);
+    }
+
+    public function test_dispatching_debounced_job_sets_delay(): void
+    {
+        $this->setupContainerWithMockCache('owner');
+        $job = new DebouncedTestJob;
+
+        $harness = new PendingDispatchHarness($job);
+        $harness->callAcquireDebounceLock();
+
+        $this->assertSame(30, $job->delay);
+    }
+
+    public function test_second_dispatch_replaces_first_lock_owner(): void
+    {
+        $cache = $this->setupContainerWithMockCache('owner-1');
+        $job1 = new DebouncedTestJob;
+        $harness1 = new PendingDispatchHarness($job1);
+        $harness1->callAcquireDebounceLock();
+
+        // Replace cache mock with new owner
+        $this->setupContainerWithMockCache('owner-2');
+        $job2 = new DebouncedTestJob;
+        $harness2 = new PendingDispatchHarness($job2);
+        $harness2->callAcquireDebounceLock();
+
+        $this->assertSame('owner-1', $job1->debounceOwner);
+        $this->assertSame('owner-2', $job2->debounceOwner);
+        $this->assertNotSame($job1->debounceOwner, $job2->debounceOwner);
+    }
+
+    public function test_superseded_job_is_detected_via_ownership_check(): void
+    {
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->once()->andReturn(false);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')->once()->andReturn($restoredLock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+
+        $job = new DebouncedTestJob;
+        $job->debounceOwner = 'old-owner';
+
+        $harness = new CallQueuedHandlerHarness($container);
+        $this->assertTrue($harness->callCommandWasDebounced($job));
+    }
+
+    public function test_current_owner_job_passes_ownership_check(): void
+    {
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->once()->andReturn(true);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')->once()->andReturn($restoredLock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+
+        $job = new DebouncedTestJob;
+        $job->debounceOwner = 'current-owner';
+
+        $harness = new CallQueuedHandlerHarness($container);
+        $this->assertFalse($harness->callCommandWasDebounced($job));
+    }
+
+    public function test_debounce_owner_survives_serialization(): void
+    {
+        $job = new DebouncedTestJob;
+        $job->debounceOwner = 'test-owner-token-xyz';
+
+        $restored = unserialize(serialize($job));
+
+        $this->assertSame('test-owner-token-xyz', $restored->debounceOwner);
+    }
+
+    public function test_different_debounce_ids_do_not_interfere(): void
+    {
+        $job1 = new DebouncedTestJobWithId('entity-1');
+        $job2 = new DebouncedTestJobWithId('entity-2');
+
+        $key1 = DebounceLock::getKey($job1);
+        $key2 = DebounceLock::getKey($job2);
+
+        $this->assertNotSame($key1, $key2);
+        $this->assertStringContainsString('entity-1', $key1);
+        $this->assertStringContainsString('entity-2', $key2);
+    }
+
+    public function test_should_be_debounced_and_should_be_unique_throws_logic_exception(): void
+    {
+        $this->setupContainerWithMockCache('owner');
+
+        $job = new DebouncedAndUniqueTestJob;
+        $harness = new PendingDispatchHarness($job);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('ShouldBeDebounced and ShouldBeUnique');
+
+        $harness->callAcquireDebounceLock();
+    }
+
+    public function test_job_debounced_event_fires_when_superseded(): void
+    {
+        $events = Mockery::mock('events');
+        $events->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::type(JobDebounced::class))
+            ->andReturnUsing(function (JobDebounced $event) {
+                $this->assertSame('redis', $event->connectionName);
+                $this->assertInstanceOf(DebouncedTestJob::class, $event->command);
+            });
+
+        $container = new Container;
+        $container->instance('events', $events);
+        Container::setInstance($container);
+
+        $queueJob = Mockery::mock(QueueJob::class);
+        $queueJob->shouldReceive('getConnectionName')->once()->andReturn('redis');
+        $queueJob->shouldReceive('delete')->once();
+
+        $command = new DebouncedTestJob;
+
+        $harness = new CallQueuedHandlerHarness($container);
+        $harness->callHandleDebouncedJob($queueJob, $command);
+    }
+
+    public function test_lock_is_released_after_successful_execution(): void
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease')->once();
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')
+            ->with(DebounceLock::getKey(new DebouncedTestJob))
+            ->once()
+            ->andReturn($lock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+
+        $job = new DebouncedTestJob;
+
+        $harness = new CallQueuedHandlerHarness($container);
+        $harness->callEnsureDebounceLockIsReleased($job);
+
+        $this->assertTrue(true); // Mockery verifies forceRelease was called
+    }
+
+    public function test_job_with_no_debounce_owner_is_not_treated_as_debounced(): void
+    {
+        $container = new Container;
+        Container::setInstance($container);
+
+        $job = new DebouncedTestJob;
+        // debounceOwner not set
+
+        $harness = new CallQueuedHandlerHarness($container);
+        $this->assertFalse($harness->callCommandWasDebounced($job));
+    }
+
+    /**
+     * Set up a container with a mock cache that returns a lock for acquire().
+     */
+    private function setupContainerWithMockCache(string $ownerToken): Cache
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease');
+        $lock->shouldReceive('get');
+        $lock->shouldReceive('owner')->andReturn($ownerToken);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')->andReturn($lock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+
+        return $cache;
+    }
+}
+
+/**
+ * Test harness that exposes the InteractsWithDebouncedJobs trait methods.
+ */
+class PendingDispatchHarness
+{
+    use InteractsWithDebouncedJobs;
+
+    protected $job;
+
+    public function __construct($job)
+    {
+        $this->job = $job;
+    }
+
+    public function callAcquireDebounceLock(): void
+    {
+        $this->acquireDebounceLock();
+    }
+}
+
+/**
+ * Test harness that exposes the ChecksDebouncedJobs trait methods.
+ */
+class CallQueuedHandlerHarness
+{
+    use ChecksDebouncedJobs;
+
+    protected $container;
+
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    public function callCommandWasDebounced($command): bool
+    {
+        return $this->commandWasDebounced($command);
+    }
+
+    public function callHandleDebouncedJob($job, $command): void
+    {
+        $this->handleDebouncedJob($job, $command);
+    }
+
+    public function callEnsureDebounceLockIsReleased($command): void
+    {
+        $this->ensureDebounceLockIsReleased($command);
+    }
+}
+
+class DebouncedTestJob implements ShouldQueue, ShouldBeDebounced
+{
+    use Dispatchable, Queueable, InteractsWithQueue;
+
+    public string $debounceOwner = '';
+
+    public static bool $handled = false;
+
+    public function debounceId(): string
+    {
+        return 'test-entity-1';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function displayName(): string
+    {
+        return 'DebouncedTestJob';
+    }
+
+    public function handle(): void
+    {
+        static::$handled = true;
+    }
+}
+
+class DebouncedTestJobWithId implements ShouldQueue, ShouldBeDebounced
+{
+    use Dispatchable, Queueable, InteractsWithQueue;
+
+    public string $debounceOwner = '';
+
+    private string $entityId;
+
+    public function __construct(string $entityId = '')
+    {
+        $this->entityId = $entityId;
+    }
+
+    public function debounceId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function displayName(): string
+    {
+        return 'DebouncedTestJobWithId';
+    }
+
+    public function handle(): void
+    {
+    }
+}
+
+class DebouncedAndUniqueTestJob implements ShouldQueue, ShouldBeDebounced, ShouldBeUnique
+{
+    use Dispatchable, Queueable, InteractsWithQueue;
+
+    public string $debounceOwner = '';
+
+    public function debounceId(): string
+    {
+        return 'test';
+    }
+
+    public function debounceFor(): int
+    {
+        return 30;
+    }
+
+    public function handle(): void
+    {
+    }
+}

--- a/tests/Unit/Queue/DebouncedJobTest.php
+++ b/tests/Unit/Queue/DebouncedJobTest.php
@@ -273,9 +273,9 @@ class CallQueuedHandlerHarness
     }
 }
 
-class DebouncedTestJob implements ShouldQueue, ShouldBeDebounced
+class DebouncedTestJob implements ShouldBeDebounced, ShouldQueue
 {
-    use Dispatchable, Queueable, InteractsWithQueue;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public string $debounceOwner = '';
 
@@ -302,9 +302,9 @@ class DebouncedTestJob implements ShouldQueue, ShouldBeDebounced
     }
 }
 
-class DebouncedTestJobWithId implements ShouldQueue, ShouldBeDebounced
+class DebouncedTestJobWithId implements ShouldBeDebounced, ShouldQueue
 {
-    use Dispatchable, Queueable, InteractsWithQueue;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public string $debounceOwner = '';
 
@@ -330,14 +330,12 @@ class DebouncedTestJobWithId implements ShouldQueue, ShouldBeDebounced
         return 'DebouncedTestJobWithId';
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }
 
-class DebouncedAndUniqueTestJob implements ShouldQueue, ShouldBeDebounced, ShouldBeUnique
+class DebouncedAndUniqueTestJob implements ShouldBeDebounced, ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, Queueable, InteractsWithQueue;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public string $debounceOwner = '';
 
@@ -351,7 +349,5 @@ class DebouncedAndUniqueTestJob implements ShouldQueue, ShouldBeDebounced, Shoul
         return 30;
     }
 
-    public function handle(): void
-    {
-    }
+    public function handle(): void {}
 }

--- a/tests/Unit/Queue/Middleware/DebouncedMiddlewareTest.php
+++ b/tests/Unit/Queue/Middleware/DebouncedMiddlewareTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Unit\Queue\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Queue\Middleware\Debounced;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class DebouncedMiddlewareTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        Container::setInstance(null);
+    }
+
+    public function test_constructor_acquires_lock_via_debounce_lock(): void
+    {
+        $this->setupContainerWithMockCacheForAcquire('ctor-owner');
+
+        $middleware = new Debounced('my-key', 60);
+
+        $this->assertSame('ctor-owner', $middleware->owner);
+    }
+
+    public function test_handle_proceeds_when_current_owner(): void
+    {
+        $this->setupContainerWithMockCacheForAcquire('current-owner');
+        $middleware = new Debounced('test-key', 60);
+
+        // Now set up cache for handle() -- isCurrentOwner + release
+        $this->setupContainerWithMockCacheForHandle(isOwner: true);
+
+        $job = Mockery::mock(QueueJob::class);
+        $job->shouldNotReceive('delete');
+
+        $nextCalled = false;
+        $middleware->handle($job, function ($passedJob) use (&$nextCalled) {
+            $nextCalled = true;
+        });
+
+        $this->assertTrue($nextCalled);
+    }
+
+    public function test_handle_deletes_job_when_not_current_owner(): void
+    {
+        $this->setupContainerWithMockCacheForAcquire('old-owner');
+        $middleware = new Debounced('test-key', 60);
+
+        // Now set up cache for handle() -- isCurrentOwner returns false
+        $this->setupContainerWithMockCacheForHandle(isOwner: false);
+
+        $job = Mockery::mock(QueueJob::class);
+        $job->shouldReceive('delete')->once();
+
+        $nextCalled = false;
+        $middleware->handle($job, function ($passedJob) use (&$nextCalled) {
+            $nextCalled = true;
+        });
+
+        $this->assertFalse($nextCalled);
+    }
+
+    public function test_handle_releases_lock_after_successful_execution(): void
+    {
+        $this->setupContainerWithMockCacheForAcquire('release-owner');
+        $middleware = new Debounced('test-key', 60);
+
+        // For handle: restore lock (isOwner), then release lock
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->once()->andReturn(true);
+
+        $releaseLock = Mockery::mock(Lock::class);
+        $releaseLock->shouldReceive('forceRelease')->once();
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')->once()->andReturn($restoredLock);
+        $cache->shouldReceive('lock')->once()->andReturn($releaseLock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+
+        $job = Mockery::mock(QueueJob::class);
+
+        $middleware->handle($job, function ($passedJob) {
+            // Do nothing -- successful execution
+        });
+
+        // Mockery verifies forceRelease was called
+        $this->assertTrue(true);
+    }
+
+    public function test_middleware_properties_survive_serialization(): void
+    {
+        $this->setupContainerWithMockCacheForAcquire('serial-owner');
+
+        $middleware = new Debounced('persist-key', 45);
+        $restored = unserialize(serialize($middleware));
+
+        $this->assertSame('persist-key', $restored->key);
+        $this->assertSame(45, $restored->debounceFor);
+        $this->assertSame('serial-owner', $restored->owner);
+    }
+
+    /**
+     * Set up container with mock cache for acquire() (constructor).
+     */
+    private function setupContainerWithMockCacheForAcquire(string $ownerToken): void
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease');
+        $lock->shouldReceive('get');
+        $lock->shouldReceive('owner')->andReturn($ownerToken);
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')->andReturn($lock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+    }
+
+    /**
+     * Set up container with mock cache for handle() checks.
+     */
+    private function setupContainerWithMockCacheForHandle(bool $isOwner): void
+    {
+        $restoredLock = Mockery::mock(Lock::class);
+        $restoredLock->shouldReceive('isOwnedByCurrentProcess')->andReturn($isOwner);
+
+        $releaseLock = Mockery::mock(Lock::class);
+        $releaseLock->shouldReceive('forceRelease');
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('restoreLock')->andReturn($restoredLock);
+        $cache->shouldReceive('lock')->andReturn($releaseLock);
+
+        $container = new Container;
+        $container->instance(Cache::class, $cache);
+        Container::setInstance($container);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ability to debounce queued jobs. When multiple dispatches occur for the same debounce identity within a time window, only the most recently dispatched job executes — **last dispatch wins**.

This is the inverse of `ShouldBeUnique`. Where unique jobs protect against duplicate processing by letting the *first* dispatch win and rejecting subsequent ones, debounced jobs let the *last* dispatch win, silently discarding earlier dispatches that are no longer relevant.

## Motivation

Many real-world workflows dispatch jobs on every change — model updates, webhook receipts, search index rebuilds, report generation. Without debounce, each change triggers a separate job, leading to redundant processing. Developers currently work around this with custom delay + cache lock patterns. This feature makes it a first-class framework concern.

**Example:** A user edits a document 10 times in 30 seconds. Without debounce, 10 index rebuild jobs run. With debounce, only the last one runs — processing the final state.

## How It Works

### Dispatch Time
When a `ShouldBeDebounced` job is dispatched, a cache lock is acquired with a unique owner token. If another dispatch for the same debounce identity occurs, it **force-releases** the previous lock and acquires a new one. The owner token is stored on the job as `$job->debounceOwner` and survives serialization through the queue.

### Execution Time
When the job is pulled from the queue, the handler checks whether the job's owner token still matches the current lock owner. If it matches, the job executes normally and the lock is released. If it doesn't match (a newer dispatch superseded it), the job is silently deleted and a `JobDebounced` event is fired.

### Lock TTL
The lock TTL equals the `debounceFor` value exactly — no default and no adjustment. The developer controls the TTL directly via `debounceFor()` method, `#[DebounceFor]` attribute, or the middleware constructor parameter.

## Comparison with `ShouldBeUnique`

| Behavior | `ShouldBeUnique` | `ShouldBeDebounced` |
|----------|-----------------|-------------------|
| Which dispatch wins? | First | Last |
| Subsequent dispatches | Rejected (not queued) | Queued, but supersede earlier ones |
| Lock acquired at | Dispatch time | Dispatch time |
| Lock checked at | Dispatch time (prevents queueing) | Execution time (skips if superseded) |
| Lock released at | After execution | After execution |
| Lock manager | `UniqueLock` | `DebounceLock` |
| Use case | Prevent duplicate work | Ensure only final state is processed |

## Usage

### Interface Approach

Implement `ShouldBeDebounced` and define `debounceFor()` to set the debounce window:

```php
use Illuminate\Contracts\Queue\ShouldBeDebounced;
use Illuminate\Contracts\Queue\ShouldQueue;

class RebuildSearchIndex implements ShouldQueue, ShouldBeDebounced
{
    public function __construct(
        public int $documentId,
    ) {}

    public function debounceId(): string
    {
        return 'document-' . $this->documentId;
    }

    public function debounceFor(): int
    {
        return 30; // seconds
    }

    public function handle(): void
    {
        // Only the last dispatch within 30s actually runs
        SearchIndex::rebuild($this->documentId);
    }
}
```

Then dispatch as normal — debounce is automatic:

```php
// User edits document multiple times rapidly
RebuildSearchIndex::dispatch($document->id); // superseded
RebuildSearchIndex::dispatch($document->id); // superseded
RebuildSearchIndex::dispatch($document->id); // this one executes
```

### PHP Attribute

Use the `#[DebounceFor]` attribute instead of a method:

```php
use Illuminate\Contracts\Queue\ShouldBeDebounced;
use Illuminate\Queue\Attributes\DebounceFor;

#[DebounceFor(debounceFor: 30)]
class RebuildSearchIndex implements ShouldQueue, ShouldBeDebounced
{
    // debounceFor() method not needed — attribute provides the value
}
```

The `debounceFor()` method takes precedence over the attribute if both are present.

### Middleware Approach

For jobs that don't implement the interface, use the `Debounced` middleware directly:

```php
use Illuminate\Queue\Middleware\Debounced;

class ProcessWebhook implements ShouldQueue
{
    public function middleware(): array
    {
        return [
            new Debounced(key: 'webhook-' . $this->webhookId, debounceFor: 60),
        ];
    }
}
```

The middleware delegates to `DebounceLock` internally, so key format and lock behavior are identical to the interface approach.

### Custom Cache Store

Override the cache store used for debounce locks:

```php
public function debounceVia(): \Illuminate\Contracts\Cache\Repository
{
    return Cache::store('redis');
}
```

### Listening for Superseded Jobs

Listen for the `JobDebounced` event to track when jobs are skipped:

```php
use Illuminate\Queue\Events\JobDebounced;

Event::listen(function (JobDebounced $event) {
    Log::info('Job debounced', [
        'connection' => $event->connectionName,
        'job' => get_class($event->command),
    ]);
});
```

## Mutual Exclusivity

`ShouldBeDebounced` and `ShouldBeUnique` are mutually exclusive. Implementing both on the same job throws a `LogicException` at dispatch time — first-wins and last-wins semantics cannot coexist.

## Implementation

### New Files
- `Illuminate\Contracts\Queue\ShouldBeDebounced` — Marker interface (no methods)
- `Illuminate\Bus\DebounceLock` — Lock manager: `acquire()`, `isCurrentOwner()`, `release()`, `getKey()`
- `Illuminate\Queue\Attributes\DebounceFor` — PHP 8 attribute for TTL configuration
- `Illuminate\Queue\Events\JobDebounced` — Event fired when a superseded job is skipped

### Middleware
- `Illuminate\Queue\Middleware\Debounced` — Standalone middleware that delegates to `DebounceLock`

### Framework Integration Traits
These traits demonstrate the integration points into existing framework classes:
- `InteractsWithDebouncedJobs` — For `PendingDispatch`: acquires debounce lock at dispatch time
- `ChecksDebouncedJobs` — For `CallQueuedHandler`: checks ownership at execution time
- `HandlesDebouncedJobTransactions` — For `Queue`: registers transaction rollback handler

### Tests
29 tests covering:
- `DebounceLock` unit tests (acquire, ownership, release, key format, attributes, custom cache)
- Integration tests (dispatch flow, supersession, serialization, mutual exclusivity, event firing)
- Middleware tests (delegation to DebounceLock, handle/delete, serialization)
- Framework fake compatibility (`Queue::fake()`, `Bus::fake()`, sync driver)