### PR TITLE
Ignore local Blade prototypes under resources/views/prototype.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _ide_helper.php
 Homestead.json
 Homestead.yaml
 Thumbs.db
+
+# Local AI / Wayfinder decision-aid prototypes (not for production or cloud)
+/resources/views/prototype


### PR DESCRIPTION
- Ignore local Blade prototypes under resources/views/prototype.
- These views are often used as local decision aids (e.g. Wayfinder maps or AI exploration) and are rarely needed in production or cloud environments.

Co-authored-by: Cursor <cursoragent@cursor.com>