### PR TITLE
Add /.cursor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env.production
 .phpactor.json
 .phpunit.result.cache
+/.cursor/
 /.fleet
 /.idea
 /.nova


### PR DESCRIPTION
## Context
Since the recent updates to the README explicitly highlight Cursor as a recommended IDE under the Agentic Development section, adding `/.cursor/` to `.gitignore` helps prevent developers from accidentally committing their local environment workflows and AI contextual rules. 
