### PR TITLE
fix: preserve false PDO options in database config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,7 +61,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            ], fn ($value) => $value !== null) : [],
         ],
 
         'mariadb' => [
@@ -81,7 +81,7 @@ return [
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 (PHP_VERSION_ID >= 80500 ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            ], fn ($value) => $value !== null) : [],
         ],
 
         'pgsql' => [


### PR DESCRIPTION
The current filter works for MYSQL_ATTR_SSL_CA and makes sens, but it causes MYSQL_ATTR_SSL_VERIFY_SERVER_CERT to be filtered out when set to false making it essentially useless as it defaults to true any way.

This only filters out `null` which appears to have been the original intent for the MYSQL_ATTR_SSL_CA case.