### PR TITLE
fix: remove port 8000 from APP_URL to prevent URI error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost:8000
+APP_URL=http://localhost
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en


### PR DESCRIPTION
## Summary

When running the Laravel development server using:

```bash
php artisan serve
```

I encountered the following error:

```text
In Request.php line 366:

Invalid URI: Host is malformed.
```

### Environment

The relevant `.env` configuration was initially:

```env
APP_URL=http://localhost:8000

DB_CONNECTION=mysql
DB_HOST=127.0.0.1
DB_PORT=3306
DB_DATABASE=shop
DB_USERNAME=admin
DB_PASSWORD=********
```

The issue was not related to `DB_HOST`. After testing different `APP_URL` values, I found that the following configuration works without any errors:

```env
APP_URL=http://localhost
```

The problem occurs when the port `8000` is included:

```env
APP_URL=http://localhost:8000
```

### Resolution

Removing the port from `APP_URL` resolved the issue:

```env
APP_URL=http://localhost
```

Since Laravel's development server normally uses port `8000`, I would like to understand why specifying `:8000` in `APP_URL` results in an `Invalid URI: Host is malformed` error, while `http://localhost` works correctly.
