### PR TITLE
Refactor Application configuration in app.php

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,7 +5,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 
-return Application::configure(basePath: dirname(__DIR__))
+return Application::configure()
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',


### PR DESCRIPTION
This pull request makes a small change to the application bootstrap process by removing the explicit `basePath` argument from the `Application::configure` call in `bootstrap/app.php`. This simplifies the configuration by relying on the default base path behavior.