### PR TITLE
[13.x] enable npm audit by default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-scripts=true
+audit=true


### PR DESCRIPTION
Given the increasing number of supply chain attacks affecting npm packages, this PR proposes enabling ``npm audit`` by default to improve visibility of dependency vulnerabilities during installation, helping identify potential security risks.