### PR TITLE
[13.x] remove compiled views from Tailwind source scanning

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,7 +1,6 @@
 @import 'tailwindcss';
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
-@source '../../storage/framework/views/*.php';
 
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',


### PR DESCRIPTION
all of these compiled view files should be covered already by Tailwind automatically scanning the `/resources` directory.

I kept this separate from #6823 because it is kind of change of behavior, as this path will no longer be scanned. but I think it's okay for it to no longer be scanned.