### PR TITLE
[13.x] Adds pao by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/pint": "^1.27",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
+        "nunomaduro/pao": "^1.0.5",
         "phpunit/phpunit": "^12.5.12"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require-dev": {
         "fakerphp/faker": "^1.23",
         "laravel/pail": "^1.2.5",
+        "laravel/pao": "^1.0.6",
         "laravel/pint": "^1.27",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "nunomaduro/pao": "^1.0.5",
         "phpunit/phpunit": "^12.5.12"
     },
     "autoload": {


### PR DESCRIPTION
This pull request adds `nunomaduro/pao` by default on the skeleton; it's already in all starter kits since last week, with 0 problems reported so far: https://github.com/laravel/maestro/pull/81.