### PR TITLE
[13.x] Add type casting for env() values in config files

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
             'url' => env('DB_URL'),
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
-            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'foreign_key_constraints' => (bool) env('DB_FOREIGN_KEYS', true),
             'busy_timeout' => null,
             'journal_mode' => null,
             'synchronous' => null,
@@ -150,7 +150,7 @@ return [
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
             'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),
-            'persistent' => env('REDIS_PERSISTENT', false),
+            'persistent' => (bool) env('REDIS_PERSISTENT', false),
         ],
 
         'default' => [
@@ -160,10 +160,10 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
-            'max_retries' => env('REDIS_MAX_RETRIES', 3),
+            'max_retries' => (int) env('REDIS_MAX_RETRIES', 3),
             'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
-            'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-            'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+            'backoff_base' => (int) env('REDIS_BACKOFF_BASE', 100),
+            'backoff_cap' => (int) env('REDIS_BACKOFF_CAP', 1000),
         ],
 
         'cache' => [
@@ -173,10 +173,10 @@ return [
             'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
-            'max_retries' => env('REDIS_MAX_RETRIES', 3),
+            'max_retries' => (int) env('REDIS_MAX_RETRIES', 3),
             'backoff_algorithm' => env('REDIS_BACKOFF_ALGORITHM', 'decorrelated_jitter'),
-            'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
-            'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
+            'backoff_base' => (int) env('REDIS_BACKOFF_BASE', 100),
+            'backoff_cap' => (int) env('REDIS_BACKOFF_CAP', 1000),
         ],
 
     ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -33,7 +33,7 @@ return [
 
     'deprecations' => [
         'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
-        'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+        'trace' => (bool) env('LOG_DEPRECATIONS_TRACE', false),
     ],
 
     /*


### PR DESCRIPTION
# Add Explicit Type Casting for `env()` Values in Config Files

## 📌 Overview

This PR introduces explicit type casting for selected `env()` values across configuration files to ensure correct data types are used at runtime — particularly for numeric strings and values that may be passed as `"0"`, `"1"`, or numeric strings instead of native booleans or integers.

---

## 🔴 Problem

While Laravel's `env()` helper does automatically convert `"true"` and `"false"` strings to native PHP booleans, it does **not** convert numeric strings. For example:

```php
env('REDIS_MAX_RETRIES') // returns string "3", not integer 3
env('REDIS_BACKOFF_BASE') // returns string "100", not integer 100
```

Additionally, if a developer sets a boolean env var using `0` or `1` instead of `true`/`false`:

```php
REDIS_PERSISTENT=1
// env() returns string "1", not boolean true
// (bool) "1" === true  ✅ — casting fixes this
```

This can lead to subtle bugs in production environments where strict type comparisons or typed function parameters are used.

---

## ✅ Solution

This PR applies explicit casting to ensure correct types at the config layer:

- **Boolean casting** for flag values:
  ```php
  (bool) env('DB_FOREIGN_KEYS', true)
  (bool) env('REDIS_PERSISTENT', false)
  ```

- **Integer casting** for numeric values:
  ```php
  (int) env('REDIS_MAX_RETRIES', 3)
  (int) env('REDIS_BACKOFF_BASE', 100)
  (int) env('REDIS_BACKOFF_CAP', 1000)
  ```

---

## 🔧 Changes Included

### `config/database.php`
- Cast `DB_FOREIGN_KEYS` to boolean
- Cast Redis-related numeric values to integers:
  - `REDIS_MAX_RETRIES`
  - `REDIS_BACKOFF_BASE`
  - `REDIS_BACKOFF_CAP`
- Cast `REDIS_PERSISTENT` to boolean

### `config/logging.php`
- Cast `LOG_DEPRECATIONS_TRACE` to boolean

---

## 🎯 Benefits

- ✅ Prevents type mismatch bugs when numeric strings are passed via `.env`
- ✅ Improves reliability of configuration handling
- ✅ Reduces subtle bugs in production environments
- ✅ Aligns runtime behavior with developer expectations
- ✅ Makes type intent explicit and readable in config files

---

## ⚠️ Backward Compatibility

This change is **non-breaking**:

- It preserves existing default values
- Laravel's `env()` already handles `true`/`false` strings — the added `(bool)` cast is a defensive layer with no behavioral change for those cases
- For numeric values, the cast ensures integers are always returned regardless of how the env var is set

---

## 🧪 Testing

- Verified behavior with different `.env` values (`true`, `false`, numeric strings like `"3"`, `"0"`, `"1"`)
- Confirmed correct type enforcement in runtime configuration

---

## 📝 Notes

This change adds a **defensive casting layer** to config files. It is especially useful in environments where:
- `.env` values may be set by non-PHP developers unfamiliar with Laravel's env parsing behavior
- Strict type comparisons (`===`) are used in application code
- Typed PHP function/method parameters require exact types