### PR TITLE
Clarify fixed timezone rationale

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -63,6 +63,10 @@ return [
     | will be used by the PHP date and date-time functions. The timezone
     | is set to "UTC" by default as it is suitable for most use cases.
     |
+    | This value is not read from the environment on purpose, as it must
+    | stay identical across every environment and server that shares a
+    | database, otherwise stored dates may be interpreted differently.
+    |
     */
 
     'timezone' => 'UTC',


### PR DESCRIPTION
Add explanatory comment to config/app.php stating the timezone is intentionally not read from the environment because it must remain identical across environments/servers that share a database to avoid misinterpreting stored dates.