### PR TITLE
Add @no_additional_args to composer test script config clear

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
         ],
         "test": [
-            "@php artisan config:clear --ansi",
+            "@php artisan config:clear --ansi @no_additional_args",
             "@php artisan test"
         ],
         "post-autoload-dump": [


### PR DESCRIPTION
To more easily allow one to run e.g. `composer test tests/Unit` or `composer test --coverage-clover=clover.xml`, the special `@no_additional_args` an be leveraged to pass addtional args solely to the second call in the script. Given that it seems very unlikely to me the first call would ever be the intended target of additional arguments supplied by the user, this seems like a reasonable improvement. 

See also https://getcomposer.org/doc/articles/scripts.md#controlling-additional-arguments. Note this requires Composer 2.8 as minimal version, but for new setups this seems like a very reasonable constraint.