### PR TITLE
Update changelog link to Laravel framework repo

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -120,7 +120,7 @@
 
                     <p class="mt-6 lg:mt-10 text-[#706f6c] dark:text-[#A1A09A]">
                         v{{ app()->version() }}
-                        <a href="https://github.com/laravel/laravel/blob/13.x/CHANGELOG.md" target="_blank" class="inline-flex items-center space-x-1 font-medium underline underline-offset-4 text-[#f53003] dark:text-[#FF4433] ml-1">
+                        <a href="https://github.com/laravel/framework/blob/13.x/CHANGELOG.md" target="_blank" class="inline-flex items-center space-x-1 font-medium underline underline-offset-4 text-[#f53003] dark:text-[#FF4433] ml-1">
                             <span>View changelog</span>
                             <svg
                                 width="10"


### PR DESCRIPTION
I believe the link should point to the framework's changelog because VERSION, shown on the welcome page, comes from the framework's Application.php.

Also, if I look at v13.5, I expect to find the 13.5 changelog, which doesn't exist in laravel/laravel.

Generally, the changes that might be of interest to developers are those present in the framework.