### PR TITLE
Add test bootstrap to isolate environment variables

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+/*
+|--------------------------------------------------------------------------
+| Ensure Test Environment Variables
+|--------------------------------------------------------------------------
+|
+| PHPUnit sets environment variables from phpunit.xml <php> section, but
+| these can be overridden by variables already present in the process
+| environment (e.g., from running `php artisan serve` or `composer run dev`
+| in the same terminal). Dotenv's immutable repository will not overwrite
+| existing process-level variables, so .env.testing values get ignored.
+|
+| This bootstrap ensures critical test variables are forced into all layers
+| (putenv, $_ENV, $_SERVER) before the application bootstraps.
+|
+*/
+
+$variables = [
+    'APP_ENV' => 'testing',
+    'BCRYPT_ROUNDS' => '4',
+    'CACHE_STORE' => 'array',
+    'DB_CONNECTION' => $_SERVER['DB_CONNECTION'] ?? 'sqlite',
+    'DB_DATABASE' => $_SERVER['DB_DATABASE'] ?? ':memory:',
+    'MAIL_MAILER' => 'array',
+    'QUEUE_CONNECTION' => 'sync',
+    'SESSION_DRIVER' => 'array',
+];
+
+foreach ($variables as $key => $value) {
+    $_ENV[$key] = $value;
+    $_SERVER[$key] = $value;
+    putenv("{$key}={$value}");
+}


### PR DESCRIPTION
## Problem

When a developer runs `php artisan serve` or `composer run dev`, environment variables from `.env` are exported to the shell process. If tests are then run in the same terminal, Dotenv's immutable repository cannot override these process-level variables with values from `.env.testing` or `phpunit.xml` `<env>` declarations.

This causes `PreventRequestForgery` middleware to receive `SESSION_DRIVER=database` instead of `array`, making its `runningUnitTests()` bypass ineffective. The result: **HTTP 419 on all POST/PUT/DELETE test requests**.

## Root Cause

1. PHPUnit sets `$_SERVER["APP_ENV"] = "testing"` from `phpunit.xml`
2. Laravel's `LoadEnvironmentVariables` detects `APP_ENV=testing` and loads `.env.testing`
3. But `Dotenv::safeLoad()` uses an **immutable** repository — it skips variables already present in the process environment
4. `SESSION_DRIVER`, `DB_DATABASE`, etc. remain at their `.env` values (inherited from parent process)
5. `PreventRequestForgery::tokensMatch()` fails because the session driver is not `array`

## Solution

Add `tests/bootstrap.php` that forces critical test environment variables into all layers (`putenv`, `$_ENV`, `$_SERVER`) **before** the application bootstraps. Update `phpunit.xml` to use this bootstrap file.

This ensures test isolation regardless of the parent process state, while still respecting custom values set in `phpunit.xml` `<env>` declarations (e.g., `DB_CONNECTION` and `DB_DATABASE` are read from `$_SERVER` which PHPUnit populates from its config).

## Steps to Reproduce

```bash
# Terminal 1: Start dev server (exports .env vars to shell)
composer run dev
# Ctrl+C to stop

# Same terminal: Run tests
php artisan test
# Result: All POST/PUT/DELETE tests fail with 419
```

## Changes

- **`tests/bootstrap.php`** (new): Forces test env vars before autoload
- **`phpunit.xml`**: Changed `bootstrap` from `vendor/autoload.php` to `tests/bootstrap.php`