### PR TITLE
Use new `artisan dev` command in `composer dev` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^13.8",
+        "laravel/framework": "^13.17",
         "laravel/tinker": "^3.0"
     },
     "require-dev": {
@@ -42,7 +42,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "@php artisan dev"
         ],
         "test": [
             "@php artisan config:clear --ansi @no_additional_args",


### PR DESCRIPTION
## Overview

The `composer dev` script hardcodes a long `npx concurrently` invocation that is hard to read and can't be customized per project. The framework now ships a first-party `php artisan dev` command that runs the same processes and can be extended or filtered through `DevCommands` in a service provider.

## Solution

Point the `dev` script at `@php artisan dev` and bump `laravel/framework` to `^13.17`, where the dev command's `dev:list` and process filtering are available. The command registers the same four processes the script ran (server, queue, logs, and vite) and still uses the skeleton's `concurrently` dependency under the hood, so day-to-day behavior is unchanged.