### PR TITLE
Restore expectsJson fallback when rendering JSON exceptions

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,6 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*'),
+            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
         );
     })->create();


### PR DESCRIPTION
The skeleton's `bootstrap/app.php` currently registers:

```php
$exceptions->shouldRenderJsonWhen(
    fn (Request $request) => $request->is('api/*'),
);
```

This was _mostly_ introduced in PR #6824. The PR was fine, but in e196bfd the  `|| $request->expectsJson()` was dropped. This is the problematic bit.

Because  `shouldRenderJsonWhen()`  replaces the framework's default decision rather than extending it, the built-in  `expectsJson()`  branch in `Handler::shouldReturnJson()`  becomes dead code once a callback is set. 

So this makes **every non- `api/*`  route ignore  `Accept: application/json`  entirely**.

This now contradicts Laravel's own documented behavior. The [Rendering Exceptions as JSON](https://laravel.com/docs/13.x/errors#rendering-exceptions-as-json) docs state JSON-vs-HTML is determined "based on the  `Accept`  header of the request," and the `shouldRenderJsonWhen` example in those same docs deliberately keeps `return $request->expectsJson();`  as the fallback. So the documented pattern is "path rule plus `expectsJson()`," but the skeleton now ships only the path rule.

A real life example of where this bit:
Statamic's Control Panel stopped receiving JSON for validation errors — the 302 redirect-back got followed repeatedly, surfacing as an infinite redirect loop. Any package relying on the documented `Accept`-header behavior is exposed to the same thing.

And it's not just us — @TullariS [commented on the commit](https://github.com/laravel/laravel/commit/e196bfdfc96903f2e10219749fcbca7c0aefe99f#commitcomment-187586285) that it broke their auth flow too: failed authentication responses were redirected to the login route instead of returning a 401, for the same reason —  Accept: application/json  was being ignored.