### PR TITLE
Update comment in config/session.php

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -219,10 +219,10 @@ return [
     | Session Serialization
     |--------------------------------------------------------------------------
     |
-    | This value controls the serialization strategy for session data, which
-    | is JSON by default. Setting this to "php" allows the storage of PHP
-    | objects in the session but can make an application vulnerable to
-    | "gadget chain" serialization attacks if the APP_KEY is leaked.
+    | This value controls the serialization strategy for session data. Setting
+    | this to "php" allows the storage of PHP objects in the session but can
+    | make an application vulnerable to "gadget chain" serialization attacks
+    | if the APP_KEY is leaked.
     |
     | Supported: "json", "php"
     |


### PR DESCRIPTION
To say that JSON is the default is misleading and incorrect.

The framework code reveals that the actual default is 'php': https://github.com/search?q=repo%3Alaravel%2Fframework%20session.serialization&type=code

The opportunity was there with the launch of Laravel 13 to change the actual default in the framework, rather than having this situation where a supposed new 'default' is only actually applied if a config value is added to a project's config file.

This would of course have needed mentioning in the Upgrade Guide, but it probably should be covered in the Upgrade Guide anyway, as the effect of this config file 'default' change is significant for projects that already stored PHP objects in the session prior to Laravel 13, which is probably a 'medium' likelihood situation.

Essentially, if during a project's Laravel 13 upgrade, the session.serialization value is added to the config file as 'json', then it's a breaking change. However, if the value is not added during upgrade, the project keeps working. But only because 'php' is the actual framework default, contrary to what this comment suggests.