### PR TITLE
Add `@laravel/multiplex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
         "laravel-vite-plugin": "^3.1",
         "tailwindcss": "^4.0.0",
         "vite": "^8.0.0"
+    },
+    "optionalDependencies": {
+        "@laravel/multiplex": "^0.4.1"
     }
 }


### PR DESCRIPTION
Pairs with laravel/framework#61100, which runs the dev processes through `@laravel/multiplex` instead of `concurrently`. Declaring it here means `npx` picks up the local copy rather than downloading it the first time someone runs `artisan dev`.

It goes in `optionalDependencies` rather than `devDependencies` because multiplex declares `"os": ["darwin", "linux"]`, and npm hard fails with `EBADPLATFORM` on a direct dependency it can't install. As an optional dependency npm just skips it on Windows and the install succeeds, which is fine since the dev command falls back to `concurrently` there anyway. `concurrently` stays put for that reason.
