### PR TITLE
Ignore temporary LSP script files in `storage/framework`

### DIFF
--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -2,6 +2,7 @@ compiled.php
 config.php
 down
 events.scanned.php
+lsp-*.php
 maintenance.php
 routes.php
 routes.scanned.php


### PR DESCRIPTION
[`ScriptRunner::write()`](https://github.com/laravel/lsp/blob/main/app/Lsp/ScriptRunner.php#L90) generates temporary Language Server scripts in `storage/framework/` which can sometimes appear in version control. I added `lsp-*.php` to `storage/framework/.gitignore` to prevent tracking them.

**NOTE:** Alternatively, `/storage/framework/lsp-*.php` could be added to the project's root `.gitignore` instead if preferred.