### PR TITLE
Add "monthly" to the available log drivers comment

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -45,7 +45,7 @@ return [
     | utilizes the Monolog PHP logging library, which includes a variety
     | of powerful log handlers and formatters that you're free to use.
     |
-    | Available drivers: "single", "daily", "slack", "syslog",
+    | Available drivers: "single", "daily", "monthly", "slack", "syslog",
     |                    "errorlog", "monolog", "custom", "stack"
     |
     */


### PR DESCRIPTION
#6847 added a `monthly` channel to `config/logging.php`, but the "Available
drivers" comment above the channels array wasn't updated. The file now
documents eight drivers while defining a channel that uses a ninth.

`Illuminate\Log\LogManager::createMonthlyDriver()` exists in the framework
and the logging documentation lists `monthly` under "Available Channel
Drivers", so this brings the comment in line with the drivers that are
actually supported.

This is a comment-only change and does not affect behavior.