### PR TITLE
[13.x] remove Tailwind `@source` calls that are already covered by default

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,8 +2,6 @@
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
-@source '../**/*.blade.php';
-@source '../**/*.js';
 
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',


### PR DESCRIPTION
with Tailwind v4, the `/resources` path is already scanned by default, so we don't need to include these calls. these lines are a carry over from the v3 days.

https://tailwindcss.com/docs/detecting-classes-in-source-files#which-files-are-scanned