### PR TITLE
[13x] Add .codex to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .phpactor.json
 .phpunit.result.cache
 /.cursor/
+/.codex
 /.idea
 /.nova
 /.phpunit.cache


### PR DESCRIPTION
This pull request addresses the need to ignore the `.codex` file in the `.gitignore` file.

Here's why:

*   The Codex VS Code extension creates a `.codex` file in the project's root.
*   Including this file in version control (like Git) is generally unnecessary and can lead to:
    *   Increased repository size.
    *   Potential conflicts when multiple developers work on the project.
    *   Unwanted changes being tracked.

By adding `/.codex` to `.gitignore`, you ensure that this file are excluded from version control, keeping your repository clean and efficient.