### PR TITLE
Remove '.fleet' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .phpactor.json
 .phpunit.result.cache
 /.cursor/
-/.fleet
 /.idea
 /.nova
 /.phpunit.cache


### PR DESCRIPTION
As JetBrains Fleet is [officially dead](https://blog.jetbrains.com/fleet/2025/12/the-future-of-fleet/) and has no adoption, this is no longer needed. 