### PR TITLE
[13.x] Add junie to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .phpactor.json
 .phpunit.result.cache
 /.codex
+/.junie
 /.cursor/
 /.idea
 /.nova


### PR DESCRIPTION
.junie is generated by Junie and contains local workspace / machine-specific data that should not be committed to version control. Since it can be created inside Laravel projects during development, adding it to .gitignore helps prevent accidental commits of non-project files.

Benefit

This keeps repositories cleaner and aligns with existing ignores for other editor and local-tool generated files already included in the default .gitignore.