### PR TITLE
[13.x] Use PHPUnit Test attribute in example tests

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
@@ -10,7 +11,8 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    #[Test]
+    public function the_application_returns_a_successful_response(): void
     {
         $response = $this->get('/');
 

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
@@ -9,7 +10,8 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_that_true_is_true(): void
+    #[Test]
+    public function true_is_true(): void
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
This PR updates the skeleton's example tests to use the PHPUnit `#[Test]` attribute instead of the `test_` method-name prefix.
  
PHPUnit 12.5 (required by this skeleton) fully supports attributes as the modern, recommended way to mark test methods, and this keeps the generated test files aligned with current PHPUnit conventions for new applications.
  
  - Add `use PHPUnit\Framework\Attributes\Test;`
  - Mark each example method with `#[Test]` and drop the redundant `test_` prefix
  
  No behavior changes.