### PR TITLE
Add 'array' as a supported maintenance mode driver doc block

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -114,7 +114,7 @@ return [
     | manage Laravel's "maintenance mode" status. The "cache" driver will
     | allow maintenance mode to be controlled across multiple machines.
     |
-    | Supported drivers: "file", "cache"
+    | Supported drivers: "file", "cache", "array"
     |
     */
 


### PR DESCRIPTION
Follows what we did here: https://github.com/laravel/framework/pull/60490 

Cus its the skeleton, feels nice / consistent to me

Also nicer for AI I suppose?

