### PR TITLE
Use `artisan dev` command in `composer dev` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.8",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {
@@ -42,7 +42,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "test": [
             "@php artisan config:clear --ansi @no_additional_args",


### PR DESCRIPTION
Same as with https://github.com/laravel/maestro/pull/171

---

Replaced `npx concurrently ...` with [the new `artisan dev` command](https://github.com/laravel/framework/pull/60412) in `composer dev`, as it provides the same defaults and removes the need to keep two configurations in sync.

Raised the minimum Laravel dependency to ^13.17 to ensure `artisan dev` and `artisan dev:list` are available.

Kept the `concurrently` Node dependency, as `artisan dev` uses it under the hood.