### PR TITLE
Support all compose file naming conventions in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
-[compose.yaml]
+[{compose,docker-compose}.{yml,yaml}]
 indent_size = 4


### PR DESCRIPTION
docker supports basically four different file name conventions for the compose file

https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file