### PR TITLE
Replaced database options filter and added option for certificate verification

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Pdo\Mysql;
 
@@ -59,7 +60,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
+            'options' => extension_loaded('pdo_mysql') ? Arr::whereNotNull([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
@@ -79,7 +80,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
+            'options' => extension_loaded('pdo_mysql') ? whereNotNull([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -62,6 +62,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? Arr::whereNotNull([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT) => false,
             ]) : [],
         ],
 
@@ -80,8 +81,9 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? whereNotNull([
+            'options' => extension_loaded('pdo_mysql') ? Arr::whereNotNull([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_VERIFY_SERVER_CERT : PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT) => false,
             ]) : [],
         ],
 


### PR DESCRIPTION
I noticed that MariaDB/MySQL PDO options are filtered using "array_filter".

This can be problematic when negatives values such "0" or "false" are used because those values are also filtered. 

## Changes

- Replaced "array_filter" by "Arr::whereNotNull" so options like MYSQL_ATTR_SSL_VERIFY_SERVER_CERT are not filtered.
- Added the option "ATTR_SSL_VERIFY_SERVER_CERT" / "MYSQL_ATTR_SSL_VERIFY_SERVER_CERT" with the value "false" as default, so if self-signed certificate is used. 

## Impact

- False values like "0" and "false" are accepted.

## Notes 

- PDO will work as usually when "MYSQL_ATTR_SSL_VERIFY_SERVER_CERT" is used with any false value and "MYSQL_ATTR_SSL_CA" / "MYSQL_ATTR_SSL_CA"  is not available.

