### PR TITLE
Remove unnecessary concurrently dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
-        "concurrently": "^10.0.3",
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.0",
         "vite": "^8.0.0"


### PR DESCRIPTION
This PR removes the `concurrently` dependency from `package.json`.

Since it is no longer used following the changes in #6849, it can be safely removed, reducing the project's npm dependencies.