### PR TITLE
[13.x] Add amazonq to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .phpunit.result.cache
 /.codex
 /.cursor/
+/.amazonq/
 /.idea
 /.nova
 /.phpunit.cache


### PR DESCRIPTION
This PR updates the .gitignore file to exclude the .amazonq directory.

.amazonq is generated by **Amazon Q** and contains local workspace / machine-specific data. Since it may be created inside Laravel projects during development, it should not be committed to version control.

**Benefit**

Ignoring this directory helps prevent accidental commits of non-project files, keeps the repository clean, and aligns with existing ignore rules for editor/tool-generated local files.