### PR TITLE
test: cover welcome page metadata

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -12,8 +12,15 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
+        config([
+            'app.name' => 'Starter Kit',
+            'app.locale' => 'fr_CA',
+        ]);
+
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertOk();
+        $response->assertSee('<html lang="fr-CA">', false);
+        $response->assertSee('<title>Starter Kit</title>', false);
     }
 }


### PR DESCRIPTION

**Repo:** laravel/laravel (⭐ 79000)
**Type:** test
**Files changed:** 1
**Lines:** +8/-1

## What
This change strengthens the default feature test for the application welcome page. Instead of only asserting that the root route responds successfully, the test now sets a custom application name and locale in configuration and verifies that the rendered HTML uses those values in the page `<title>` and root `<html lang="...">` attribute.

## Why
The starter app's welcome page already derives its metadata from application configuration, but the existing test did not protect that behavior. Adding these assertions turns the example test into a small regression test for visible page metadata, which is useful for catching accidental template changes while keeping the patch limited to a single, low-risk file.

## Testing
Intended verification: run `php artisan test --filter=ExampleTest`.
Local checks run here: reviewed the Git diff and commit output only. Full test execution was not possible in this environment because the clone does not include `vendor/`, and `php` is not available on `PATH`.

## Risk
Low - the patch only changes a test and does not modify runtime application behavior.
