### PR TITLE
Add production security hardening for VPS deployment

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+        $response->headers->set(
+            'Content-Security-Policy',
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'"
+        );
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(\App\Http\Middleware\SecurityHeaders::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,12 @@
 
     RewriteEngine On
 
+    # Force HTTPS in production
+    RewriteCond %{HTTPS} off
+    RewriteCond %{HTTP_HOST} !^localhost$ [NC]
+    RewriteCond %{HTTP_HOST} !^127\.0\.0\.1$
+    RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
     # Handle Authorization Header
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::middleware('throttle:60,1')->group(function () {
+    Route::get('/', function () {
+        return view('welcome');
+    });
 });


### PR DESCRIPTION
## Summary
- Add `SecurityHeaders` middleware (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, X-XSS-Protection, Permissions-Policy, CSP) registered globally in bootstrap/app.php
- Force HTTPS redirect in public/.htaccess, skipping localhost/127.0.0.1 so local dev is unaffected
- Wrap web routes in `throttle:60,1` to defend against request abuse

## Test plan
- [ ] Deploy to staging with HTTPS and verify HTTP redirects to HTTPS
- [ ] Inspect response headers via DevTools or securityheaders.com
- [ ] Confirm localhost loads without redirect loop
- [ ] Verify rate limiting returns 429 after 60 requests/min

🤖 Generated with [Claude Code](https://claude.ai/claude-code)