### PR TITLE
fix: remove port 8000 from APP_URL to prevent URI error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost:8000
+APP_URL=http://localhost
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en


### PR DESCRIPTION
# Sumnary

When running a Laravel application locally with `php artisan serve`, I encountered the following exception:

```text
In Request.php line 366:

Invalid URI: Host is malformed.
```

### Steps to reproduce

1. Create a new Laravel application using the Laravel application skeleton:

```bash
composer create-project laravel/laravel test-app
cd test-app
```

2. Configure the `.env` file with:

```env
APP_ENV=local
APP_DEBUG=true
APP_URL=http://localhost:8000:8000
```

3. Run the development server:

```bash
php artisan serve
```

4. The application throws:

```text
Invalid URI: Host is malformed.
```

should not result in an `Invalid URI: Host is malformed` exception. As in the commit two months ago, when port 8000 was registered in http://localhost, this probably caused these problems because Laravel itself already registers port 8000 at the end of the address, and therefore when Laravel is installed, two ports are registered.

### Environment

* Laravel: v13.10.1
* PHP: 8.3
* OS: Linux Mint 22.3
* Composer: v2.7.1

### Screencast

https://github.com/user-attachments/assets/a4b15b5d-28c0-4a10-bcca-0dc6a7f77fcf